### PR TITLE
Fix issue-26 - Context metadata to specify platform specific enums

### DIFF
--- a/backend/packages/Upgrade/.env.example
+++ b/backend/packages/Upgrade/.env.example
@@ -78,3 +78,5 @@ EMAIL_BUCKET                    = "upgrade-csv-upload"
 #
 CONTEXT = app@addition@subtraction@multiplication@division@addition simple@subtraction simple@multiplication simple@division simple@addition medium@subtraction medium@multiplication medium@division medium@addition hard@subtraction hard@multiplication hard@division hard@fraction
 ADMIN_USERS = mglover@carnegielearning.com:admin/\sritter@carnegielearning.com:admin/\sfancsali@carnegielearning.com:admin/\nirmal@playpowerlabs.com:admin/\vivek@playpowerlabs.com:admin/\mmchenry@carnegielearning.com:admin/\apople@carnegielearning.com:admin/\leslie@carnegielearning.com:admin/\sgrieco@carnegielearning.com:admin/\lseaman@carnegielearning.com:admin/\kschaefer@carnegielearning.com:admin/\abright@carnegielearning.com:admin/\amurphy@carnegielearning.com:admin/\derek@playpowerlabs.com:admin/\jaydip.hirapara@playpowerlabs.com:admin/\dhaval.prajapati@playpowerlabs.com:admin/\dev@playpowerlabs.com:admin/\dhrushit@playpowerlabs.com:admin
+EXP_POINTS = expPoint1@expPoint2@point3@point4@expPoint5
+EXP_IDS = expId1@expId2@Id3@id4@expId5

--- a/backend/packages/Upgrade/.env.test
+++ b/backend/packages/Upgrade/.env.test
@@ -78,3 +78,5 @@ EMAIL_BUCKET                    = "upgrade-csv-upload"
 #
 CONTEXT = app@addition@subtraction@multiplication@division@addition simple@subtraction simple@multiplication simple@division simple@addition medium@subtraction medium@multiplication medium@division medium@addition hard@subtraction hard@multiplication hard@division hard@fraction
 ADMIN_USERS = mglover@carnegielearning.com:admin/\sritter@carnegielearning.com:admin/\sfancsali@carnegielearning.com:admin/\nirmal@playpowerlabs.com:admin/\vivek@playpowerlabs.com:admin/\mmchenry@carnegielearning.com:admin/\apople@carnegielearning.com:admin/\leslie@carnegielearning.com:admin/\sgrieco@carnegielearning.com:admin/\lseaman@carnegielearning.com:admin/\kschaefer@carnegielearning.com:admin/\abright@carnegielearning.com:admin/\amurphy@carnegielearning.com:admin/\derek@playpowerlabs.com:admin/\jaydip.hirapara@playpowerlabs.com:admin/\dhaval.prajapati@playpowerlabs.com:admin/\dev@playpowerlabs.com:admin/\dhrushit@playpowerlabs.com:admin
+EXP_POINTS = expPoint1@expPoint2@point3@point4@expPoint5
+EXP_IDS = expId1@expId2@Id3@id4@expId5

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
@@ -179,6 +179,24 @@ export class ExperimentController {
 
   /**
    * @swagger
+   * /experiments/expPointsAndIds:
+   *    get:
+   *       description: Get experiment points and ids
+   *       tags:
+   *         - Experiments
+   *       produces:
+   *         - application/json
+   *       responses:
+   *          '200':
+   *            description: Experiment points and ids list
+   */
+  @Get('/expPointsAndIds')
+  public getExpPointsAndIds(): object {
+    return this.experimentService.getExpPointsAndIds();
+  }
+
+  /**
+   * @swagger
    * /experiments/paginated:
    *    post:
    *       description: Get Paginated Experiment

--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -117,6 +117,13 @@ export class ExperimentService {
     return env.initialization.context;
   }
 
+  public getExpPointsAndIds(): object {
+    return {
+      expPoints: env.initialization.expPoints,
+      expIds: env.initialization.expIds
+    };
+  }
+
   public create(experiment: ExperimentInput, currentUser: User): Promise<Experiment> {
     this.log.info('Create a new experiment => ', experiment.toString());
     // TODO add entry in audit log of creating experiment

--- a/backend/packages/Upgrade/src/env.ts
+++ b/backend/packages/Upgrade/src/env.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import * as pkg from '../package.json';
 
 import { getOsEnv, getOsPath, getOsPaths, normalizePort, toBool } from './lib/env';
-import { getOsEnvOptional, toNumber, parseContext, parseAdminUsers } from './lib/env/utils';
+import { getOsEnvOptional, toNumber, parseEnvironmentValuesBySpecialChar, parseAdminUsers } from './lib/env/utils';
 
 /**
  * Load .env file or for tests the .env.test file.
@@ -80,8 +80,10 @@ export const env = {
     region: getOsEnv('AWS_REGION'),
   },
   initialization: {
-    context: parseContext(getOsEnv('CONTEXT')),
+    context: parseEnvironmentValuesBySpecialChar(getOsEnv('CONTEXT')),
     adminUsers: parseAdminUsers(getOsEnv('ADMIN_USERS')),
+    expPoints: parseEnvironmentValuesBySpecialChar(getOsEnv('EXP_POINTS')),
+    expIds: parseEnvironmentValuesBySpecialChar(getOsEnv('EXP_IDS')),
   },
   hostUrl: getOsEnv('HOST_URL'),
   tokenSecretKey: getOsEnv('TOKEN_SECRET_KEY'),

--- a/backend/packages/Upgrade/src/lib/env/utils.ts
+++ b/backend/packages/Upgrade/src/lib/env/utils.ts
@@ -57,12 +57,12 @@ export function normalizePort(port: string): number | string | boolean {
   return false;
 }
 
-export function parseContext(value: string): string[] {
+export function parseEnvironmentValuesBySpecialChar(value: string, separator: string = '@'): string[] {
   if (!value) {
     return [];
   }
-  const contextArray = value.split('@');
-  return contextArray.length > 0 ? contextArray : [];
+  const parsedArray = value.split(separator);
+  return parsedArray.length > 0 ? parsedArray : [];
 }
 
 export function parseAdminUsers(value: string): Array<{ email: string; role: string }> {

--- a/frontend/projects/abtesting/src/app/core/experiments/experiments.data.service.ts
+++ b/frontend/projects/abtesting/src/app/core/experiments/experiments.data.service.ts
@@ -80,4 +80,9 @@ export class ExperimentDataService {
     const url = environment.api.experimentGraphInfo;
     return this.http.post(url, params);
   }
+
+  fetchExperimentPointsAndIds() {
+    const url = environment.api.expPointsAndIds;
+    return this.http.get(url);
+  }
 }

--- a/frontend/projects/abtesting/src/app/core/experiments/experiments.service.ts
+++ b/frontend/projects/abtesting/src/app/core/experiments/experiments.service.ts
@@ -28,7 +28,8 @@ import {
   selectExperimentStatById,
   selectIsGraphLoading,
   selectSortKey,
-  selectSortAs
+  selectSortAs,
+  selectExperimentPointsAndIds
 } from './store/experiments.selectors';
 import * as experimentAction from './store//experiments.actions';
 import { AppState } from '../core.state';
@@ -64,6 +65,7 @@ export class ExperimentService {
   selectExperimentGraphInfo$ = this.store$.pipe(select(selectExperimentGraphInfo));
   isGraphLoading$ = this.store$.pipe(select(selectIsGraphLoading));
   experimentStatById$ = (experimentId) => this.store$.pipe(select(selectExperimentStatById, { experimentId }));
+  expPointsAndIds$ = this.store$.pipe(select(selectExperimentPointsAndIds));
 
   selectSearchExperimentParams(): Observable<Object> {
     return combineLatest(this.selectSearchKey$, this.selectSearchString$).pipe(
@@ -138,6 +140,10 @@ export class ExperimentService {
 
   fetchExperimentContext() {
     this.store$.dispatch(experimentAction.actionFetchExperimentContext());
+  }
+
+  fetchExperimentPointsAndIds() {
+    this.store$.dispatch(experimentAction.actionFetchExperimentPointsAndIds());
   }
 
   setSearchKey(searchKey: EXPERIMENT_SEARCH_KEY) {

--- a/frontend/projects/abtesting/src/app/core/experiments/store/experiments.actions.ts
+++ b/frontend/projects/abtesting/src/app/core/experiments/store/experiments.actions.ts
@@ -193,6 +193,20 @@ export const actionFetchExperimentDetailStatSuccess = createAction(
   '[Experiment] Fetch Experiment Detail stat Success',
   props<{ stat: IExperimentEnrollmentDetailStats }>()
 );
+
 export const actionFetchExperimentDetailStatFailure = createAction(
   '[Experiment] Fetch Experiment Detail stat Failure',
+);
+
+export const actionFetchExperimentPointsAndIds = createAction(
+  '[Experiment] Fetch Experiment Points and Ids',
+);
+
+export const actionFetchExperimentPointsAndIdsSuccess = createAction(
+  '[Experiment] Fetch Experiment Points and Ids Success',
+  props<{ expPointsAndIds: object }>()
+);
+
+export const actionFetchExperimentPointsAndIdsFailure = createAction(
+  '[Experiment] Fetch Experiment Points and Ids Failure',
 );

--- a/frontend/projects/abtesting/src/app/core/experiments/store/experiments.effects.ts
+++ b/frontend/projects/abtesting/src/app/core/experiments/store/experiments.effects.ts
@@ -24,7 +24,8 @@ import {
   selectTotalExperiment,
   selectSearchString,
   selectExperimentGraphInfo,
-  selectExperimentContext
+  selectExperimentContext,
+  selectExperimentPointsAndIds
 } from './experiments.selectors';
 import { combineLatest } from 'rxjs';
 import { selectCurrentUser } from '../../auth/store/auth.selectors';
@@ -354,6 +355,22 @@ export class ExperimentEffects {
         this.experimentDataService.fetchExperimentContext().pipe(
           map((context: string[]) => experimentAction.actionFetchExperimentContextSuccess({ context })),
           catchError(() => [experimentAction.actionFetchExperimentContextFailure()])
+        )
+      )
+    )
+  );
+
+  fetchExperimentPointsAndIds$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(experimentAction.actionFetchExperimentPointsAndIds),
+      withLatestFrom(
+        this.store$.pipe(select(selectExperimentPointsAndIds))
+      ),
+      filter(([, expPointsAndIds]) => !Object.keys(expPointsAndIds).length),
+      switchMap(() =>
+        this.experimentDataService.fetchExperimentPointsAndIds().pipe(
+          map((expPointsAndIds: object) => experimentAction.actionFetchExperimentPointsAndIdsSuccess({ expPointsAndIds })),
+          catchError(() => [experimentAction.actionFetchExperimentPointsAndIdsFailure()])
         )
       )
     )

--- a/frontend/projects/abtesting/src/app/core/experiments/store/experiments.model.ts
+++ b/frontend/projects/abtesting/src/app/core/experiments/store/experiments.model.ts
@@ -159,6 +159,11 @@ export interface ExperimentPaginationParams {
   sortParams?: IExperimentSortParams;
 }
 
+export interface IExpPointsAndIds {
+  expPoints: string[],
+  expIds: string[]
+}
+
 export interface IExperimentGraphInfo {
   [DATE_RANGE.LAST_SEVEN_DAYS]: IEnrollmentStatByDate[],
   [DATE_RANGE.LAST_THREE_MONTHS]: IEnrollmentStatByDate[],
@@ -186,7 +191,8 @@ export interface ExperimentState extends EntityState<Experiment> {
   isGraphInfoLoading: boolean;
   allPartitions: {};
   allExperimentNames: {};
-  context: string[]
+  context: string[],
+  expPointsAndIds: {}
 }
 
 export interface State extends AppState {

--- a/frontend/projects/abtesting/src/app/core/experiments/store/experiments.reducer.ts
+++ b/frontend/projects/abtesting/src/app/core/experiments/store/experiments.reducer.ts
@@ -28,7 +28,8 @@ export const initialState: ExperimentState = adapter.getInitialState({
   isGraphInfoLoading: false,
   allPartitions: null,
   allExperimentNames: null,
-  context: []
+  context: [],
+  expPointsAndIds: {}
 });
 
 const reducer = createReducer(
@@ -162,6 +163,10 @@ const reducer = createReducer(
   on(
     experimentsAction.actionFetchExperimentContextSuccess,
     (state, { context }) => ({ ...state, context })
+  ),
+  on(
+    experimentsAction.actionFetchExperimentPointsAndIdsSuccess,
+    (state, { expPointsAndIds }) => ({ ...state, expPointsAndIds })
   ),
   on(
     experimentsAction.actionFetchExperimentDetailStatSuccess,

--- a/frontend/projects/abtesting/src/app/core/experiments/store/experiments.selectors.ts
+++ b/frontend/projects/abtesting/src/app/core/experiments/store/experiments.selectors.ts
@@ -118,3 +118,8 @@ export const selectExperimentStatById = createSelector(
     return state.stats[experimentId];
   }
 );
+
+export const selectExperimentPointsAndIds = createSelector(
+  selectExperimentState,
+  (state) => state.expPointsAndIds
+);

--- a/frontend/projects/abtesting/src/app/core/local-storage/local-storage.service.spec.ts
+++ b/frontend/projects/abtesting/src/app/core/local-storage/local-storage.service.spec.ts
@@ -43,7 +43,8 @@ describe('LocalStorageService', () => {
       isGraphInfoLoading: false,
       allPartitions: null,
       allExperimentNames: null,
-      context: []
+      context: [],
+      expPointsAndIds: {}
     }
     service.setItem(ExperimentLocalStorageKeys.EXPERIMENT_SORT_KEY, EXPERIMENT_SORT_KEY.STATUS);
     service.setItem(ExperimentLocalStorageKeys.EXPERIMENT_SORT_TYPE, EXPERIMENT_SORT_AS.DESCENDING);

--- a/frontend/projects/abtesting/src/app/core/local-storage/local-storage.service.ts
+++ b/frontend/projects/abtesting/src/app/core/local-storage/local-storage.service.ts
@@ -37,7 +37,8 @@ export class LocalStorageService {
       isGraphInfoLoading: false,
       allPartitions: null,
       allExperimentNames: null,
-      context: []
+      context: [],
+      expPointsAndIds: {}
     };
 
     const state = {

--- a/frontend/projects/abtesting/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.html
+++ b/frontend/projects/abtesting/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.html
@@ -59,7 +59,6 @@
                   | translate
               "
               formControlName="assignmentWeight"
-              
             />
           </mat-form-field>
         </mat-cell>
@@ -128,7 +127,7 @@
       + {{ 'home.new-experiment.design.add-condition.text' | translate }}
     </button>
   </ng-container>
-  
+
   <!-- Partition Table -->
   <ng-container>
     <mat-table
@@ -166,7 +165,13 @@
                   | translate
               "
               formControlName="expPoint"
+              [matAutocomplete]="autoCompleteExperimentPoints"
             />
+            <mat-autocomplete #autoCompleteExperimentPoints="matAutocomplete">
+              <mat-option *ngFor="let expPoint of filteredExpPoints$[groupIndex] | async" [value]="expPoint">
+                {{ expPoint }}
+              </mat-option>
+            </mat-autocomplete>
           </mat-form-field>
         </mat-cell>
       </ng-container>
@@ -188,7 +193,13 @@
                   | translate
               "
               formControlName="expId"
+              [matAutocomplete]="autoCompleteExperimentIds"
             />
+            <mat-autocomplete #autoCompleteExperimentIds="matAutocomplete">
+              <mat-option *ngFor="let expId of filteredExpIds$[groupIndex] | async" [value]="expId">
+                {{ expId }}
+              </mat-option>
+            </mat-autocomplete>
           </mat-form-field>
         </mat-cell>
       </ng-container>
@@ -227,6 +238,12 @@
   <span
     class="ft-14-600 validation-message"
     *ngFor="let error of partitionPointErrors"
+  >{{ error }} </span>
+
+  <!-- If experiment point and id are not from predefined value -->
+  <span
+    class="ft-14-600 validation-message"
+    *ngFor="let error of expPointAndIdErrors"
   >{{ error }} </span>
 
   <div class="button-container">

--- a/frontend/projects/abtesting/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
+++ b/frontend/projects/abtesting/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
@@ -12,12 +12,12 @@ import {
   OnDestroy
 } from '@angular/core';
 import { FormBuilder, FormGroup, Validators, FormArray, AbstractControl } from '@angular/forms';
-import { BehaviorSubject, Subscription } from 'rxjs';
-import { NewExperimentDialogEvents, NewExperimentDialogData, NewExperimentPaths, ExperimentVM, ExperimentCondition } from '../../../../../core/experiments/store/experiments.model';
+import { BehaviorSubject, Observable, Subscription } from 'rxjs';
+import { NewExperimentDialogEvents, NewExperimentDialogData, NewExperimentPaths, ExperimentVM, ExperimentCondition, ExperimentPartition, IExpPointsAndIds } from '../../../../../core/experiments/store/experiments.model';
 import { ExperimentFormValidators } from '../../validators/experiment-form.validators';
 import { ExperimentService } from '../../../../../core/experiments/experiments.service';
 import { TranslateService } from '@ngx-translate/core';
-import { filter } from 'rxjs/operators';
+import { filter, map, startWith } from 'rxjs/operators';
 import * as uuid from 'uuid';
 
 @Component({
@@ -51,6 +51,14 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
 
   conditionDisplayedColumns = [ 'conditionNumber', 'conditionCode', 'assignmentWeight', 'description', 'removeCondition'];
   partitionDisplayedColumns = ['partitionNumber', 'expPoint', 'expId', 'removePartition'];
+
+  // Used for experiment point and ids auto complete dropdown
+  filteredExpPoints$: Observable<string[]>[] = [];
+  filteredExpIds$: Observable<string[]>[] = [];
+  expPointsAndIds: IExpPointsAndIds | {} = {};
+  expPointsAndIdsSub: Subscription;
+  expPointAndIdErrors: string[];
+
   constructor(
     private _formBuilder: FormBuilder,
     private experimentService: ExperimentService,
@@ -60,13 +68,17 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
       'home.new-experiment.design.assignment-partition-error-1.text',
       'home.new-experiment.design.assignment-partition-error-2.text',
       'home.new-experiment.design.assignment-partition-error-3.text',
-      'home.new-experiment.design.assignment-partition-error-4.text'
-    ]).subscribe(arrayValues => {
+      'home.new-experiment.design.assignment-partition-error-4.text',
+      'home.new-experiment.design.partition-point-selection-error.text',
+      'home.new-experiment.design.partition-id-selection-error.text'
+    ]).subscribe(translatedMessage => {
       this.partitionErrorMessages = [
-        arrayValues['home.new-experiment.design.assignment-partition-error-1.text'],
-        arrayValues['home.new-experiment.design.assignment-partition-error-2.text'],
-        arrayValues['home.new-experiment.design.assignment-partition-error-3.text'],
-        arrayValues['home.new-experiment.design.assignment-partition-error-4.text'],
+        translatedMessage['home.new-experiment.design.assignment-partition-error-1.text'],
+        translatedMessage['home.new-experiment.design.assignment-partition-error-2.text'],
+        translatedMessage['home.new-experiment.design.assignment-partition-error-3.text'],
+        translatedMessage['home.new-experiment.design.assignment-partition-error-4.text'],
+        translatedMessage['home.new-experiment.design.partition-point-selection-error.text'],
+        translatedMessage['home.new-experiment.design.partition-id-selection-error.text'],
       ];
     })
   }
@@ -106,9 +118,38 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
     }
     this.updateView();
 
+    // Bind predefined values of experiment points and ids from backend
+    const partitionFormControl = this.experimentDesignForm.get('partitions') as FormArray;
+    partitionFormControl.controls.forEach((_, index) => {
+      this.manageExpPointAndIdControl(index)
+    });
+
+
     this.experimentDesignForm.get('partitions').valueChanges.subscribe(newValues => {
       this.validatePartitionNames(newValues);
     });
+
+    this.expPointsAndIdsSub = this.experimentService.expPointsAndIds$
+      .subscribe(expPointsAndIds => this.expPointsAndIds = expPointsAndIds);
+  }
+
+  manageExpPointAndIdControl(index: number) {
+    const partitionFormControl = this.experimentDesignForm.get('partitions') as FormArray;
+    this.filteredExpPoints$[index] = partitionFormControl.at(index).get('expPoint').valueChanges
+      .pipe(
+        startWith<string>(''),
+        map(expPoint => this.filterExpPointsAndIds(expPoint, 'expPoints'))
+      );
+    this.filteredExpIds$[index] = partitionFormControl.at(index).get('expId').valueChanges
+      .pipe(
+        startWith<string>(''),
+        map(expId => this.filterExpPointsAndIds(expId, 'expIds'))
+      );
+  }
+
+  private filterExpPointsAndIds(value: string, key: string): string[] {
+    const filterValue = value.toLowerCase();
+    return this.expPointsAndIds ? (this.expPointsAndIds[key] || []).filter(option => option.toLowerCase().indexOf(filterValue) === 0) : [];
   }
 
   addConditions(conditionCode = null, assignmentWeight = null, description = null) {
@@ -128,10 +169,15 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   addConditionOrPartition(type: string) {
-    const form = type === 'condition' ? this.addConditions() : this.addPartitions();
+    const isPartition = type === 'partition';
+    const form = isPartition ? this.addPartitions() : this.addConditions();
     this[type].push(form);
-    const scrollTableType = type === 'condition' ? 'conditionTable' : 'partitionTable';
+    const scrollTableType = isPartition ? 'partitionTable' : 'conditionTable';
     this.updateView(scrollTableType);
+    if (isPartition) {
+      const partitionFormControl = this.experimentDesignForm.get('partitions') as FormArray;
+      this.manageExpPointAndIdControl(partitionFormControl.controls.length - 1);
+    }
   }
 
   removeConditionOrPartition(type: string, groupIndex: number) {
@@ -175,7 +221,7 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
       }
       if (partitions.find((value, partitionIndex) =>
         value.expPoint === partition.expPoint &&
-        value.expId === partition.expId &&
+        (value.expId || '') === (partition.expId || '') && // To match null and empty string, add '' as default value. expId as optional and hence it's value can be null.
         partitionIndex !== index &&
         duplicatePartitions.indexOf(partition.expId ? partition.expPoint + ' and ' + partition.expId : partition.expPoint) === -1)) {
         duplicatePartitions.push(partition.expId ? partition.expPoint + ' and ' + partition.expId : partition.expPoint);
@@ -204,6 +250,36 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
     }
   }
 
+  validatePartitions() {
+    // Reset expPointAndIdErrors errors to re-validate data
+    this.expPointAndIdErrors = [];
+    const partitions: ExperimentPartition[] = this.experimentDesignForm.get('partitions').value;
+    this.validateExpPoints(partitions);
+    this.validateExpIds(partitions);
+  }
+
+  validateExpPoints(partitions: ExperimentPartition[]) {
+    const expPoints = partitions.map(partition => partition.expPoint);
+    for (let expPointIndex = 0; expPointIndex < expPoints.length; expPointIndex++) {
+      if ((this.expPointsAndIds as IExpPointsAndIds).expPoints.indexOf(expPoints[expPointIndex]) === -1) {
+        // Add partition point selection error
+        this.expPointAndIdErrors.push(this.partitionErrorMessages[4]);
+        break;
+      }
+    }
+  }
+
+  validateExpIds(partitions: ExperimentPartition[]) {
+    const expIds = partitions.map(partition => partition.expId).filter(expId => expId);
+    for (let expIdIndex = 0; expIdIndex < expIds.length; expIdIndex++) {
+      if ((this.expPointsAndIds as IExpPointsAndIds).expIds.indexOf(expIds[expIdIndex]) === -1) {
+        // Add partition id selection error
+        this.expPointAndIdErrors.push(this.partitionErrorMessages[5]);
+        break;
+      }
+    }
+  }
+
   emitEvent(eventType: NewExperimentDialogEvents) {
     switch (eventType) {
       case NewExperimentDialogEvents.CLOSE_DIALOG:
@@ -212,7 +288,8 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
       case NewExperimentDialogEvents.SEND_FORM_DATA:
       case NewExperimentDialogEvents.SAVE_DATA:
         this.validateConditionCodes(this.experimentDesignForm.get('conditions').value);
-        if (!this.partitionPointErrors.length && this.experimentDesignForm.valid && !this.conditionCodeError) {
+        this.validatePartitions();
+        if (!this.partitionPointErrors.length && !this.expPointAndIdErrors.length && this.experimentDesignForm.valid && !this.conditionCodeError) {
           const experimentDesignFormData = this.experimentDesignForm.value;
 
           experimentDesignFormData.conditions = experimentDesignFormData.conditions.map(
@@ -269,5 +346,6 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
   ngOnDestroy() {
     this.allPartitionsSub.unsubscribe();
     this.partitionErrorMessagesSub.unsubscribe();
+    this.expPointsAndIdsSub.unsubscribe();
   }
 }

--- a/frontend/projects/abtesting/src/app/features/dashboard/home/components/modal/new-experiment/new-experiment.component.ts
+++ b/frontend/projects/abtesting/src/app/features/dashboard/home/components/modal/new-experiment/new-experiment.component.ts
@@ -32,6 +32,8 @@ export class NewExperimentComponent implements OnInit {
   ngOnInit() {
     // Used to fetch context only once
     this.experimentService.fetchExperimentContext();
+    // Fetch predefined experiment points and ids only once
+    this.experimentService.fetchExperimentPointsAndIds();
   }
 
   onNoClick(): void {

--- a/frontend/projects/abtesting/src/assets/i18n/en.json
+++ b/frontend/projects/abtesting/src/assets/i18n/en.json
@@ -99,6 +99,8 @@
   "home.new-experiment.design.assignment-partition-error-2.text": " partition data are already exist",
   "home.new-experiment.design.assignment-partition-error-3.text": " partition data is duplicate",
   "home.new-experiment.design.assignment-partition-error-4.text": " partition data are duplicate",
+  "home.new-experiment.design.partition-point-selection-error.text": "Please select experiment point from predefined values",
+  "home.new-experiment.design.partition-id-selection-error.text": " Please select experiment id from predefined values",
   "home.new-experiment.schedule.start-automatically.text": "Start Automatically",
   "home.new-experiment.schedule.end-automatically.text": "End Automatically",
   "home.new-experiment.schedule.start-on.text": "Starts on",

--- a/frontend/projects/abtesting/src/environments/environment.bsnl.ts
+++ b/frontend/projects/abtesting/src/environments/environment.bsnl.ts
@@ -42,6 +42,7 @@ export const environment = {
     metrics: `${endpointApi}/metric`,
     metricsSave: `${endpointApi}/metric/save`,
     queryResult: `${endpointApi}/query/analyse`,
-    getVersion: `${endpointApi}/version`
+    getVersion: `${endpointApi}/version`,
+    expPointsAndIds: `${endpointApi}/experiments/expPointsAndIds`,
   }
 };

--- a/frontend/projects/abtesting/src/environments/environment.prod.ts
+++ b/frontend/projects/abtesting/src/environments/environment.prod.ts
@@ -43,6 +43,7 @@ export const environment = {
     metrics: `${endpointApi}/metric`,
     metricsSave: `${endpointApi}/metric/save`,
     queryResult: `${endpointApi}/query/analyse`,
-    getVersion: `${endpointApi}/version`
+    getVersion: `${endpointApi}/version`,
+    expPointsAndIds: `${endpointApi}/experiments/expPointsAndIds`,
   }
 };

--- a/frontend/projects/abtesting/src/environments/environment.staging.ts
+++ b/frontend/projects/abtesting/src/environments/environment.staging.ts
@@ -42,6 +42,7 @@ export const environment = {
     metrics: `${endpointApi}/metric`,
     metricsSave: `${endpointApi}/metric/save`,
     queryResult: `${endpointApi}/query/analyse`,
-    getVersion: `${endpointApi}/version`
+    getVersion: `${endpointApi}/version`,
+    expPointsAndIds: `${endpointApi}/experiments/expPointsAndIds`,
   }
 };

--- a/frontend/projects/abtesting/src/environments/environment.ts
+++ b/frontend/projects/abtesting/src/environments/environment.ts
@@ -47,6 +47,7 @@ export const environment = {
     metrics: `${endpointApi}/metric`,
     metricsSave: `${endpointApi}/metric/save`,
     queryResult: `${endpointApi}/query/analyse`,
-    getVersion: `${endpointApi}/version`
+    getVersion: `${endpointApi}/version`,
+    expPointsAndIds: `${endpointApi}/experiments/expPointsAndIds`,
   }
 };


### PR DESCRIPTION
1. We need to add _EXP_POINTS_ and _EXP_IDS_  separated by **@** in environment variables.
2. Environment variable's values will be used to show experiment points and Ids in the dropdown at the time of creating or updating experiment.