### PR TITLE
fix/issue-26: Backtracking change for allowing QA process because we were not allowing experiment creation unless the point/ID were valid

### DIFF
--- a/frontend/projects/abtesting/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
+++ b/frontend/projects/abtesting/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
@@ -59,7 +59,7 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
   filteredExpIds$: Observable<string[]>[] = [];
   expPointsAndIds: IExpPointsAndIds | {} = {};
   expPointsAndIdsSub: Subscription;
-  expPointAndIdErrors: string[];
+  expPointAndIdErrors: string[] = [];
 
   constructor(
     private _formBuilder: FormBuilder,
@@ -320,8 +320,9 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
         this.validateConditionCodes(this.experimentDesignForm.get('conditions').value);
         this.validateConditionCount(this.experimentDesignForm.get('conditions').value);
         this.validatePartitionCount(this.experimentDesignForm.get('partitions').value);
-        if (!this.partitionPointErrors.length && this.experimentDesignForm.valid && !this.conditionCodeError && !this.conditionCountError && !this.partitionCountError) {
-        this.validatePartitions();
+        
+        // TODO: Uncomment to validate partitions with predefined expPoint and expId
+        // this.validatePartitions();
         if (!this.partitionPointErrors.length && !this.expPointAndIdErrors.length && this.experimentDesignForm.valid && !this.conditionCodeError) {
           const experimentDesignFormData = this.experimentDesignForm.value;
 
@@ -346,7 +347,6 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
           });
         }
         break;
-      }
     }
   }
   


### PR DESCRIPTION
We merged it but then realized that it will slow down the QA process because we were not allowing experiment creation unless the point/ID were valid. So we are raising this backtracking PR which will just comment out one line in the frontend that does the validation. We can think about the validation and whether we want to allow experiments to go into enrolling mode with invalid points and IDs etc. later