### PR TITLE
Fix issue-34 - Data export links from email are inconsistent

### DIFF
--- a/backend/packages/Upgrade/src/api/services/AnalyticsService.ts
+++ b/backend/packages/Upgrade/src/api/services/AnalyticsService.ts
@@ -505,9 +505,9 @@ export class AnalyticsService {
       } else {
         emailText = `Here are the new exported data
         <br>
-        <a href=\"${signedUrl[0]}\">Experiment Data Json</a>
+        <a href=\"${signedUrl[0]}\">Experiment Metadata</a>
         <br>
-        <a href=\"${signedUrl[1]}\">Experiment Metadata</a>`;
+        <a href=\"${signedUrl[1]}\">Experiment Data Json</a>`;
       }
 
       const emailSubject = `Exported Data for experiment ${experiment.name}`;


### PR DESCRIPTION
Fix the Experiment Data Json and Experiment Metadata sign url in exporting experiment