### PR TITLE
Fix/issue 63,61

### DIFF
--- a/backend/packages/Upgrade/src/api/models/MonitoredExperimentPoint.ts
+++ b/backend/packages/Upgrade/src/api/models/MonitoredExperimentPoint.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryColumn, Column, ManyToOne, OneToMany } from 'typeorm';
+import { Entity, PrimaryColumn, Column, ManyToOne, OneToMany, Index } from 'typeorm';
 import { BaseModel } from './base/BaseModel';
 import { ExperimentUser } from './ExperimentUser';
 import { MonitoredExperimentPointLog } from './MonitorExperimentPointLog';
@@ -9,6 +9,7 @@ export class MonitoredExperimentPoint extends BaseModel {
   @PrimaryColumn()
   public id: string;
 
+  @Index()
   @Column()
   public experimentId: string;
 

--- a/backend/packages/Upgrade/src/database/migrations/1622887727649-indexingExperimentIdInMonitorPointExperiment.ts
+++ b/backend/packages/Upgrade/src/database/migrations/1622887727649-indexingExperimentIdInMonitorPointExperiment.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+// tslint:disable-next-line: class-name
+export class indexingExperimentIdInMonitorPointExperiment1622887727649 implements MigrationInterface {
+  public name = 'indexingExperimentIdInMonitorPointExperiment1622887727649';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX "IDX_5a5d806842a4176f73c12db4db" ON "monitored_experiment_point" ("experimentId") `
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_5a5d806842a4176f73c12db4db"`);
+  }
+}


### PR DESCRIPTION
Issue 63 - Monitored Point documents are not deleted on experiment delete. Experiment log entry is added after the experiment delete is successful.

Issue 61 - Indexing is added in monitored_experiment_point table to query by experimentId so that all the users can be excluded when experiment state is changed to enrolling.