### PR TITLE
Fix/issue 9 Transaction for start & end experiment

### DIFF
--- a/backend/packages/Upgrade/package.json
+++ b/backend/packages/Upgrade/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ab_testing_backend",
-    "version": "1.0.41",
+    "version": "1.0.42",
     "description": "Backend for A/B Testing Project",
     "main": "index.js",
     "scripts": {

--- a/backend/packages/Upgrade/src/api/repositories/ExperimentAuditLogRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/ExperimentAuditLogRepository.ts
@@ -41,7 +41,7 @@ export class ExperimentAuditLogRepository extends Repository<ExperimentAuditLog>
     user: User,
     entityManger?: EntityManager
   ): Promise<ExperimentAuditLog> {
-    const that = entityManger ? entityManger : this; 
+    const that = entityManger || this;
     const result = await that
       .createQueryBuilder()
       .insert()

--- a/backend/packages/Upgrade/src/api/repositories/ExperimentAuditLogRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/ExperimentAuditLogRepository.ts
@@ -1,5 +1,5 @@
 import { ExperimentAuditLog } from '../models/ExperimentAuditLog';
-import { EntityRepository, Repository } from 'typeorm';
+import { EntityRepository, Repository, EntityManager } from 'typeorm';
 import { EXPERIMENT_LOG_TYPE } from 'upgrade_types';
 import { User } from '../models/User';
 import repositoryError from './utils/repositoryError';
@@ -35,9 +35,17 @@ export class ExperimentAuditLogRepository extends Repository<ExperimentAuditLog>
       });
   }
 
-  public async saveRawJson(type: EXPERIMENT_LOG_TYPE, data: any, user: User): Promise<ExperimentAuditLog> {
-    const result = await this.createQueryBuilder()
+  public async saveRawJson(
+    type: EXPERIMENT_LOG_TYPE,
+    data: any,
+    user: User,
+    entityManger?: EntityManager
+  ): Promise<ExperimentAuditLog> {
+    const that = entityManger ? entityManger : this; 
+    const result = await that
+      .createQueryBuilder()
       .insert()
+      .into(ExperimentAuditLog)
       .values({ type, data, user })
       .returning('*')
       .execute()

--- a/backend/packages/Upgrade/src/api/repositories/ExperimentRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/ExperimentRepository.ts
@@ -87,7 +87,8 @@ export class ExperimentRepository extends Repository<Experiment> {
     startDate: Date = null,
     entityManager?: EntityManager
   ): Promise<Experiment> {
-    const result = await entityManager
+    const that = entityManager ? entityManager : this;
+    const result = await that
       .createQueryBuilder()
       .update(Experiment)
       .set({ state, startOn: scheduleDate, endDate, startDate })

--- a/backend/packages/Upgrade/src/api/repositories/ExperimentRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/ExperimentRepository.ts
@@ -87,7 +87,7 @@ export class ExperimentRepository extends Repository<Experiment> {
     startDate: Date = null,
     entityManager?: EntityManager
   ): Promise<Experiment> {
-    const that = entityManager ? entityManager : this;
+    const that = entityManager || this;
     const result = await that
       .createQueryBuilder()
       .update(Experiment)

--- a/backend/packages/Upgrade/src/api/repositories/ExperimentRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/ExperimentRepository.ts
@@ -84,10 +84,12 @@ export class ExperimentRepository extends Repository<Experiment> {
     state: EXPERIMENT_STATE,
     scheduleDate: Date,
     endDate: Date = null,
-    startDate: Date = null
+    startDate: Date = null,
+    entityManager?: EntityManager
   ): Promise<Experiment> {
-    const result = await this.createQueryBuilder('experiment')
-      .update()
+    const result = await entityManager
+      .createQueryBuilder()
+      .update(Experiment)
       .set({ state, startOn: scheduleDate, endDate, startDate })
       .where({ id: experimentId })
       .returning('*')

--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -14,7 +14,7 @@ import { ExperimentPartitionRepository } from '../repositories/ExperimentPartiti
 import { ExperimentCondition } from '../models/ExperimentCondition';
 import { ExperimentPartition, getExperimentPartitionID } from '../models/ExperimentPartition';
 import { ScheduledJobService } from './ScheduledJobService';
-import { getConnection, In } from 'typeorm';
+import { getConnection, In, EntityManager } from 'typeorm';
 import { ExperimentAuditLogRepository } from '../repositories/ExperimentAuditLogRepository';
 import { diffString } from 'json-diff';
 import { EXPERIMENT_LOG_TYPE, EXPERIMENT_STATE, CONSISTENCY_RULE, ENROLLMENT_CODE, SERVER_ERROR } from 'upgrade_types';
@@ -206,8 +206,10 @@ export class ExperimentService {
     experimentId: string,
     state: EXPERIMENT_STATE,
     user: User,
+    em?: EntityManager | any,
     scheduleDate?: Date
   ): Promise<Experiment> {
+    em = em || this;
     if (state === EXPERIMENT_STATE.ENROLLING || state === EXPERIMENT_STATE.PREVIEW) {
       await this.populateExclusionTable(experimentId, state);
     }
@@ -243,7 +245,8 @@ export class ExperimentService {
       state,
       scheduleDate,
       endDate,
-      startDate
+      startDate,
+      em
     );
 
     // updating experiment schedules here

--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -206,10 +206,9 @@ export class ExperimentService {
     experimentId: string,
     state: EXPERIMENT_STATE,
     user: User,
-    em?: EntityManager | any,
-    scheduleDate?: Date
+    scheduleDate?: Date,
+    entityManager?: EntityManager
   ): Promise<Experiment> {
-    em = em || this;
     if (state === EXPERIMENT_STATE.ENROLLING || state === EXPERIMENT_STATE.PREVIEW) {
       await this.populateExclusionTable(experimentId, state);
     }
@@ -228,7 +227,7 @@ export class ExperimentService {
       data = { ...data, startOn: scheduleDate };
     }
     // add experiment audit logs
-    this.experimentAuditLogRepository.saveRawJson(EXPERIMENT_LOG_TYPE.EXPERIMENT_STATE_CHANGED, data, user);
+    await this.experimentAuditLogRepository.saveRawJson(EXPERIMENT_LOG_TYPE.EXPERIMENT_STATE_CHANGED, data, user, entityManager);
 
     let endDate = oldExperiment.endDate || null;
     let startDate = oldExperiment.startDate || null;
@@ -246,7 +245,7 @@ export class ExperimentService {
       scheduleDate,
       endDate,
       startDate,
-      em
+      entityManager
     );
 
     // updating experiment schedules here

--- a/backend/packages/Upgrade/src/api/services/ScheduledJobService.ts
+++ b/backend/packages/Upgrade/src/api/services/ScheduledJobService.ts
@@ -27,18 +27,22 @@ export class ScheduledJobService {
   ) {}
 
   public async startExperiment(id: string): Promise<any> {
+    console.log('-----------call 2------------',id);
     const scheduledJob = await this.scheduledJobRepository.findOne(id, { relations: ['experiment'] });
-    if (scheduledJob && scheduledJob.experiment) {
+    //if (scheduledJob && scheduledJob.experiment) {
+      console.log('-----------call 2.5------------',scheduledJob);
       const experiment = await this.experimentRepository.findOne(scheduledJob.experiment.id);
-      if (scheduledJob && experiment) {
+      console.log('-----------call 3------------');
+      //if (scheduledJob && experiment) {
         const systemUser = await this.userRepository.findOne({ email: systemUserDoc.email });
         const experimentService = Container.get<ExperimentService>(ExperimentService);
         // update experiment startOn
         await this.experimentRepository.update({ id: experiment.id }, { startOn: null });
+        console.log('-----------call 4------------');
         return experimentService.updateState(scheduledJob.experiment.id, EXPERIMENT_STATE.ENROLLING, systemUser);
-      }
-    }
-    return {};
+      //}
+    //}
+    //return {};
   }
 
   public async endExperiment(id: string): Promise<any> {

--- a/backend/packages/Upgrade/src/api/services/ScheduledJobService.ts
+++ b/backend/packages/Upgrade/src/api/services/ScheduledJobService.ts
@@ -31,10 +31,10 @@ export class ScheduledJobService {
         const scheduledJob = await scheduledJobRepository.findOne(id, { relations: ['experiment'] });
 
         const currentDate = new Date();
-        const timeDif = Math.abs(currentDate.getTime() - scheduledJob.timeStamp.getTime());
+        const timeDiff = Math.abs(currentDate.getTime() - scheduledJob.timeStamp.getTime());
         const fiveHoursInMS = 18000000;
 
-        if (timeDif > fiveHoursInMS) {
+        if (timeDiff > fiveHoursInMS) {
           const errorMsg =  'Time Differnce of more than 5 hours is found';
           await scheduledJobRepository.delete({id: scheduledJob.id});
           throw new Error(errorMsg);
@@ -70,18 +70,18 @@ export class ScheduledJobService {
   public async endExperiment(id: string): Promise<any> {
     return await getConnection().transaction(async (transactionalEntityManager) => {
       try {
-        const schedulerJobRepository = transactionalEntityManager.getRepository(ScheduledJob);
-        const scheduledJob = await schedulerJobRepository.findOne(id, { relations: ['experiment'] });
+        const scheduledJobRepository = transactionalEntityManager.getRepository(ScheduledJob);
+        const scheduledJob = await scheduledJobRepository.findOne(id, { relations: ['experiment'] });
         const experimentRepository = transactionalEntityManager.getRepository(Experiment);
         const experiment = await experimentRepository.findOne(scheduledJob.experiment.id);
 
         const currentDate = new Date();
-        const timeDif = Math.abs(currentDate.getTime() - scheduledJob.timeStamp.getTime());
+        const timeDiff = Math.abs(currentDate.getTime() - scheduledJob.timeStamp.getTime());
         const fiveHoursInMS = 18000000;
 
-        if (timeDif > fiveHoursInMS) {
+        if (timeDiff > fiveHoursInMS) {
           const errorMsg =  'Time Differnce of more than 5 hours is found';
-          await schedulerJobRepository.delete({id: scheduledJob.id});
+          await scheduledJobRepository.delete({id: scheduledJob.id});
           throw new Error(errorMsg);
         }
 

--- a/backend/packages/Upgrade/src/api/services/ScheduledJobService.ts
+++ b/backend/packages/Upgrade/src/api/services/ScheduledJobService.ts
@@ -27,26 +27,34 @@ export class ScheduledJobService {
   public async startExperiment(id: string): Promise<any> {
     return await getConnection().transaction(async (transactionalEntityManager) => {
       try {
-        const scheduledJob = await transactionalEntityManager.getRepository(ScheduledJob).findOne(id, { relations: ['experiment'] });
+        const scheduledJobRepository = transactionalEntityManager.getRepository(ScheduledJob);
+        const scheduledJob = await scheduledJobRepository.findOne(id, { relations: ['experiment'] });
 
         const currentDate = new Date();
         const timeDif = Math.abs(currentDate.getTime() - scheduledJob.timeStamp.getTime());
         const fiveHoursInMS = 18000000;
-        
+
         if (timeDif > fiveHoursInMS) {
           const errorMsg =  'Time Differnce of more than 5 hours is found';
-          await transactionalEntityManager.getRepository(ScheduledJob).delete({id: scheduledJob.id});
+          await scheduledJobRepository.delete({id: scheduledJob.id});
           throw new Error(errorMsg);
         }
 
         if (scheduledJob && scheduledJob.experiment) {
-          const experiment = await transactionalEntityManager.getRepository(Experiment).findOne(scheduledJob.experiment.id);
+          const experimentRepository = transactionalEntityManager.getRepository(Experiment);
+          const experiment = await experimentRepository.findOne(scheduledJob.experiment.id);
           if (scheduledJob && experiment) {
             const systemUser = await transactionalEntityManager.getRepository(User).findOne({ email: systemUserDoc.email });
             const experimentService = Container.get<ExperimentService>(ExperimentService);
             // update experiment startOn
-            await transactionalEntityManager.getRepository(Experiment).update({ id: experiment.id }, { startOn: null });
-            return experimentService.updateState(scheduledJob.experiment.id, EXPERIMENT_STATE.ENROLLING, systemUser, null, transactionalEntityManager);
+            await experimentRepository.update({ id: experiment.id }, { startOn: null });
+            return experimentService.updateState(
+              scheduledJob.experiment.id,
+              EXPERIMENT_STATE.ENROLLING,
+              systemUser,
+              null,
+              transactionalEntityManager
+            );
           }
         }
         return {};
@@ -60,16 +68,18 @@ export class ScheduledJobService {
   public async endExperiment(id: string): Promise<any> {
     return await getConnection().transaction(async (transactionalEntityManager) => {
       try {
-        const scheduledJob = await transactionalEntityManager.getRepository(ScheduledJob).findOne(id, { relations: ['experiment'] });
-        const experiment = await transactionalEntityManager.getRepository(Experiment).findOne(scheduledJob.experiment.id);
+        const schedulerJobRepository = transactionalEntityManager.getRepository(ScheduledJob);
+        const scheduledJob = await schedulerJobRepository.findOne(id, { relations: ['experiment'] });
+        const experimentRepository = transactionalEntityManager.getRepository(Experiment);
+        const experiment = await experimentRepository.findOne(scheduledJob.experiment.id);
 
         const currentDate = new Date();
         const timeDif = Math.abs(currentDate.getTime() - scheduledJob.timeStamp.getTime());
         const fiveHoursInMS = 18000000;
-        
+
         if (timeDif > fiveHoursInMS) {
           const errorMsg =  'Time Differnce of more than 5 hours is found';
-          await transactionalEntityManager.getRepository(ScheduledJob).delete({id: scheduledJob.id});
+          await schedulerJobRepository.delete({id: scheduledJob.id});
           throw new Error(errorMsg);
         }
 
@@ -77,7 +87,7 @@ export class ScheduledJobService {
           const systemUser = await transactionalEntityManager.getRepository(User).findOne({ email: systemUserDoc.email });
           const experimentService = Container.get<ExperimentService>(ExperimentService);
           // update experiment startOn
-          await transactionalEntityManager.getRepository(Experiment).update({ id: experiment.id }, { endOn: null });
+          await experimentRepository.update({ id: experiment.id }, { endOn: null });
           return experimentService.updateState(
             scheduledJob.experiment.id,
             EXPERIMENT_STATE.ENROLLMENT_COMPLETE,


### PR DESCRIPTION
In this PR, we have created a transaction for the start experiment and end experiment of the scheduler. Along with it, we are throwing an error if the time window, time at function is called and the timeStamp in Scheduler Repository is more than 5 hours.