### PR TITLE
Fix/issue 90 - create nullable-Order for condition and partition

### DIFF
--- a/backend/packages/Upgrade/src/api/models/ExperimentCondition.ts
+++ b/backend/packages/Upgrade/src/api/models/ExperimentCondition.ts
@@ -31,6 +31,13 @@ export class ExperimentCondition extends BaseModel {
   @Column()
   public assignmentWeight: number;
 
+  @IsNotEmpty()
+  @IsNumber()
+  @Column({
+    nullable: true,
+  })
+  public order: number;
+
   @ManyToOne((type) => Experiment, (experiment) => experiment.conditions, { onDelete: 'CASCADE' })
   public experiment: Experiment;
 }

--- a/backend/packages/Upgrade/src/api/models/ExperimentPartition.ts
+++ b/backend/packages/Upgrade/src/api/models/ExperimentPartition.ts
@@ -1,5 +1,5 @@
 import { Entity, PrimaryColumn, Column, ManyToOne } from 'typeorm';
-import { IsNotEmpty, IsAlphanumeric } from 'class-validator';
+import { IsNotEmpty, IsAlphanumeric, IsNumber } from 'class-validator';
 import { Experiment } from './Experiment';
 import { BaseModel } from './base/BaseModel';
 
@@ -22,6 +22,13 @@ export class ExperimentPartition extends BaseModel {
 
   @Column()
   public description: string;
+
+  @IsNotEmpty()
+  @IsNumber()
+  @Column({
+    nullable: true,
+  })
+  public order: number;
 
   @ManyToOne((type) => Experiment, (experiment) => experiment.partitions, { onDelete: 'CASCADE' })
   public experiment: Experiment;

--- a/backend/packages/Upgrade/src/api/repositories/ExperimentConditionRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/ExperimentConditionRepository.ts
@@ -14,12 +14,13 @@ export class ExperimentConditionRepository extends Repository<ExperimentConditio
       .into(ExperimentCondition)
       .values(conditionDoc)
       .onConflict(
-        `("id") DO UPDATE SET "name" = :name, "description" = :description, "conditionCode" = :conditionCode, "assignmentWeight" = :assignmentWeight`
+        `("id") DO UPDATE SET "name" = :name, "description" = :description, "conditionCode" = :conditionCode, "assignmentWeight" = :assignmentWeight, "order" = :order`
       )
       .setParameter('name', conditionDoc.name)
       .setParameter('description', conditionDoc.description)
       .setParameter('conditionCode', conditionDoc.conditionCode)
       .setParameter('assignmentWeight', conditionDoc.assignmentWeight)
+      .setParameter('order', conditionDoc.order)
       .returning('*')
       .execute()
       .catch((errorMsg: any) => {

--- a/backend/packages/Upgrade/src/api/repositories/ExperimentPartitionRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/ExperimentPartitionRepository.ts
@@ -13,9 +13,10 @@ export class ExperimentPartitionRepository extends Repository<ExperimentPartitio
       .insert()
       .into(ExperimentPartition)
       .values(partitionDoc)
-      .onConflict(`("id") DO UPDATE SET "expId" = :expId, "description" = :description`)
+      .onConflict(`("id") DO UPDATE SET "expId" = :expId, "description" = :description, "order" = :order`)
       .setParameter('expId', partitionDoc.expId)
       .setParameter('description', partitionDoc.description)
+      .setParameter('order', partitionDoc.order)
       .returning('*')
       .execute()
       .catch((errorMsg: any) => {

--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -77,7 +77,9 @@ export class ExperimentService {
       .leftJoinAndSelect('experiment.conditions', 'conditions')
       .leftJoinAndSelect('experiment.partitions', 'partitions')
       .leftJoinAndSelect('experiment.queries', 'queries')
-      .leftJoinAndSelect('queries.metric', 'metric');
+      .leftJoinAndSelect('queries.metric', 'metric')
+      .addOrderBy('conditions.order', 'ASC')
+      .addOrderBy('partitions.order', 'ASC');
     if (searchParams) {
       const customSearchString = searchParams.string.split(' ').join(`:*&`);
       // add search query

--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -128,6 +128,18 @@ export class ExperimentService {
   public create(experiment: ExperimentInput, currentUser: User): Promise<Experiment> {
     this.log.info('Create a new experiment => ', experiment.toString());
     // TODO add entry in audit log of creating experiment
+
+    // order for condition
+    experiment.conditions.forEach((condition, index) => {
+      const newCondition = {...condition, order: index + 1};
+      experiment.conditions[index] = newCondition;
+    });
+
+    // order for partition
+    experiment.partitions.forEach((partition, index) => {
+      const newPartition = {...partition, order: index + 1};
+      experiment.partitions[index] = newPartition;
+    });
     return this.addExperimentInDB(experiment, currentUser);
   }
 

--- a/backend/packages/Upgrade/src/database/migrations/1624884267999-versionChangeTypeORM.ts
+++ b/backend/packages/Upgrade/src/database/migrations/1624884267999-versionChangeTypeORM.ts
@@ -1,7 +1,8 @@
-import {MigrationInterface, QueryRunner} from "typeorm";
+import {MigrationInterface, QueryRunner} from 'typeorm';
 
+// tslint:disable-next-line: class-name
 export class versionChangeTypeORM1624884267999 implements MigrationInterface {
-    name = 'versionChangeTypeORM1624884267999'
+    public name = 'versionChangeTypeORM1624884267999';
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`ALTER TABLE "metric_log" DROP CONSTRAINT "FK_c022cd84fd9fa789cbaee40b41c"`);

--- a/backend/packages/Upgrade/src/database/migrations/1625912408079-addOrderToConditionAndPartition.ts
+++ b/backend/packages/Upgrade/src/database/migrations/1625912408079-addOrderToConditionAndPartition.ts
@@ -1,0 +1,17 @@
+import {MigrationInterface, QueryRunner} from 'typeorm';
+
+// tslint:disable-next-line: class-name
+export class addOrderToConditionAndPartition1625912408079 implements MigrationInterface {
+    public name = 'addOrderToConditionAndPartition1625912408079';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "experiment_condition" ADD "order" integer`);
+        await queryRunner.query(`ALTER TABLE "experiment_partition" ADD "order" integer`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "experiment_partition" DROP COLUMN "order"`);
+        await queryRunner.query(`ALTER TABLE "experiment_condition" DROP COLUMN "order"`);
+    }
+
+}

--- a/backend/packages/Upgrade/test/integration/Experiment/conditionAndPartition/Condition.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/conditionAndPartition/Condition.ts
@@ -1,0 +1,94 @@
+import { individualAssignmentExperiment } from '../../mockData/experiment/index';
+import { Logger as WinstonLogger } from '../../../../src/lib/logger';
+import { ExperimentService } from '../../../../src/api/services/ExperimentService';
+import { Container } from 'typedi';
+import { UserService } from '../../../../src/api/services/UserService';
+import { systemUser } from '../../mockData/user/index';
+
+export default async function NoPartitionPoint(): Promise<void> {
+  // const logger = new WinstonLogger(__filename);
+  const experimentService = Container.get<ExperimentService>(ExperimentService);
+  // experiment object
+  const experimentObject = individualAssignmentExperiment;
+  const userService = Container.get<UserService>(UserService);
+
+  // creating new user
+  const user = await userService.upsertUser(systemUser as any);
+
+  // create experiment
+  await experimentService.create(experimentObject as any, user);
+  const experiments = await experimentService.find();
+
+  // sort conditions
+  experiments[0].conditions.sort((a,b) => {
+    return a.order > b.order ? 1 : a.order < b.order ? -1 : 0
+  });
+
+  expect(experiments[0].conditions).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: 'Condition B',
+        description: 'Condition B',
+        conditionCode: 'ConditionB',
+        assignmentWeight: 60,
+        twoCharacterId: 'CB',
+        order: 2,
+      }),
+      expect.objectContaining({
+        name: 'Condition A',
+        description: 'Condition A',
+        conditionCode: 'ConditionA',
+        assignmentWeight: 40,
+        twoCharacterId: 'CA',
+        order: 1,
+      }),
+    ])
+  );
+
+  // adding new condition 
+  const newExperimentDoc = {
+    ...experiments[0],
+    conditions: [
+      ...experiments[0].conditions,
+      {
+        name: 'Condition C',
+        description: 'Condition C',
+        conditionCode: 'Condition C',
+        assignmentWeight: 50,
+        twoCharacterId: 'CC',
+      },
+    ],
+  }
+
+  // delete first condition
+  newExperimentDoc.conditions.shift()
+
+  // order for condition
+  newExperimentDoc.conditions.forEach((condition,index) => {
+    const newCondition = {...condition, order: index + 1};
+    newExperimentDoc.conditions[index] = newCondition;
+  });
+
+  const updatedExperimentDoc = await experimentService.update(newExperimentDoc.id, newExperimentDoc as any, user);
+
+  expect(updatedExperimentDoc.conditions).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: 'Condition B',
+        description: 'Condition B',
+        conditionCode: 'ConditionB',
+        assignmentWeight: 60,
+        twoCharacterId: 'CB',
+        order: 1,
+      }),
+      expect.objectContaining({
+        name: 'Condition C',
+        description: 'Condition C',
+        conditionCode: 'Condition C',
+        assignmentWeight: 50,
+        twoCharacterId: 'CC',
+        order: 2,
+      }),
+    ])
+  )
+}

--- a/backend/packages/Upgrade/test/integration/Experiment/conditionAndPartition/Partition.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/conditionAndPartition/Partition.ts
@@ -1,0 +1,102 @@
+import { individualAssignmentExperiment } from '../../mockData/experiment/index';
+import { Logger as WinstonLogger } from '../../../../src/lib/logger';
+import { ExperimentService } from '../../../../src/api/services/ExperimentService';
+import { Container } from 'typedi';
+import { UserService } from '../../../../src/api/services/UserService';
+import { systemUser } from '../../mockData/user/index';
+
+export default async function NoPartitionPoint(): Promise<void> {
+  // const logger = new WinstonLogger(__filename);
+  const experimentService = Container.get<ExperimentService>(ExperimentService);
+  // experiment object
+  const experimentObject = individualAssignmentExperiment;
+  const userService = Container.get<UserService>(UserService);
+
+  // creating new user
+  const user = await userService.upsertUser(systemUser as any);
+
+  // create experiment
+  await experimentService.create(experimentObject as any, user);
+  const experiments = await experimentService.find();
+
+  // sort partitions
+  experiments[0].partitions.sort((a,b) => {
+    return a.order > b.order ? 1 : a.order < b.order ? -1 : 0
+  });
+
+  expect(experiments[0].partitions).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        expPoint: 'CurriculumSequence',
+        expId: 'W1',
+        description: 'Partition on Workspace 1',
+        twoCharacterId: 'W1',
+        order: 1,
+      }),
+      expect.objectContaining({
+        expPoint: 'CurriculumSequence',
+        expId: 'W2',
+        description: 'Partition on Workspace 2',
+        twoCharacterId: 'W2',
+        order: 2,
+      }),
+      expect.objectContaining({
+        expPoint: 'CurriculumSequence',
+        description: 'No Partition',
+        twoCharacterId: 'NP',
+        order: 3,
+      }),
+    ])
+  );
+
+
+  // adding new partition
+  const newExperimentDoc = {
+    ...experiments[0],
+    partitions: [
+      ...experiments[0].partitions,
+      {
+        expPoint: 'CurriculumSequence ',
+        expId: 'W3',
+        description: 'Partition on Workspace 3',
+        twoCharacterId: 'W3',
+      },
+    ],
+  }
+
+  // delete first partition
+  newExperimentDoc.partitions.shift()
+
+  // order for condition
+  newExperimentDoc.partitions.forEach((partition,index) => {
+    const newPartition = {...partition, order: index + 1};
+    newExperimentDoc.partitions[index] = newPartition;
+  });
+
+  const updatedExperimentDoc = await experimentService.update(newExperimentDoc.id, newExperimentDoc as any, user);
+
+  expect(updatedExperimentDoc.partitions).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        expPoint: 'CurriculumSequence',
+        expId: 'W2',
+        description: 'Partition on Workspace 2',
+        twoCharacterId: 'W2',
+        order: 1,
+      }),
+      expect.objectContaining({
+        expPoint: 'CurriculumSequence',
+        description: 'No Partition',
+        twoCharacterId: 'NP',
+        order: 2,
+      }),
+      expect.objectContaining({
+        expPoint: 'CurriculumSequence ',
+        expId: 'W3',
+        description: 'Partition on Workspace 3',
+        twoCharacterId: 'W3',
+        order: 3,
+      }),
+    ])
+  )
+}

--- a/backend/packages/Upgrade/test/integration/Experiment/conditionAndPartition/index.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/conditionAndPartition/index.ts
@@ -1,0 +1,50 @@
+import { Container } from 'typedi';
+import { ExperimentUserService } from '../../../../src/api/services/ExperimentUserService';
+import { CheckService } from '../../../../src/api/services/CheckService';
+import { experimentUsers } from '../../mockData/experimentUsers/index';
+import TestCase1 from './Condition';
+import TestCase2 from './Partition';
+
+const initialChecks = async () => {
+  const userService = Container.get<ExperimentUserService>(ExperimentUserService);
+  const checkService = Container.get<CheckService>(CheckService);
+
+  // check all the tables are empty
+  const users = await userService.find();
+  expect(users.length).toEqual(0);
+
+  const monitoredPoints = await checkService.getAllMarkedExperimentPoints();
+  expect(monitoredPoints.length).toEqual(0);
+
+  const groupAssignments = await checkService.getAllGroupAssignments();
+  expect(groupAssignments.length).toEqual(0);
+
+  const groupExclusions = await checkService.getAllGroupExclusions();
+  expect(groupExclusions.length).toEqual(0);
+
+  const individualAssignments = await checkService.getAllIndividualAssignment();
+  expect(individualAssignments.length).toEqual(0);
+
+  const individualExclusions = await checkService.getAllIndividualExclusion();
+  expect(individualExclusions.length).toEqual(0);
+
+  // create users over here
+  await userService.create(experimentUsers as any);
+
+  // get all user here
+  const userList = await userService.find();
+  expect(userList.length).toBe(experimentUsers.length);
+  experimentUsers.map((user) => {
+    expect(userList).toContainEqual(user);
+  });
+};
+
+export const ConditionOrder = async () => {
+  await initialChecks();
+  await TestCase1();
+};
+
+export const PartitionOrder = async () => {
+  await initialChecks();
+  await TestCase2();
+};

--- a/backend/packages/Upgrade/test/integration/Experiment/onlyExperimentPoint/NoPartitionPoint.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/onlyExperimentPoint/NoPartitionPoint.ts
@@ -18,6 +18,17 @@ export default async function NoPartitionPoint(): Promise<void> {
   // create experiment
   await experimentService.create(experimentObject as any, user);
   const experiments = await experimentService.find();
+
+  // sort conditions
+  experiments[0].conditions.sort((a,b) => {
+    return a.order > b.order ? 1 : a.order < b.order ? -1 : 0
+  });
+
+  // sort partitions
+  experiments[0].partitions.sort((a,b) => {
+    return a.order > b.order ? 1 : a.order < b.order ? -1 : 0
+  });
+
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -83,6 +94,18 @@ export default async function NoPartitionPoint(): Promise<void> {
     ],
   };
 
+  // order for condition
+  newExperimentDoc.conditions.forEach((condition,index) => {
+    const newCondition = {...condition, order: index + 1};
+    newExperimentDoc.conditions[index] = newCondition;
+  });
+
+  // order for partition
+  newExperimentDoc.partitions.forEach((partition,index) => {
+    const newPartition = {...partition, order: index + 1};
+    newExperimentDoc.partitions[index] = newPartition;
+  });
+
   const updatedExperimentDoc = await experimentService.update(newExperimentDoc.id, newExperimentDoc as any, user);
   // check the conditions
   expect(updatedExperimentDoc.conditions).toEqual(
@@ -92,6 +115,7 @@ export default async function NoPartitionPoint(): Promise<void> {
           name: condition.name,
           description: condition.description,
           conditionCode: condition.conditionCode,
+          order: condition.order,
         });
       }),
       expect.objectContaining({
@@ -100,6 +124,7 @@ export default async function NoPartitionPoint(): Promise<void> {
         conditionCode: 'Condition C',
         assignmentWeight: 50,
         twoCharacterId: 'CC',
+        order: 2,
       }),
     ])
   );
@@ -117,6 +142,7 @@ export default async function NoPartitionPoint(): Promise<void> {
           expPoint: partition.expPoint,
           expId: partition.expId,
           description: partition.description,
+          order: partition.order,
         });
       }),
       expect.objectContaining({
@@ -124,6 +150,7 @@ export default async function NoPartitionPoint(): Promise<void> {
         expId: 'W3',
         description: 'Partition on Workspace 3',
         twoCharacterId: 'W3',
+        order: 3,
       }),
     ])
   );

--- a/backend/packages/Upgrade/test/integration/Experiment/update/UpdateExperiment.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/update/UpdateExperiment.ts
@@ -19,6 +19,17 @@ export default async function UpdateExperiment(): Promise<void> {
   // create experiment
   await experimentService.create(individualAssignmentExperiment as any, user);
   let experiments = await experimentService.find();
+
+  // sort conditions
+  experiments[0].conditions.sort((a,b) => {
+    return a.order > b.order ? 1 : a.order < b.order ? -1 : 0
+  });
+
+  // sort partitions
+  experiments[0].partitions.sort((a,b) => {
+    return a.order > b.order ? 1 : a.order < b.order ? -1 : 0
+  });
+
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -84,6 +95,18 @@ export default async function UpdateExperiment(): Promise<void> {
     ],
   };
 
+  // order for condition
+  newExperimentDoc.conditions.forEach((condition,index) => {
+    const newCondition = {...condition, order: index + 1};
+    newExperimentDoc.conditions[index] = newCondition;
+  });
+
+  // order for partition
+  newExperimentDoc.partitions.forEach((partition,index) => {    
+    const newCondition = {...partition, order: index + 1};
+    newExperimentDoc.partitions[index] = newCondition;
+  });
+
   const updatedExperimentDoc = await experimentService.update(newExperimentDoc.id, newExperimentDoc as any, user);
   // check the conditions
   expect(updatedExperimentDoc.conditions).toEqual(
@@ -93,6 +116,7 @@ export default async function UpdateExperiment(): Promise<void> {
           name: condition.name,
           description: condition.description,
           conditionCode: condition.conditionCode,
+          order: condition.order,
         });
       }),
       expect.objectContaining({
@@ -101,6 +125,7 @@ export default async function UpdateExperiment(): Promise<void> {
         conditionCode: 'Condition C',
         assignmentWeight: 50,
         twoCharacterId: 'CC',
+        order: 2,
       }),
     ])
   );
@@ -120,6 +145,7 @@ export default async function UpdateExperiment(): Promise<void> {
           expPoint: partition.expPoint,
           expId: partition.expId,
           description: partition.description,
+          order: partition.order,
         });
       }),
       expect.objectContaining({
@@ -127,6 +153,7 @@ export default async function UpdateExperiment(): Promise<void> {
         expId: 'W3',
         description: 'Partition on Workspace 3',
         twoCharacterId: 'W3',
+        order: 3,
       }),
     ])
   );

--- a/backend/packages/Upgrade/test/integration/PreviewExperiment/DeletePreviewAssignmentsWithExperimentUpdate.ts
+++ b/backend/packages/Upgrade/test/integration/PreviewExperiment/DeletePreviewAssignmentsWithExperimentUpdate.ts
@@ -22,6 +22,17 @@ export default async function testCase(): Promise<void> {
   // create experiment
   await experimentService.create(experimentObject as any, user);
   const experiments = await experimentService.find();
+
+  // sort conditions
+  experiments[0].conditions.sort((a,b) => {
+    return a.order > b.order ? 1 : a.order < b.order ? -1 : 0
+  });
+
+  // sort partitions
+  experiments[0].partitions.sort((a,b) => {
+    return a.order > b.order ? 1 : a.order < b.order ? -1 : 0
+  });
+
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -82,6 +93,12 @@ export default async function testCase(): Promise<void> {
     ],
   };
 
+  // order for condition
+  newExperimentDoc.conditions.forEach((condition,index) => {
+    const newCondition = {...condition, order: index + 1};
+    newExperimentDoc.conditions[index] = newCondition;
+  });
+
   const updatedExperimentDoc = await experimentService.update(newExperimentDoc.id, newExperimentDoc as any, user);
   // check the conditions
   expect(updatedExperimentDoc.conditions).toEqual(
@@ -92,6 +109,7 @@ export default async function testCase(): Promise<void> {
         conditionCode: 'Condition C',
         assignmentWeight: 50,
         twoCharacterId: 'CC',
+        order: 1,
       }),
     ])
   );

--- a/backend/packages/Upgrade/test/integration/index.test.ts
+++ b/backend/packages/Upgrade/test/integration/index.test.ts
@@ -64,6 +64,7 @@ import { IndividualExperimentEnrollmentCode } from './Experiment/enrollmentCode'
 import { GroupExperimentEnrollmentCode, ExperimentExperimentEnrollmentCode } from './Experiment/enrollmentCode/index';
 import { MonitoredPointForExport } from './Experiment/analytics';
 import { GroupAndParticipants, ParticipantsOnly } from './EndingCriteria';
+import { ConditionOrder, PartitionOrder } from './Experiment/conditionAndPartition';
 
 describe('Integration Tests', () => {
   // -------------------------------------------------------------------------
@@ -415,6 +416,15 @@ describe('Integration Tests', () => {
     done();
   });
 
+  test('Order For Condition', async (done) => {
+    await ConditionOrder();
+    done();
+  });
+
+  test('Order For Partition', async (done) => {
+    await PartitionOrder();
+    done();
+  });
   // test('Monitored Point for Export', async (done) => {
   //   await MonitoredPointForExport();
   //   done();

--- a/frontend/projects/abtesting/src/app/core/experiments/store/experiments.model.ts
+++ b/frontend/projects/abtesting/src/app/core/experiments/store/experiments.model.ts
@@ -105,6 +105,7 @@ export interface ExperimentCondition {
   conditionCode: string;
   assignmentWeight: number;
   twoCharacterId: string;
+  order: number;
 }
 
 export interface ExperimentPartition {
@@ -113,6 +114,7 @@ export interface ExperimentPartition {
   expId: string;
   description: string;
   twoCharacterId: string;
+  order: number;
 }
 
 export interface ExperimentNameVM {

--- a/frontend/projects/abtesting/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
+++ b/frontend/projects/abtesting/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
@@ -111,10 +111,10 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
       this.condition.removeAt(0);
       this.partition.removeAt(0);
       this.experimentInfo.conditions.forEach(condition => {
-        this.condition.push(this.addConditions(condition.conditionCode, condition.assignmentWeight, condition.description));
+        this.condition.push(this.addConditions(condition.conditionCode, condition.assignmentWeight, condition.description, condition.order));
       });
       this.experimentInfo.partitions.forEach(partition => {
-        this.partition.push(this.addPartitions(partition.expPoint, partition.expId, partition.description));
+        this.partition.push(this.addPartitions(partition.expPoint, partition.expId, partition.description, partition.order));
       });
     }
     this.updateView();
@@ -153,19 +153,21 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
     return this.contextMetaData ? (this.contextMetaData[key] || []).filter(option => option.toLowerCase().indexOf(filterValue) === 0) : [];
   }
 
-  addConditions(conditionCode = null, assignmentWeight = null, description = null) {
+  addConditions(conditionCode = null, assignmentWeight = null, description = null, order = null) {
     return this._formBuilder.group({
       conditionCode: [conditionCode, Validators.required],
       assignmentWeight: [assignmentWeight, Validators.required],
-      description: [description]
+      description: [description],
+      order: [order]
     });
   }
 
-  addPartitions(expPoint = null, expId = null, description = '') {
+  addPartitions(expPoint = null, expId = null, description = '', order = null) {
     return this._formBuilder.group({
       expPoint: [expPoint, Validators.required],
       expId: [expId],
-      description: [description]
+      description: [description],
+      order: [order]
     });
   }
 
@@ -344,18 +346,22 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
         if (!this.partitionPointErrors.length && !this.expPointAndIdErrors.length && this.experimentDesignForm.valid && !this.conditionCodeError) {
           const experimentDesignFormData = this.experimentDesignForm.value;
 
+          let order = 1;
           experimentDesignFormData.conditions = experimentDesignFormData.conditions.map(
             (condition, index) => {
               return this.experimentInfo
-                ? ({ ...this.experimentInfo.conditions[index], ...condition })
-                : ({ id: uuid.v4(), ...condition, name: ''});
+                ? ({ ...this.experimentInfo.conditions[index], ...condition, order: order++ })
+                : ({ id: uuid.v4(), ...condition, name: '', order: order++ });
             }
           );
           experimentDesignFormData.partitions = experimentDesignFormData.partitions.map(
             (partition, index) => {
               return this.experimentInfo
-                ? ({ ...this.experimentInfo.partitions[index], ...partition })
-                : (partition.expId ? partition : this.removePartitionName(partition));
+                ? ({ ...this.experimentInfo.partitions[index], ...partition, order: order++ })
+                : (partition.expId 
+                  ? ({...partition, order: order++ }) 
+                  : ({...this.removePartitionName(partition), order: order++ })
+                );
             }
           );
           this.emitExperimentDialogEvent.emit({

--- a/frontend/projects/abtesting/src/app/features/dashboard/home/components/modal/import-experiment/import-experiment.component.ts
+++ b/frontend/projects/abtesting/src/app/features/dashboard/home/components/modal/import-experiment/import-experiment.component.ts
@@ -79,6 +79,7 @@ export class ImportExperimentComponent {
       conditionCode: 'string',
       assignmentWeight: 'number',
       twoCharacterId: 'string',
+      order: 'number'
     }
 
     const partitionSchema: Record<keyof ExperimentPartition, string> = {
@@ -87,6 +88,7 @@ export class ImportExperimentComponent {
       expId: 'string',
       description: 'string',
       twoCharacterId: 'string',
+      order: 'number'
     }
 
     let missingProperties = this.checkForMissingProperties({ schema: experimentSchema, data: experiment });


### PR DESCRIPTION
I created a copy of backend version 1.0.52 - 7642243 and wrote the code for 'order'. 

I created a column 'Order' (number & nullable) for condition and partition. This Order will get increasing integer in order as the user has given input in UI during the creating and updating of conditions and partitions.

While displaying in the UI the conditions and partitions will be sorted as per the 'Order' every time, so the conditions and partitions will never be displayed in random order.