### PR TITLE
Backend changes for the init() call issue # 69 (not creating user anywhere except the init() call)

### DIFF
--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
@@ -292,20 +292,19 @@ export class ExperimentClientController {
    *            description: Log blob data
    */
   @Post('bloblog')
-  public blobLog(@Req() request: express.Request): any {
+  public blobLog(@Req() request: express.Request): Promise<Log[] | any> {
     return new Promise((resolve, reject) => {
       request.on('readable', async (data) => {
         const blobData = JSON.parse(request.read());
         try {
-          // The function will throw error is iserId doesn't exist
+          // The function will throw error if userId doesn't exist
           const response = await this.experimentAssignmentService.blobDataLog(blobData.userId, blobData.value);
           resolve(response);
-        }
-        catch(error) {
+        } catch (error) {
           // The error is rejected so promise can now handle this error
-          reject(error); 
+          reject(error);
         }
-      })
+      });
     }).catch(error => {
       throw new Error(
         JSON.stringify({

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
@@ -292,7 +292,7 @@ export class ExperimentClientController {
    *            description: Log blob data
    */
   @Post('bloblog')
-  public blobLog(@Req() request: express.Request): Promise<Log[] | any> {
+  public blobLog(@Req() request: express.Request): any {
     return new Promise((resolve, reject) => {
       request.on('readable', async (data) => {
         const blobData = JSON.parse(request.read());

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
@@ -7,7 +7,7 @@ import { ExperimentUser } from '../models/ExperimentUser';
 import { ExperimentUserService } from '../services/ExperimentUserService';
 import { UpdateWorkingGroupValidator } from './validators/UpdateWorkingGroupValidator';
 import { MonitoredExperimentPoint } from '../models/MonitoredExperimentPoint';
-import { IExperimentAssignment, ISingleMetric, IGroupMetric } from 'upgrade_types';
+import { IExperimentAssignment, ISingleMetric, IGroupMetric, SERVER_ERROR} from 'upgrade_types';
 import { FailedParamsValidator } from './validators/FailedParamsValidator';
 import { ExperimentError } from '../models/ExperimentError';
 import { FeatureFlag } from '../models/FeatureFlag';
@@ -292,13 +292,27 @@ export class ExperimentClientController {
    *            description: Log blob data
    */
   @Post('bloblog')
-  public blobLog(@Req() request: express.Request): Promise<Log[]> {
-    return new Promise((resolve) => {
+  public blobLog(@Req() request: express.Request): any {
+    return new Promise((resolve, reject) => {
       request.on('readable', async (data) => {
         const blobData = JSON.parse(request.read());
-        const response = await this.experimentAssignmentService.blobDataLog(blobData.userId, blobData.value);
-        resolve(response);
-      });
+        try {
+          // The function will throw error is iserId doesn't exist
+          const response = await this.experimentAssignmentService.blobDataLog(blobData.userId, blobData.value);
+          resolve(response);
+        }
+        catch(error) {
+          // The error is rejected so promise can now handle this error
+          reject(error); 
+        }
+      })
+    }).catch(error => {
+      throw new Error(
+        JSON.stringify({
+          type: SERVER_ERROR.EXPERIMENT_USER_NOT_DEFINED,
+          message: error.message,
+        })
+      );
     });
   }
 

--- a/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
@@ -22,7 +22,6 @@ import { IndividualAssignment } from '../models/IndividualAssignment';
 import { GroupAssignment } from '../models/GroupAssignment';
 import { IndividualExclusion } from '../models/IndividualExclusion';
 import { GroupExclusion } from '../models/GroupExclusion';
-import { ExperimentUserRepository } from '../repositories/ExperimentUserRepository';
 import { Experiment } from '../models/Experiment';
 import { ExplicitIndividualExclusionRepository } from '../repositories/ExplicitIndividualExclusionRepository';
 import { ExplicitGroupExclusionRepository } from '../repositories/ExplicitGroupExclusionRepository';
@@ -66,8 +65,6 @@ export class ExperimentAssignmentService {
     private monitoredExperimentPointLogRepository: MonitoredExperimentPointLogRepository,
     @OrmRepository()
     private monitoredExperimentPointRepository: MonitoredExperimentPointRepository,
-    @OrmRepository()
-    private userRepository: ExperimentUserRepository,
     @OrmRepository()
     private explicitIndividualExclusionRepository: ExplicitIndividualExclusionRepository,
     @OrmRepository()
@@ -232,9 +229,14 @@ export class ExperimentAssignmentService {
     let experimentUser: ExperimentUser = usersData[0];
     const previewUser: PreviewUser = usersData[1];
 
-    // create user if user not defined
+    // throw error if user not defined
     if (!experimentUser) {
-      experimentUser = await this.userRepository.save({ id: userId });
+      throw new Error(
+        JSON.stringify({
+          type: SERVER_ERROR.EXPERIMENT_USER_NOT_DEFINED,
+          message: `User not defined : ${userId}`,
+        })
+      );
     }
 
     // query all experiment and sub experiment
@@ -513,9 +515,9 @@ export class ExperimentAssignmentService {
     let userDoc = await this.experimentUserService.getOriginalUserDoc(userId);
     const keyUniqueArray = [];
 
-    // create user if user does not exist
+    // throw error if user not defined
     if (!userDoc) {
-      userDoc = await this.userRepository.save({ id: userId });
+      throw new Error(`User not defined: ${userId}`);
     }
 
     // extract the array value
@@ -533,9 +535,14 @@ export class ExperimentAssignmentService {
     let userDoc = await this.experimentUserService.getOriginalUserDoc(userId);
     const keyUniqueArray = [];
 
-    // create user if user does not exist
+    // throw error if user not defined
     if (!userDoc) {
-      userDoc = await this.userRepository.save({ id: userId });
+      throw new Error(
+        JSON.stringify({
+          type: SERVER_ERROR.EXPERIMENT_USER_NOT_DEFINED,
+          message: `User not defined: ${userId}`,
+        })
+      );
     }
 
     // extract the array value
@@ -556,9 +563,14 @@ export class ExperimentAssignmentService {
     const error = new ExperimentError();
     let userDoc = await this.experimentUserService.getOriginalUserDoc(userId);
 
-    // create user if user does not exist
+    // throw error if user not defined
     if (!userDoc) {
-      userDoc = await this.userRepository.save({ id: userId });
+      throw new Error(
+        JSON.stringify({
+          type: SERVER_ERROR.EXPERIMENT_USER_NOT_DEFINED,
+          message: `User not defined: ${userId}`,
+        })
+      );
     }
 
     error.type = SERVER_ERROR.REPORTED_ERROR;

--- a/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
@@ -226,7 +226,7 @@ export class ExperimentAssignmentService {
       this.previewUserService.findOne(userId),
     ]);
 
-    let experimentUser: ExperimentUser = usersData[0];
+    const experimentUser: ExperimentUser = usersData[0];
     const previewUser: PreviewUser = usersData[1];
 
     // throw error if user not defined
@@ -512,7 +512,7 @@ export class ExperimentAssignmentService {
   public async blobDataLog(userId: string, blobLog: ILogInput[]): Promise<Log[]> {
     this.log.info(`Add blob data userId ${userId} and value ${blobLog}`);
 
-    let userDoc = await this.experimentUserService.getOriginalUserDoc(userId);
+    const userDoc = await this.experimentUserService.getOriginalUserDoc(userId);
     const keyUniqueArray = [];
 
     // throw error if user not defined
@@ -532,7 +532,7 @@ export class ExperimentAssignmentService {
   public async dataLog(userId: string, jsonLog: ILogInput[]): Promise<Log[]> {
     this.log.info(`Add data log userId ${userId} and value ${JSON.stringify(jsonLog, null, 2)}`);
 
-    let userDoc = await this.experimentUserService.getOriginalUserDoc(userId);
+    const userDoc = await this.experimentUserService.getOriginalUserDoc(userId);
     const keyUniqueArray = [];
 
     // throw error if user not defined
@@ -561,7 +561,7 @@ export class ExperimentAssignmentService {
     experimentId: string
   ): Promise<ExperimentError> {
     const error = new ExperimentError();
-    let userDoc = await this.experimentUserService.getOriginalUserDoc(userId);
+    const userDoc = await this.experimentUserService.getOriginalUserDoc(userId);
 
     // throw error if user not defined
     if (!userDoc) {

--- a/backend/packages/Upgrade/src/api/services/ExperimentUserService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentUserService.ts
@@ -58,9 +58,15 @@ export class ExperimentUserService {
   public async setAliasesForUser(userId: string, aliases: string[]): Promise<ExperimentUser[]> {
     this.log.info('Set aliases for experiment user => ', userId, aliases);
     let userExist = await this.getOriginalUserDoc(userId);
+
+    // throw error if user not defined
     if (!userExist) {
-      // Create experiment user if it does not exist
-      userExist = await this.userRepository.save({ id: userId });
+      throw new Error(
+        JSON.stringify({
+          type: SERVER_ERROR.EXPERIMENT_USER_NOT_DEFINED,
+          message: `User not defined: ${userId}`,
+        })
+      );
     }
     const promiseArray = [];
     aliases.map((aliasId) => {

--- a/backend/packages/Upgrade/src/api/services/ExperimentUserService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentUserService.ts
@@ -57,7 +57,7 @@ export class ExperimentUserService {
 
   public async setAliasesForUser(userId: string, aliases: string[]): Promise<ExperimentUser[]> {
     this.log.info('Set aliases for experiment user => ', userId, aliases);
-    let userExist = await this.getOriginalUserDoc(userId);
+    const userExist = await this.getOriginalUserDoc(userId);
 
     // throw error if user not defined
     if (!userExist) {
@@ -158,6 +158,15 @@ export class ExperimentUserService {
     this.log.info('Update working group => ', userId, workingGroup);
     const userExist = await this.getOriginalUserDoc(userId);
 
+    if (!userExist) {
+      throw new Error(
+        JSON.stringify({
+          type: SERVER_ERROR.EXPERIMENT_USER_NOT_DEFINED,
+          message: `User not defined: ${userId}`,
+        })
+      );
+    }
+
     // TODO check if workingGroup is the subset of group membership
     const newDocument = userExist ? { ...userExist, workingGroup } : { id: userId, workingGroup };
     return this.userRepository.save(newDocument);
@@ -176,6 +185,15 @@ export class ExperimentUserService {
     );
 
     const userExist = await this.getOriginalUserDoc(userId);
+
+    if (!userExist) {
+      throw new Error(
+        JSON.stringify({
+          type: SERVER_ERROR.EXPERIMENT_USER_NOT_DEFINED,
+          message: `User not defined: ${userId}`,
+        })
+      );
+    }
 
     // update assignments
     if (userExist && userExist.group) {

--- a/backend/packages/Upgrade/src/api/services/ExperimentUserService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentUserService.ts
@@ -168,7 +168,7 @@ export class ExperimentUserService {
     }
 
     // TODO check if workingGroup is the subset of group membership
-    const newDocument = userExist ? { ...userExist, workingGroup } : { id: userId, workingGroup };
+    const newDocument = { ...userExist, workingGroup };
     return this.userRepository.save(newDocument);
   }
 
@@ -200,7 +200,7 @@ export class ExperimentUserService {
       await this.removeAssignments(userExist.id, groupMembership, userExist.group);
     }
 
-    const newDocument = userExist ? { ...userExist, group: groupMembership } : { id: userId, group: groupMembership };
+    const newDocument = { ...userExist, group: groupMembership };
 
     // update group membership
     return this.userRepository.save(newDocument);

--- a/backend/packages/Upgrade/test/integration/ExperimentUser/NoExperimentUserOnAssignment.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentUser/NoExperimentUserOnAssignment.ts
@@ -39,9 +39,8 @@ export default async function testCase(): Promise<void> {
   expect(experimentUser.length).toEqual(0);
 
   // get all experiment condition for user 1
-  const experimentConditionAssignments = await getAllExperimentCondition(experimentUsers[0].id);
-  expect(experimentConditionAssignments).toHaveLength(0);
+  await expect(getAllExperimentCondition(experimentUsers[0].id)).rejects.toThrow();
 
   experimentUser = await experimentUserService.find();
-  expect(experimentUser.length).toEqual(1);
+  expect(experimentUser.length).toEqual(0);
 }

--- a/backend/packages/Upgrade/test/integration/UserNotDefined/index.ts
+++ b/backend/packages/Upgrade/test/integration/UserNotDefined/index.ts
@@ -1,0 +1,21 @@
+import Container from 'typedi';
+import { ExperimentAssignmentService } from '../../../src/api/services/ExperimentAssignmentService';
+import { ExperimentUserService } from '../../../src/api/services/ExperimentUserService';
+import { experimentUsers } from '../mockData/experimentUsers/index';
+
+export const UserNotDefined = async () => {
+  const experimentUserService = Container.get<ExperimentUserService>(ExperimentUserService);
+  const experimentAssignmentService = Container.get<ExperimentAssignmentService>(ExperimentAssignmentService);
+
+  await expect(experimentAssignmentService.getAllExperimentConditions(experimentUsers[0].id, null, null)).rejects.toThrow();
+
+  await expect(experimentAssignmentService.blobDataLog(experimentUsers[0].id, null)).rejects.toThrow();
+
+  await expect(experimentAssignmentService.dataLog(experimentUsers[0].id, null)).rejects.toThrow();
+
+  await expect(experimentAssignmentService.clientFailedExperimentPoint(null, null, experimentUsers[0].id, null)).rejects.toThrow();
+
+  await expect(experimentAssignmentService.markExperimentPoint(experimentUsers[0].id, null, null, null)).rejects.toThrow();
+
+  await expect(experimentUserService.setAliasesForUser(experimentUsers[0].id, null)).rejects.toThrow();
+};

--- a/backend/packages/Upgrade/test/integration/UserNotDefined/index.ts
+++ b/backend/packages/Upgrade/test/integration/UserNotDefined/index.ts
@@ -18,4 +18,8 @@ export const UserNotDefined = async () => {
   await expect(experimentAssignmentService.markExperimentPoint(experimentUsers[0].id, null, null, null)).rejects.toThrow();
 
   await expect(experimentUserService.setAliasesForUser(experimentUsers[0].id, null)).rejects.toThrow();
+
+  await expect(experimentUserService.updateGroupMembership(experimentUsers[0].id, null)).rejects.toThrow();
+
+  await expect(experimentUserService.updateWorkingGroup(experimentUsers[0].id, null)).rejects.toThrow();
 };

--- a/backend/packages/Upgrade/test/integration/index.test.ts
+++ b/backend/packages/Upgrade/test/integration/index.test.ts
@@ -65,6 +65,7 @@ import { GroupExperimentEnrollmentCode, ExperimentExperimentEnrollmentCode } fro
 import { MonitoredPointForExport } from './Experiment/analytics';
 import { GroupAndParticipants, ParticipantsOnly } from './EndingCriteria';
 import { ConditionOrder, PartitionOrder } from './Experiment/conditionAndPartition';
+import { UserNotDefined } from './UserNotDefined';
 
 describe('Integration Tests', () => {
   // -------------------------------------------------------------------------
@@ -144,6 +145,11 @@ describe('Integration Tests', () => {
 
   test('Support Get Assignments', async (done) => {
     await GetAssignments();
+    done();
+  });
+
+  test('User not defined', async (done) => {
+    await UserNotDefined();
     done();
   });
 


### PR DESCRIPTION
The [PR](https://github.com/CarnegieLearningWeb/UpGrade/pull/103) is split into two parts. In this PR, I have removed user creation from the client-controller file for the following calls, and ```user not defined``` error is thrown.

1. /mark,
2. /assign,
3. /useraliases,
4. /datalog,
5. /bloblog,
6. /failed,
7. /groupmembership,
8. /workinggroup