### PR TITLE
Fix for issue 115 synced conditions on post experiment rule modal 

### DIFF
--- a/frontend/projects/abtesting/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
+++ b/frontend/projects/abtesting/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
@@ -349,7 +349,7 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
           experimentDesignFormData.conditions = experimentDesignFormData.conditions.map(
             (condition, index) => {
               return this.experimentInfo
-                ? ({ ...this.experimentInfo.conditions[index], ...condition, order: order++ })
+                ? ({ ...this.experimentInfo.conditions[index], ...condition, id: uuid.v4(), order: order++ })
                 : ({ id: uuid.v4(), ...condition, name: '', order: order++ });
             }
           );

--- a/frontend/projects/abtesting/src/app/features/dashboard/home/components/experiment-post-condition/experiment-post-condition.component.ts
+++ b/frontend/projects/abtesting/src/app/features/dashboard/home/components/experiment-post-condition/experiment-post-condition.component.ts
@@ -25,6 +25,9 @@ export class ExperimentPostConditionComponent implements OnInit, OnChanges {
   constructor(private _formBuilder: FormBuilder) { }
 
   ngOnChanges() {
+    this.experimentConditions = [
+      { value: 'default', id: 'default' }
+    ];
     if (this.newExperimentData.conditions && this.newExperimentData.conditions.length) {
       this.newExperimentData.conditions.map(value => {
         const isConditionExist = this.experimentConditions.find((condition) => condition.id === value.id);
@@ -32,6 +35,7 @@ export class ExperimentPostConditionComponent implements OnInit, OnChanges {
           ? this.experimentConditions
           : [ ...this.experimentConditions, { value: value.conditionCode, id: value.id }];
       });
+    console.log(this.experimentConditions);
     }
   }
 


### PR DESCRIPTION
Changing conditions while creating or editing an experiment now gets synced on post experiment rule modal page to allow users to select them.