### PR TITLE
Added sample responses in swagger (such as 200, 404, 500) and created API documentation

### DIFF
--- a/backend/packages/Upgrade/src/api/controllers/AnalyticsController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/AnalyticsController.ts
@@ -43,6 +43,25 @@ export class AnalyticsController {
    *       responses:
    *          '200':
    *            description: Analytics For Experiment Enrollment
+   *            schema:
+   *              type: array
+   *              description: ''
+   *              minItems: 1
+   *              uniqueItems: true
+   *              items:
+   *                type: object
+   *                required:
+   *                  - users
+   *                  - groups
+   *                  - id
+   *                properties:
+   *                  users:
+   *                    type: number
+   *                  groups:
+   *                    type: number
+   *                  id:
+   *                    type: string
+   *                    minLength: 1
    */
   @Post('/enrollment')
   public async analyticsService(
@@ -74,6 +93,54 @@ export class AnalyticsController {
    *       responses:
    *          '200':
    *            description: Analytics For Experiment Enrollment Detail
+   *            schema:
+   *              type: object
+   *              properties:
+   *                id:
+   *                  type: string
+   *                  minLength: 1
+   *                users:
+   *                  type: number
+   *                groups:
+   *                  type: number
+   *                usersExcluded:
+   *                  type: number
+   *                groupsExcluded:
+   *                  type: number
+   *                conditions:
+   *                  type: array
+   *                  uniqueItems: true
+   *                  minItems: 1
+   *                  items:
+   *                    required:
+   *                      - id
+   *                      - users
+   *                      - groups
+   *                    properties:
+   *                      id:
+   *                        type: string
+   *                        minLength: 1
+   *                      users:
+   *                        type: number
+   *                      groups:
+   *                        type: number
+   *                      partitions:
+   *                        type: array
+   *                        uniqueItems: true
+   *                        minItems: 1
+   *                        items:
+   *                          required:
+   *                            - id
+   *                            - users
+   *                            - groups
+   *                          properties:
+   *                            id:
+   *                              type: string
+   *                              minLength: 1
+   *                            users:
+   *                              type: number
+   *                            groups:
+   *                              type: number
    */
   @Post('/enrollment/detail')
   public async analyticsDetailService(
@@ -109,6 +176,57 @@ export class AnalyticsController {
    *       responses:
    *          '200':
    *            description: Analytics For Experiment Enrollment
+   *            schema:
+   *              type: array
+   *              description: ''
+   *              minItems: 1
+   *              uniqueItems: true
+   *              items:
+   *                type: object
+   *                required:
+   *                  - date
+   *                  - stats
+   *                properties:
+   *                  date:
+   *                    type: string
+   *                    minLength: 1
+   *                  stats:
+   *                    type: object
+   *                    properties:
+   *                      id:
+   *                        type: string
+   *                        minLength: 1
+   *                      conditions:
+   *                        type: array
+   *                        uniqueItems: true
+   *                        minItems: 1
+   *                        items:
+   *                          required:
+   *                            - id
+   *                          properties:
+   *                            id:
+   *                              type: string
+   *                              minLength: 1
+   *                            partitions:
+   *                              type: array
+   *                              uniqueItems: true
+   *                              minItems: 1
+   *                              items:
+   *                                required:
+   *                                  - id
+   *                                  - users
+   *                                  - groups
+   *                                properties:
+   *                                  id:
+   *                                    type: string
+   *                                    minLength: 1
+   *                                  users:
+   *                                    type: number
+   *                                  groups:
+   *                                    type: number
+   *                    required:
+   *                      - id
+   *                      - conditions
    */
   @Post('/enrollment/date')
   public async enrollmentByDate(

--- a/backend/packages/Upgrade/src/api/controllers/ExcludeController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExcludeController.ts
@@ -6,6 +6,67 @@ import { SERVER_ERROR } from 'upgrade_types';
 
 /**
  * @swagger
+ * definitions:
+ *   userExcludeResponse:
+ *     type: array
+ *     description: ''
+ *     minItems: 1
+ *     uniqueItems: true
+ *     items:
+ *       type: object
+ *       required:
+ *         - createdAt
+ *         - updatedAt
+ *         - versionNumber
+ *         - userId
+ *       properties:
+ *         createdAt:
+ *           type: string
+ *           minLength: 1
+ *         updatedAt:
+ *           type: string
+ *           minLength: 1
+ *         versionNumber:
+ *           type: number
+ *         userId:
+ *           type: string
+ *           minLength: 1
+ *   groupExclude:
+ *     type: array
+ *     description: ''
+ *     minItems: 1
+ *     uniqueItems: true
+ *     items:
+ *       type: object
+ *       required:
+ *         - createdAt
+ *         - updatedAt
+ *         - versionNumber
+ *         - id
+ *         - groupId
+ *         - type
+ *       properties:
+ *         createdAt:
+ *           type: string
+ *           minLength: 1
+ *         updatedAt:
+ *           type: string
+ *           minLength: 1
+ *         versionNumber:
+ *           type: number
+ *         id:
+ *           type: string
+ *           minLength: 1
+ *         groupId:
+ *           type: string
+ *           minLength: 1
+ *         type:
+ *           type: string
+ *           minLength: 1
+ */
+
+/**
+ * @swagger
  * tags:
  *   - name: Exclude
  *     description: To Exclude Users and Groups from experiments
@@ -27,6 +88,8 @@ export class ExcludeController {
    *       responses:
    *          '200':
    *            description: All Excluded Users
+   *            schema:
+   *              $ref: '#/definitions/userExcludeResponse'
    */
   @Get('/user')
   public getExcludedUser(): Promise<ExplicitIndividualExclusion[]> {
@@ -59,6 +122,8 @@ export class ExcludeController {
    *       responses:
    *          '200':
    *            description: Exclude user from experiment
+   *            schema:
+   *              $ref: '#/definitions/userExcludeResponse'
    */
   @Put('/user')
   public excludeUser(@BodyParam('id') id: string): Promise<ExplicitIndividualExclusion> {
@@ -84,6 +149,8 @@ export class ExcludeController {
    *       responses:
    *          '200':
    *            description: Delete User By Id
+   *            schema:
+   *              $ref: '#/definitions/userExcludeResponse'
    */
   @Delete('/user/:id')
   public delete(@Param('id') id: string): Promise<ExplicitIndividualExclusion | undefined> {
@@ -105,6 +172,8 @@ export class ExcludeController {
    *       responses:
    *          '200':
    *            description: All Excluded Groups
+   *            schema:
+   *              $ref: '#/definitions/userExcludeResponse'
    */
   @Get('/group')
   public getExcludedGroups(): Promise<ExplicitGroupExclusion[]> {
@@ -139,6 +208,8 @@ export class ExcludeController {
    *       responses:
    *          '200':
    *            description: Exclude group from experiment
+   *            schema:
+   *              $ref: '#/definitions/userExcludeResponse'
    */
   @Put('/group')
   public excludeGroup(@BodyParam('type') type: string, @BodyParam('id') id: string): Promise<ExplicitGroupExclusion> {
@@ -170,6 +241,8 @@ export class ExcludeController {
    *       responses:
    *          '200':
    *            description: Delete User By Id
+   *            schema:
+   *              $ref: '#/definitions/userExcludeResponse'
    */
   @Delete('/group/:type/:id')
   public deleteGroup(

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
@@ -274,7 +274,7 @@ export class ExperimentClientController {
    *                - userId
    *                - condition
    *          '500':
-   *            description: User not defined 
+   *            description: User not defined
    */
   @Post('mark')
   public markExperimentPoint(
@@ -552,7 +552,7 @@ export class ExperimentClientController {
    *          '200':
    *            description: Filtered Metrics
    *          '500':
-   *            description: Insert error in database 
+   *            description: Insert error in database
    */
   @Post('metric')
   public filterMetrics(@BodyParam('metricUnit') metricUnit: Array<ISingleMetric | IGroupMetric>): Promise<Metric[]> {

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
@@ -158,6 +158,8 @@ export class ExperimentClientController {
    *            description: Set Group Membership
    *            schema:
    *              $ref: '#/definitions/initResponse'
+   *          '500':
+   *            description: null value in column "id" of relation "experiment_user" violates not-null constraint
    */
   @Post('groupmembership')
   public setGroupMemberShip(
@@ -195,6 +197,8 @@ export class ExperimentClientController {
    *            description: Set Group Membership
    *            schema:
    *              $ref: '#/definitions/initResponse'
+   *          '500':
+   *            description: null value in column "id" of relation "experiment_user" violates not-null constraint
    */
   @Post('workinggroup')
   public setWorkingGroup(
@@ -213,23 +217,20 @@ export class ExperimentClientController {
    *         - application/json
    *       parameters:
    *         - in: body
-   *           name: userId
+   *           name: experimentUser
    *           required: true
    *           schema:
-   *             type: string
-   *           description: User ID
-   *         - in: body
-   *           name: experimentPoint
-   *           required: true
-   *           schema:
-   *             type: string
-   *           description: Experiment Point
-   *         - in: body
-   *           name: partitionId
-   *           required: true
-   *           schema:
-   *             type: string
-   *           description: Partition ID
+   *             type: object
+   *             properties:
+   *               userId:
+   *                 type: string
+   *               experimentPoint:
+   *                 type: string
+   *               partitionId:
+   *                 type: string
+   *               condition:
+   *                 type: string
+   *           description: ExperimentUser
    *       tags:
    *         - Client Side SDK
    *       produces:
@@ -272,6 +273,8 @@ export class ExperimentClientController {
    *                - enrollmentCode
    *                - userId
    *                - condition
+   *          '500':
+   *            description: User not defined 
    */
   @Post('mark')
   public markExperimentPoint(
@@ -371,6 +374,8 @@ export class ExperimentClientController {
    *                      - conditionCode
    *                      - assignmentWeight
    *                      - order
+   *          '500':
+   *            description: null value in column "id" of relation "experiment_user" violates not-null constraint
    */
   @Post('assign')
   public getAllExperimentConditions(
@@ -397,7 +402,9 @@ export class ExperimentClientController {
    *               userId:
    *                 type: string
    *               value:
-   *                 type: string
+   *                 type: array
+   *                 items:
+   *                   type: object
    *            description: User Document
    *       tags:
    *         - Client Side SDK
@@ -406,6 +413,8 @@ export class ExperimentClientController {
    *       responses:
    *          '200':
    *            description: Log data
+   *          '500':
+   *            description: null value in column "id\" of relation \"experiment_user\" violates not-null constraint
    */
   @Post('log')
   public log(
@@ -421,7 +430,7 @@ export class ExperimentClientController {
    *    post:
    *       description: Post blob log data
    *       consumes:
-   *         - multipart/form-data
+   *         - application/json
    *       parameters:
    *          - in: body
    *            name: data
@@ -432,8 +441,9 @@ export class ExperimentClientController {
    *               userId:
    *                 type: string
    *               value:
-   *                 type: string
-   *                 format: binary
+   *                 type: array
+   *                 items:
+   *                   type: object
    *            description: User Document
    *       tags:
    *         - Client Side SDK
@@ -472,6 +482,8 @@ export class ExperimentClientController {
    *                type: string
    *              experimentPoint:
    *                type: string
+   *              userId:
+   *                type: string
    *              experimentId:
    *                type: string
    *            description: Experiment Error from client
@@ -482,6 +494,8 @@ export class ExperimentClientController {
    *       responses:
    *          '200':
    *            description: Client side reported error
+   *          '500':
+   *            description: null value in column "id\" of relation \"experiment_user\" violates not-null constraint
    */
   @Post('failed')
   public failedExperimentPoint(
@@ -498,7 +512,7 @@ export class ExperimentClientController {
 
   /**
    * @swagger
-   * /featureflags:
+   * /featureflag:
    *    get:
    *       description: Get all feature flags using SDK
    *       produces:
@@ -537,6 +551,8 @@ export class ExperimentClientController {
    *       responses:
    *          '200':
    *            description: Filtered Metrics
+   *          '500':
+   *            description: Insert error in database 
    */
   @Post('metric')
   public filterMetrics(@BodyParam('metricUnit') metricUnit: Array<ISingleMetric | IGroupMetric>): Promise<Metric[]> {
@@ -604,6 +620,8 @@ export class ExperimentClientController {
    *                  originalUser:
    *                    type: string
    *                    minLength: 1
+   *          '500':
+   *            description: null value in column "id\" of relation \"experiment_user\" violates not-null constraint
    */
   @Post('useraliases')
   public setUserAliases(@Body() user: ExperimentUserAliasesValidator): Promise<ExperimentUser[]> {

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
@@ -22,8 +22,60 @@ import * as express from 'express';
 
 /**
  * @swagger
+ * definitions:
+ *   initResponse:
+ *     type: object
+ *     properties:
+ *       createdAt:
+ *         type: string
+ *         minLength: 1
+ *       updatedAt:
+ *         type: string
+ *         minLength: 1
+ *       versionNumber:
+ *         type: number
+ *       id:
+ *         type: string
+ *         minLength: 1
+ *       group:
+ *         type: object
+ *         properties:
+ *           class:
+ *             type: array
+ *             items:
+ *               required: []
+ *               properties: {}
+ *         required:
+ *           - class
+ *       workingGroup:
+ *         type: object
+ *         properties:
+ *           school:
+ *             type: string
+ *             minLength: 1
+ *           class:
+ *             type: string
+ *             minLength: 1
+ *           instructor:
+ *             type: string
+ *             minLength: 1
+ *         required:
+ *           - school
+ *           - class
+ *           - instructor
+ *     required:
+ *       - createdAt
+ *       - updatedAt
+ *       - versionNumber
+ *       - id
+ *       - group
+ *       - workingGroup
+ */
+
+/**
+ * @swagger
  * tags:
- *   - name: Experiment Point
+ *   - name: Client Side SDK
  *     description: CRUD operations related to experiments points
  */
 
@@ -60,12 +112,14 @@ export class ExperimentClientController {
    *                 type: object
    *           description: ExperimentUser
    *       tags:
-   *         - Experiment Point
+   *         - Client Side SDK
    *       produces:
    *         - application/json
    *       responses:
    *          '200':
    *            description: Set Group Membership
+   *            schema:
+   *              $ref: '#/definitions/initResponse'
    */
   @Post('init')
   public async init(
@@ -96,12 +150,14 @@ export class ExperimentClientController {
    *                 type: object
    *           description: ExperimentUser
    *       tags:
-   *         - Experiment Point
+   *         - Client Side SDK
    *       produces:
    *         - application/json
    *       responses:
    *          '200':
    *            description: Set Group Membership
+   *            schema:
+   *              $ref: '#/definitions/initResponse'
    */
   @Post('groupmembership')
   public setGroupMemberShip(
@@ -131,12 +187,14 @@ export class ExperimentClientController {
    *                 type: object
    *           description: ExperimentUser
    *       tags:
-   *         - Experiment Point
+   *         - Client Side SDK
    *       produces:
    *         - application/json
    *       responses:
    *          '200':
    *            description: Set Group Membership
+   *            schema:
+   *              $ref: '#/definitions/initResponse'
    */
   @Post('workinggroup')
   public setWorkingGroup(
@@ -173,12 +231,47 @@ export class ExperimentClientController {
    *             type: string
    *           description: Partition ID
    *       tags:
-   *         - Experiment Point
+   *         - Client Side SDK
    *       produces:
    *         - application/json
    *       responses:
    *          '200':
    *            description: Experiment Point is Marked
+   *            schema:
+   *              type: object
+   *              properties:
+   *                createdAt:
+   *                  type: string
+   *                  minLength: 1
+   *                updatedAt:
+   *                  type: string
+   *                  minLength: 1
+   *                versionNumber:
+   *                  type: number
+   *                id:
+   *                  type: string
+   *                  minLength: 1
+   *                experimentId:
+   *                  type: string
+   *                  minLength: 1
+   *                enrollmentCode:
+   *                  type: string
+   *                  minLength: 1
+   *                userId:
+   *                  type: string
+   *                  minLength: 1
+   *                condition:
+   *                  type: string
+   *                  minLength: 1
+   *              required:
+   *                - createdAt
+   *                - updatedAt
+   *                - versionNumber
+   *                - id
+   *                - experimentId
+   *                - enrollmentCode
+   *                - userId
+   *                - condition
    */
   @Post('mark')
   public markExperimentPoint(
@@ -213,12 +306,71 @@ export class ExperimentClientController {
    *                 type: string
    *            description: User Document
    *       tags:
-   *         - Experiment Point
+   *         - Client Side SDK
    *       produces:
    *         - application/json
    *       responses:
    *          '200':
    *            description: Experiment Point is Assigned
+   *            schema:
+   *              type: array
+   *              description: ''
+   *              minItems: 1
+   *              uniqueItems: true
+   *              items:
+   *                type: object
+   *                required:
+   *                  - expId
+   *                  - expPoint
+   *                  - twoCharacterId
+   *                  - assignedCondition
+   *                properties:
+   *                  expId:
+   *                    type: string
+   *                    minLength: 1
+   *                  expPoint:
+   *                    type: string
+   *                    minLength: 1
+   *                  twoCharacterId:
+   *                    type: string
+   *                    minLength: 1
+   *                  assignedCondition:
+   *                    type: object
+   *                    properties:
+   *                      createdAt:
+   *                        type: string
+   *                        minLength: 1
+   *                      updatedAt:
+   *                        type: string
+   *                        minLength: 1
+   *                      versionNumber:
+   *                        type: number
+   *                      id:
+   *                        type: string
+   *                        minLength: 1
+   *                      twoCharacterId:
+   *                        type: string
+   *                        minLength: 1
+   *                      name:
+   *                        type: string
+   *                      description: {}
+   *                      conditionCode:
+   *                        type: string
+   *                        minLength: 1
+   *                      assignmentWeight:
+   *                        type: number
+   *                      order:
+   *                        type: number
+   *                    required:
+   *                      - createdAt
+   *                      - updatedAt
+   *                      - versionNumber
+   *                      - id
+   *                      - twoCharacterId
+   *                      - name
+   *                      - conditionCode
+   *                      - assignmentWeight
+   *                      - order
    */
   @Post('assign')
   public getAllExperimentConditions(
@@ -248,7 +400,7 @@ export class ExperimentClientController {
    *                 type: string
    *            description: User Document
    *       tags:
-   *         - Experiment Point
+   *         - Client Side SDK
    *       produces:
    *         - application/json
    *       responses:
@@ -284,7 +436,7 @@ export class ExperimentClientController {
    *                 format: binary
    *            description: User Document
    *       tags:
-   *         - Experiment Point
+   *         - Client Side SDK
    *       produces:
    *         - application/json
    *       responses:
@@ -324,7 +476,7 @@ export class ExperimentClientController {
    *                type: string
    *            description: Experiment Error from client
    *       tags:
-   *         - Experiment Point
+   *         - Client Side SDK
    *       produces:
    *         - application/json
    *       responses:
@@ -352,7 +504,7 @@ export class ExperimentClientController {
    *       produces:
    *         - application/json
    *       tags:
-   *         - Experiment Point
+   *         - Client Side SDK
    *       responses:
    *          '200':
    *            description: Feature flags list
@@ -379,7 +531,7 @@ export class ExperimentClientController {
    *                type: object
    *            description: Filtered Metrics
    *       tags:
-   *         - Experiment Point
+   *         - Client Side SDK
    *       produces:
    *         - application/json
    *       responses:
@@ -416,12 +568,42 @@ export class ExperimentClientController {
    *                 type: string
    *            description: Set user aliases
    *       tags:
-   *         - Experiment Point
+   *         - Client Side SDK
    *       produces:
    *         - application/json
    *       responses:
    *          '200':
    *            description: Experiment User aliases added
+   *            schema:
+   *              type: array
+   *              description: ''
+   *              minItems: 1
+   *              uniqueItems: true
+   *              items:
+   *                type: object
+   *                required:
+   *                  - id
+   *                  - createdAt
+   *                  - updatedAt
+   *                  - versionNumber
+   *                  - originalUser
+   *                properties:
+   *                  id:
+   *                    type: string
+   *                    minLength: 1
+   *                  group: {}
+   *                  workingGroup: {}
+   *                  createdAt:
+   *                    type: string
+   *                    minLength: 1
+   *                  updatedAt:
+   *                    type: string
+   *                    minLength: 1
+   *                  versionNumber:
+   *                    type: number
+   *                  originalUser:
+   *                    type: string
+   *                    minLength: 1
    */
   @Post('useraliases')
   public setUserAliases(@Body() user: ExperimentUserAliasesValidator): Promise<ExperimentUser[]> {

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
@@ -684,10 +684,12 @@ export class ExperimentController {
    *            description: New Experiment is created
    *            schema:
    *              $ref: '#/definitions/ExperimentResponse'
+   *          '400':
+   *            description: default as ConditionCode is not allowed
    *          '401':
    *            description: AuthorizationRequiredError
    *          '500':
-   *            description: Inert Error in database
+   *            description: Insert Error in database
    */
 
   @Post()
@@ -726,7 +728,7 @@ export class ExperimentController {
    *          '401':
    *            description: AuthorizationRequiredError
    *          '500':
-   *            description: Inert Error in database
+   *            description: Insert Error in database
    */
 
   @Post('/batch')

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
@@ -110,6 +110,197 @@ interface ExperimentPaginationInfo extends PaginationResponse {
  *         type: array
  *         items:
  *           type: object
+ *   ExperimentResponse:
+ *     description: ''
+ *     type: object
+ *     properties:
+ *       createdAt:
+ *         type: string
+ *         minLength: 1
+ *       updatedAt:
+ *         type: string
+ *         minLength: 1
+ *       versionNumber:
+ *         type: number
+ *       id:
+ *         type: string
+ *         minLength: 1
+ *       name:
+ *         type: string
+ *         minLength: 1
+ *       description:
+ *         type: string
+ *         minLength: 1
+ *       context:
+ *         type: array
+ *         items:
+ *           required: []
+ *           properties: {}
+ *       state:
+ *         type: string
+ *         minLength: 1
+ *       startOn: {}
+ *       consistencyRule:
+ *         type: string
+ *         minLength: 1
+ *       assignmentUnit:
+ *         type: string
+ *         minLength: 1
+ *       postExperimentRule:
+ *         type: string
+ *         minLength: 1
+ *       enrollmentCompleteCondition: {}
+ *       endOn: {}
+ *       revertTo: {}
+ *       tags:
+ *         type: array
+ *         items:
+ *           required: []
+ *           properties: {}
+ *       group:
+ *         type: string
+ *         minLength: 1
+ *       logging:
+ *         type: boolean
+ *       conditions:
+ *         type: array
+ *         uniqueItems: true
+ *         minItems: 1
+ *         items:
+ *           required:
+ *             - createdAt
+ *             - updatedAt
+ *             - versionNumber
+ *             - id
+ *             - twoCharacterId
+ *             - name
+ *             - description
+ *             - conditionCode
+ *             - assignmentWeight
+ *           properties:
+ *             createdAt:
+ *               type: string
+ *               minLength: 1
+ *             updatedAt:
+ *               type: string
+ *               minLength: 1
+ *             versionNumber:
+ *               type: number
+ *             id:
+ *               type: string
+ *               minLength: 1
+ *             twoCharacterId:
+ *               type: string
+ *               minLength: 1
+ *             name:
+ *               type: string
+ *               minLength: 1
+ *             description:
+ *               type: string
+ *               minLength: 1
+ *             conditionCode:
+ *               type: string
+ *               minLength: 1
+ *             assignmentWeight:
+ *               type: number
+ *             order: {}
+ *       partitions:
+ *         type: array
+ *         uniqueItems: true
+ *         minItems: 1
+ *         items:
+ *           required:
+ *             - createdAt
+ *             - updatedAt
+ *             - versionNumber
+ *             - id
+ *             - twoCharacterId
+ *             - expPoint
+ *             - expId
+ *             - description
+ *           properties:
+ *             createdAt:
+ *               type: string
+ *               minLength: 1
+ *             updatedAt:
+ *               type: string
+ *               minLength: 1
+ *             versionNumber:
+ *               type: number
+ *             id:
+ *               type: string
+ *               minLength: 1
+ *             twoCharacterId:
+ *               type: string
+ *               minLength: 1
+ *             expPoint:
+ *               type: string
+ *               minLength: 1
+ *             expId:
+ *               type: string
+ *               minLength: 1
+ *             description:
+ *               type: string
+ *               minLength: 1
+ *             order: {}
+ *       queries:
+ *         type: array
+ *         items:
+ *           required: []
+ *           properties: {}
+ *       stateTimeLogs:
+ *         type: array
+ *         uniqueItems: true
+ *         minItems: 1
+ *         items:
+ *           required:
+ *             - createdAt
+ *             - updatedAt
+ *             - versionNumber
+ *             - id
+ *             - fromState
+ *             - toState
+ *             - timeLog
+ *           properties:
+ *             createdAt:
+ *               type: string
+ *               minLength: 1
+ *             updatedAt:
+ *               type: string
+ *               minLength: 1
+ *             versionNumber:
+ *               type: number
+ *             id:
+ *               type: string
+ *               minLength: 1
+ *             fromState:
+ *               type: string
+ *               minLength: 1
+ *             toState:
+ *               type: string
+ *               minLength: 1
+ *             timeLog:
+ *               type: string
+ *               minLength: 1
+ *     required:
+ *       - createdAt
+ *       - updatedAt
+ *       - versionNumber
+ *       - id
+ *       - name
+ *       - description
+ *       - context
+ *       - state
+ *       - consistencyRule
+ *       - assignmentUnit
+ *       - postExperimentRule
+ *       - tags
+ *       - group
+ *       - logging
+ *       - conditions
+ *       - partitions
+ *       - queries
+ *       - stateTimeLogs
  */
 
 /**
@@ -135,6 +326,20 @@ export class ExperimentController {
    *       responses:
    *          '200':
    *            description: Experiment Name List
+   *            schema:
+   *              type: array
+   *              items:
+   *                type: object
+   *                required:
+   *                  - id
+   *                  - name
+   *                properties:
+   *                  id:
+   *                    type: string
+   *                  name:
+   *                    type: string
+   *          '401':
+   *            description: AuthorizationRequiredError
    */
   @Get('/names')
   public findName(): Promise<Array<Pick<Experiment, 'id' | 'name'>>> {
@@ -153,6 +358,12 @@ export class ExperimentController {
    *       responses:
    *          '200':
    *            description: Experiment List
+   *            schema:
+   *              type: array
+   *              items:
+   *                $ref: '#/definitions/ExperimentResponse'
+   *          '401':
+   *            description: AuthorizationRequiredError
    */
   @Get()
   public find(): Promise<Experiment[]> {
@@ -171,6 +382,27 @@ export class ExperimentController {
    *       responses:
    *          '200':
    *            description: contextMetaData list
+   *            schema:
+   *              type: object
+   *              properties:
+   *                appContext:
+   *                  type: array
+   *                  items:
+   *                    properties: {}
+   *                expPoints:
+   *                  type: array
+   *                  items:
+   *                    properties: {}
+   *                expIds:
+   *                  type: array
+   *                  items:
+   *                    properties: {}
+   *                groupTypes:
+   *                  type: array
+   *                  items:
+   *                    properties: {}
+   *          '401':
+   *            description: AuthorizationRequiredError
    */
   @Get('/contextMetaData')
   public getContextMetaData(): object {
@@ -222,6 +454,19 @@ export class ExperimentController {
    *       responses:
    *          '200':
    *            description: Get Paginated Experiments
+   *            schema:
+   *              type: object
+   *              properties:
+   *                total:
+   *                  type: number
+   *                nodes:
+   *                  type: array
+   *                  items:
+   *                    $ref: '#/definitions/ExperimentResponse'
+   *          '401':
+   *            description: AuthorizationRequiredError
+   *          '500':
+   *            description: Insert Error in database
    */
   @Post('/paginated')
   public async paginatedFind(
@@ -264,6 +509,25 @@ export class ExperimentController {
    *       responses:
    *          '200':
    *            description: Get All Experiment Partitions
+   *            schema:
+   *               type: array
+   *               description: ''
+   *               minItems: 1
+   *               uniqueItems: true
+   *               items:
+   *                 type: object
+   *                 required:
+   *                   - expPoint
+   *                   - expId
+   *                 properties:
+   *                   expPoint:
+   *                     type: string
+   *                     minLength: 1
+   *                   expId:
+   *                     type: string
+   *                     minLength: 1
+   *          '401':
+   *            description: AuthorizationRequiredError
    *          '404':
    *            description: Experiment Partitions not found
    */
@@ -291,8 +555,14 @@ export class ExperimentController {
    *       responses:
    *          '200':
    *            description: Get Experiment By Id
+   *            schema:
+   *              $ref: '#/definitions/ExperimentResponse'
+   *          '401':
+   *            description: AuthorizationRequiredError
    *          '404':
    *            description: Experiment not found
+   *          '500':
+   *            description: id should be of type UUID
    */
   @Get('/single/:id')
   @OnUndefined(ExperimentNotFoundError)
@@ -326,8 +596,56 @@ export class ExperimentController {
    *       responses:
    *          '200':
    *            description: Get Experiment By Id
+   *            schema:
+   *              type: array
+   *              description: ''
+   *              minItems: 1
+   *              uniqueItems: true
+   *              items:
+   *                type: object
+   *                required:
+   *                  - createdAt
+   *                  - updatedAt
+   *                  - versionNumber
+   *                  - id
+   *                  - twoCharacterId
+   *                  - name
+   *                  - description
+   *                  - conditionCode
+   *                  - assignmentWeight
+   *                properties:
+   *                  createdAt:
+   *                    type: string
+   *                    minLength: 1
+   *                  updatedAt:
+   *                    type: string
+   *                    minLength: 1
+   *                  versionNumber:
+   *                    type: number
+   *                  id:
+   *                    type: string
+   *                    minLength: 1
+   *                  twoCharacterId:
+   *                    type: string
+   *                    minLength: 1
+   *                  name:
+   *                    type: string
+   *                    minLength: 1
+   *                  description:
+   *                    type: string
+   *                    minLength: 1
+   *                  conditionCode:
+   *                    type: string
+   *                    minLength: 1
+   *                  assignmentWeight:
+   *                    type: number
+   *                  order: {}
+   *          '401':
+   *            description: AuthorizationRequiredError
    *          '404':
    *            description: Experiment not found
+   *          '500':
+   *            description: id should be of type UUID
    */
   @Get('/conditions/:id')
   @OnUndefined(ExperimentNotFoundError)
@@ -364,6 +682,12 @@ export class ExperimentController {
    *       responses:
    *          '200':
    *            description: New Experiment is created
+   *            schema:
+   *              $ref: '#/definitions/ExperimentResponse'
+   *          '401':
+   *            description: AuthorizationRequiredError
+   *          '500':
+   *            description: Inert Error in database
    */
 
   @Post()
@@ -397,6 +721,12 @@ export class ExperimentController {
    *       responses:
    *          '200':
    *            description: New Experiment is created
+   *            schema:
+   *              $ref: '#/definitions/ExperimentResponse'
+   *          '401':
+   *            description: AuthorizationRequiredError
+   *          '500':
+   *            description: Inert Error in database
    */
 
   @Post('/batch')
@@ -425,6 +755,14 @@ export class ExperimentController {
    *       responses:
    *          '200':
    *            description: Delete Experiment By Id
+   *            schema:
+   *              $ref: '#/definitions/ExperimentResponse'
+   *          '401':
+   *            description: AuthorizationRequiredError
+   *          '404':
+   *            description: Not found error
+   *          '500':
+   *            description: id should be of type UUID
    */
 
   @Delete('/:id')
@@ -466,6 +804,10 @@ export class ExperimentController {
    *       responses:
    *          '200':
    *            description: Experiment State is updated
+   *          '401':
+   *            description: AuthorizationRequiredError
+   *          '500':
+   *            description: id should be of type UUID, invalid input value for enum 'state' violates not-null constrain
    */
   @Post('/state')
   public async updateState(
@@ -521,6 +863,12 @@ export class ExperimentController {
    *       responses:
    *          '200':
    *            description: Experiment is updated
+   *            schema:
+   *              $ref: '#/definitions/ExperimentResponse'
+   *          '401':
+   *            description: AuthorizationRequiredError
+   *          '500':
+   *            description: invalid input syntax for type uuid, Error in experiment schedular (user is not authorized), Insert Error in database
    */
   @Put('/:id')
   public update(
@@ -555,6 +903,8 @@ export class ExperimentController {
   *       responses:
   *          '200':
   *            description: Experiment is imported
+  *          '401':
+  *            description: AuthorizationRequiredError
   */
   @Post('/import')
   public importExperiment(

--- a/backend/packages/Upgrade/test/unit/controllers/AnalyticsController.test.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/AnalyticsController.test.ts
@@ -1,0 +1,73 @@
+import app from '../../utils/expressApp';
+import request from 'supertest';
+import { configureLogger } from '../../utils/logger';
+import { useContainer as routingUseContainer } from 'routing-controllers';
+import { Container } from 'typedi';
+import uuid from 'uuid/v4';
+import AuditServiceMock from './mocks/AuditServiceMock';
+import { AnalyticsService } from '../../../src/api/services/AnalyticsService';
+
+import { useContainer as classValidatorUseContainer } from 'class-validator';
+
+describe('Analytics Controller Testing', () => {
+  beforeAll(() => {
+    configureLogger();
+    routingUseContainer(Container);
+    //ormUseContainer(Container);
+    classValidatorUseContainer(Container);
+
+    // set mock container
+    Container.set(AnalyticsService, new AuditServiceMock());
+  });
+
+  afterAll(() => {
+    Container.reset();
+  });
+
+  test('Post request for /api/stats/enrollment', async done => {
+    await request(app)
+      .post('/api/stats/enrollment')
+      .send({experimentIds: [uuid()]})
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
+    done();
+  });
+
+  test('Post request for /api/stats/enrollment/detail', async done => {
+    await request(app)
+      .post('/api/stats/enrollment/detail')
+      .send({experimentId: uuid()})
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
+    done();
+  });
+
+  test('Post request for /api/stats/enrollment/date', async done => {
+    await request(app)
+      .post('/api/stats/enrollment/date')
+      .send({
+          experimentId: uuid(),
+          dateEnum: "xyz",
+          clientOffset: 330
+        })
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
+    done();
+  });
+
+  test('Post request for /api/stats/csv', async done => {
+    await request(app)
+      .post('/api/stats/csv')
+      .send({
+          experimentId: uuid(),
+          email: "xyz@gmail.com",
+        })
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
+    done();
+  });
+});

--- a/backend/packages/Upgrade/test/unit/controllers/ExcludeController.test.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/ExcludeController.test.ts
@@ -1,0 +1,82 @@
+import app from '../../utils/expressApp';
+import request from 'supertest';
+import { configureLogger } from '../../utils/logger';
+import { useContainer as routingUseContainer } from 'routing-controllers';
+import { Container } from 'typedi';
+import uuid from 'uuid/v4';
+import ExcludeServiceMock from './mocks/ExcludeServiceMock';
+import { ExcludeService } from '../../../src/api/services/ExcludeService';
+
+import { useContainer as classValidatorUseContainer } from 'class-validator';
+import { useContainer as ormUseContainer } from 'typeorm';
+
+describe('Exclude Controller Testing', () => {
+  beforeAll(() => {
+    configureLogger();
+    routingUseContainer(Container);
+    ormUseContainer(Container);
+    classValidatorUseContainer(Container);
+  
+    // set mock container
+    Container.set(ExcludeService, new ExcludeServiceMock());
+  });
+  
+  afterAll(() => {
+    Container.reset();
+  });
+  
+  test('Get request for /api/exclude/user', async done => {
+    await request(app)
+      .get('/api/exclude/user')
+      .expect('Content-Type', /json/)
+      .expect(200);
+    done();
+  });
+
+  test('Put request for /api/exclude/user', async done => {
+    await request(app)
+      .put('/api/exclude/user')
+      .send({id: uuid()})
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
+    done();
+  });
+
+  test('Delete request for /api/exclude/user/:id', async done => {
+    await request(app)
+      .delete(`/api/exclude/user/${uuid()}`)
+      .expect('Content-Type', /json/)
+      .expect(200);
+    done();
+  });
+
+  test('Get request for /api/exclude/group', async done => {
+    await request(app)
+      .get('/api/exclude/group')
+      .expect('Content-Type', /json/)
+      .expect(200);
+    done();
+  });
+
+  test('Put request for /api/exclude/group', async done => {
+    await request(app)
+      .put('/api/exclude/group')
+      .send({
+        id: uuid(),
+        type: "abs"
+      })
+      .expect('Content-Type', /json/)
+      .expect(200);
+    done();
+  });
+
+  const type = "abc";
+  test('Delete request for /api/group/:type/:id', async done => {
+    await request(app)
+      .delete(`/api/exclude/group/${type}/${uuid()}`)
+      .expect('Content-Type', /json/)
+      .expect(200);
+    done();
+  });
+});

--- a/backend/packages/Upgrade/test/unit/controllers/ExperimentClientController.test.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/ExperimentClientController.test.ts
@@ -1,0 +1,236 @@
+import app from '../../utils/expressApp';
+import request from 'supertest';
+import { configureLogger } from '../../utils/logger';
+import { useContainer as routingUseContainer } from 'routing-controllers';
+import { Container } from 'typedi';
+import { ExperimentService } from '../../../src/api/services/ExperimentService';
+import { ExperimentAssignmentService } from '../../../src/api/services/ExperimentAssignmentService';
+import { ExperimentUserService } from '../../../src/api/services/ExperimentUserService';
+import { FeatureFlagService } from '../../../src/api/services/FeatureFlagService';
+import { MetricService } from '../../../src/api/services/MetricService';
+import { ClientLibMiddleware } from '../../../src/api/middlewares/ClientLibMiddleware';
+import ExperimentServieMock from './mocks/ExperimentServiceMock';
+import ExperimentAssignmentServieMock from './mocks/ExperimentAssignmentServiceMock';
+import ExperimentUserServiceMock from './mocks/ExperimentUserServiceMock';
+import FeatureFlagServiceMock from './mocks/FeatureFlagServiceMock';
+import MetricServiceMock from './mocks/MetricServiceMock';
+import ClientLibMiddlewareMock from './mocks/ClientLibMiddlewareMock'
+
+import { useContainer as classValidatorUseContainer } from 'class-validator';
+import { useContainer as ormUseContainer } from 'typeorm';
+import uuid from 'uuid';
+
+describe('Experiment Client Controller Testing', () => {
+  beforeAll(() => {
+    configureLogger();
+    routingUseContainer(Container);
+    ormUseContainer(Container);
+    classValidatorUseContainer(Container);
+
+    Container.set(ExperimentService, new ExperimentServieMock());
+    Container.set(ExperimentAssignmentService, new ExperimentAssignmentServieMock());
+    Container.set(ExperimentUserService, new ExperimentUserServiceMock());
+    Container.set(FeatureFlagService, new FeatureFlagServiceMock());
+    Container.set(MetricService, new MetricServiceMock());
+    Container.set(ClientLibMiddleware, new ClientLibMiddlewareMock());
+
+  });
+  
+  afterAll(() => {
+    Container.reset();
+  });
+
+  const logData = {
+    "userId": "u22",
+    "value": [
+      {
+        "userId": "u22",
+        "timestamp": "1970-01-01T00:00:00Z",
+        "metrics": {
+          "groupedMetrics": [
+            {
+              "groupClass": "masteryWorkspace",
+              "groupKey": "calculating_area_of_square",
+              "groupUniquifier": "1990-10-10T00:00:00Z",
+              "attributes": {
+                  "hintCount": 31
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+
+  const blobLogData = {
+    "userId": "u23",
+    "value": [
+      {
+        "userId": "u23",
+        "timestamp": "1970-01-01T00:00:00Z",
+        "metrics": {
+          "groupedMetrics": [
+            {
+              "groupClass": "masteryWorkspace",
+              "groupKey": "calculating_area_of_square",
+              "groupUniquifier": "1990-10-10T00:00:00Z",
+              "attributes": {
+                "hintCount": 31
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+
+  test('Post request for /api/init', async done => {
+    // creating express app here
+    await request(app)
+      .post('/api/init')
+      .send({
+          id: "123",
+      })
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
+    done();
+  });
+
+  test('Post request for /api/groupmembership', async done => {
+    await request(app)
+      .post('/api/groupmembership')
+      .send({
+        id: "u21",
+        group: {
+            class: [
+                "C1",
+                "C2"
+            ]
+        }
+      })
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
+    done();
+  });
+
+  test('Post request for /api/workinggroup', async done => {
+    await request(app)
+      .post('/api/workinggroup')
+      .send({
+        id: "u21",
+        workingGroup: {
+            school: "testschool",
+            class: "testclass",
+            instructor: "testteacher"
+        }
+      })
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
+    done();
+  });
+
+  test('Post request for /api/mark', async done => {
+    await request(app)
+      .post('/api/mark')
+      .send({
+          userId: "u21",
+          experimentPoint: "p",
+          condition: "condition",
+          partitionId: "q",
+      })
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
+    done();
+  });
+
+  test('Post request for /api/assign', async done => {
+    await request(app)
+      .post('/api/assign')
+      .send({
+          userId: "u21",
+          context: "abc"
+      })
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
+    done();
+  });
+
+  test('Post request for /api/log', async done => {
+    await request(app)
+      .post('/api/log')
+      .send({
+          userId: "u21",
+          logData
+      })
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
+    done();
+  });
+
+  // test('Post request for /api/bloblog', async done => {
+  //   await request(app)
+  //     .post('/api/bloblog')
+  //     .send({blobLogData})
+  //     .set('Accept', 'application/json')
+  //     .expect('Content-Type', /json/)
+  //     .expect(200);
+  //     // remaining
+  //   done();
+  // });
+
+  test('Post request for /api/failed', async done => {
+    await request(app)
+      .post('/api/failed')
+      .send({
+          reason: "xyz",
+          experimentPoint: "p",
+          userId: "u123",
+          experimentId: uuid()
+      })
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
+    done();
+  });
+
+  test('Get request for /api/featureflag', async done => {
+    await request(app)
+      .get('/api/featureflag')
+      .expect('Content-Type', /json/)
+      .expect(200);
+    done();
+  });
+
+  test('Post request for /api/metric', async done => {
+    await request(app)
+      .post('/api/metric')
+      .send({
+          userId: "u21",
+          alia: ["abc"]
+      })
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
+      // ok done but post request better
+    done();
+  });
+
+  test('Post request for /api/useraliases', async done => {
+    await request(app)
+      .post('/api/useraliases')
+      .send({
+        userId: "u21",
+        aliases: ["abc"]
+      })
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
+    done();
+  });
+});

--- a/backend/packages/Upgrade/test/unit/controllers/ExperimentClientController.test.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/ExperimentClientController.test.ts
@@ -85,7 +85,6 @@ describe('Experiment Client Controller Testing', () => {
   }
 
   test('Post request for /api/init', async done => {
-    // creating express app here
     await request(app)
       .post('/api/init')
       .send({
@@ -180,7 +179,6 @@ describe('Experiment Client Controller Testing', () => {
   //     .set('Accept', 'application/json')
   //     .expect('Content-Type', /json/)
   //     .expect(200);
-  //     // remaining
   //   done();
   // });
 
@@ -211,13 +209,11 @@ describe('Experiment Client Controller Testing', () => {
     await request(app)
       .post('/api/metric')
       .send({
-          userId: "u21",
-          alia: ["abc"]
+          metricUnit: {},
       })
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
       .expect(200);
-      // ok done but post request better
     done();
   });
 

--- a/backend/packages/Upgrade/test/unit/controllers/ExperimentController.test.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/ExperimentController.test.ts
@@ -3,31 +3,192 @@ import request from 'supertest';
 import { configureLogger } from '../../utils/logger';
 import { useContainer as routingUseContainer } from 'routing-controllers';
 import { Container } from 'typedi';
-import MockExperimentController from './mocks/MockService';
+import uuid from 'uuid/v4';
+import ExperimentServieMock from './mocks/ExperimentServiceMock';
 import { ExperimentService } from '../../../src/api/services/ExperimentService';
-import { ExperimentAssignmentService } from '../../../src/api/services/ExperimentAssignmentService';
+
+import { useContainer as classValidatorUseContainer } from 'class-validator';
+import { useContainer as ormUseContainer } from 'typeorm';
 
 describe('Experiment Controller Testing', () => {
   beforeAll(() => {
     configureLogger();
     routingUseContainer(Container);
+    ormUseContainer(Container);
+    classValidatorUseContainer(Container);
 
     // set mock container
-    Container.set(ExperimentService, new MockExperimentController());
-    Container.set(ExperimentAssignmentService, new MockExperimentController());
+    Container.set(ExperimentService, new ExperimentServieMock());
   });
 
   afterAll(() => {
     Container.reset();
   });
 
+  const experimentData = {
+    id: "string",
+    name: "string",
+    description: "string",
+    state: "inactive",
+    startOn: "2021-08-11T05:41:51.655Z",
+    consistencyRule: "individual",
+    assignmentUnit: "individual",
+    postExperimentRule: "continue",
+    enrollmentCompleteCondition: {
+      userCount: 0,
+      groupCount: 0
+    },
+    endOn: "2021-08-11T05:41:51.655Z",
+    revertTo: "string",
+    tags: [
+      "string"
+    ],
+    group: "string",
+    conditions: [
+      {
+        name: "string",
+        assignmentWeight: 0,
+        description: "string"
+      }
+    ],
+    partitions: [
+      {
+        point: "string",
+        name: "string",
+        description: "string"
+      }
+    ],
+    metrics: [
+      {}
+    ]
+  }
+
   test('Get request for /api/experiments', async done => {
-    // creating express app here
     await request(app)
       .get('/api/experiments')
       .expect('Content-Type', /json/)
       .expect(200);
+    done();
+  });
 
+  test('Post request for /api/experiments', async done => {
+    await request(app)
+      .post('/api/experiments')
+      .send(experimentData)
+      .expect('Content-Type', /json/)
+      .expect(200);
+    done();
+  });
+
+  test('Get request for /api/experiments/names', async done => {
+    await request(app)
+      .get('/api/experiments/names')
+      .expect('Content-Type', /json/)
+      .expect(200);
+    done();
+  });
+
+  test('Get request for /api/experiments/contextMetaData', async done => {
+    await request(app)
+      .get('/api/experiments/contextMetaData')
+      .expect('Content-Type', /json/)
+      .expect(200);
+    done();
+  });
+
+  test('Post request for /api/experiments/paginated', async done => {
+    await request(app)
+      .post('/api/experiments/paginated')
+      .send({
+        skip: 0,
+        take: 20,
+        sortParams: {key: "name", sortAs: "ASC"}
+      })
+      .set('Accept', 'application/json')
+      .expect(200);
+    done();
+  });
+
+  test('Get request for /api/experiments/partitions', async done => {
+    await request(app)
+      .get('/api/experiments/partitions')
+      .expect('Content-Type', /json/)
+      .expect(200);
+    done();
+  });
+
+  test('Get request for /api/experiments/single/:id', async done => {
+    await request(app)
+      .get(`/api/experiments/single/${uuid()}`)
+      .expect('Content-Type', /json/)
+      .expect(200)
+    done();
+  });
+
+  const expIdNotTypeUUID = 'abc';
+  test('Get request for /api/experiments/single/:id', async done => {
+    await request(app)
+      .get(`/api/experiments/single/${expIdNotTypeUUID}`)
+      .expect(500)
+    done();
+  });
+
+  test('Get request for /api/experiments/conditions/:id', async done => {
+    await request(app)
+      .get(`/api/experiments/conditions/${uuid()}`)
+      .expect('Content-Type', /json/)
+      .expect(200);
+    done();
+  });
+
+  test('Get request for /api/experiments/conditions/:id', async done => {
+    await request(app)
+    .get(`/api/experiments/single/${expIdNotTypeUUID}`)
+      .expect(500);
+    done();
+  });
+
+  test('Post request for /api/experiments/batch', async done => {
+    await request(app)
+      .post('/api/experiments/batch')
+      .send(experimentData)
+      .expect('Content-Type', /json/)
+      .expect(200);
+      done();
+  });
+
+  test('Delete request for /api/experiments/:id', async done => {
+    await request(app)
+      .delete(`/api/experiments/${uuid()}`)
+      .expect('Content-Type', /json/)
+      .expect(200);
+    done();
+  });
+
+  test('Put request for /api/experiments/:id', async done => {
+    await request(app)
+      .put(`/api/experiments/${uuid()}`)
+      .expect(200);
+    done();
+  });
+
+  test('Post request for /api/experiments/state', async done => {
+    await request(app)
+      .post('/api/experiments/state')
+      .send({id: uuid(), state: "enrollmentComplete"})
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
+    done();
+  });
+
+  test('Post request for /api/experiments/import', async done => {
+    await request(app)
+      .post('/api/experiments/import')
+      .send(experimentData)
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
     done();
   });
 });

--- a/backend/packages/Upgrade/test/unit/controllers/ExperimentController.test.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/ExperimentController.test.ts
@@ -172,6 +172,13 @@ describe('Experiment Controller Testing', () => {
     done();
   });
 
+  test('Put request for /api/experiments/:id', async done => {
+    await request(app)
+      .put(`/api/experiments/${expIdNotTypeUUID}`)
+      .expect(500);
+    done();
+  });
+
   test('Post request for /api/experiments/state', async done => {
     await request(app)
       .post('/api/experiments/state')

--- a/backend/packages/Upgrade/test/unit/controllers/ScheduledJobsController.test.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/ScheduledJobsController.test.ts
@@ -6,6 +6,8 @@ import request from 'supertest';
 import uuid from 'uuid/v4';
 import { ScheduledJobService } from '../../../src/api/services/ScheduledJobService';
 import ScheduledJobServiceMock from './mocks/ScheduledJobServiceMock';
+import { ScheduleJobMiddleware } from '../../../src/api/middlewares/ScheduleJobMiddleware';
+import ScheduleJobMiddlewareMock from './mocks/ScheduleJobMiddlewareMock'
 
 describe('Scheduled Job Controller Testing', () => {
   beforeAll(() => {
@@ -14,6 +16,7 @@ describe('Scheduled Job Controller Testing', () => {
 
     // set mock container
     Container.set(ScheduledJobService, new ScheduledJobServiceMock());
+    Container.set(ScheduleJobMiddleware, new ScheduleJobMiddlewareMock());
   });
 
   afterAll(() => {
@@ -33,7 +36,6 @@ describe('Scheduled Job Controller Testing', () => {
   });
 
   test('Post request for /api/scheduledJobs/end', async done => {
-    // creating express app here
     await request(app)
       .post('/api/scheduledJobs/end')
       .send({ id: uuid() })

--- a/backend/packages/Upgrade/test/unit/controllers/mocks/AuditServiceMock.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/mocks/AuditServiceMock.ts
@@ -1,0 +1,21 @@
+import { Service } from 'typedi';
+import { DATE_RANGE } from 'upgrade_types';
+
+@Service()
+export default class AuditServiceMock {
+  public getEnrollments(experimentIds: string[]): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public getDetailEnrollment(experimentId: string): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public getEnrollmentStatsByDate(experimentId: string, dateEnum: DATE_RANGE, clientOffset: number): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public getCSVData(experimentId: string, email: string): Promise<[]> {
+    return Promise.resolve([]);
+  }
+}

--- a/backend/packages/Upgrade/test/unit/controllers/mocks/ClientLibMiddlewareMock.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/mocks/ClientLibMiddlewareMock.ts
@@ -1,0 +1,7 @@
+import * as express from 'express';
+
+export default class MockClientLibMiddleware {
+  public async use(req: express.Request, res: express.Response, next: express.NextFunction): Promise<any> {
+    next();
+  }
+}

--- a/backend/packages/Upgrade/test/unit/controllers/mocks/ExcludeServiceMock.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/mocks/ExcludeServiceMock.ts
@@ -1,0 +1,27 @@
+import { Service } from 'typedi';
+
+@Service()
+export default class ExcludeServiceMock {
+
+  public getAllUser(): Promise<[]> {
+    return Promise.resolve([]);
+  }
+  public excludeUser(id: string): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public deleteUser(id: string): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public getAllGroups(): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public excludeGroup(id: string, type: string): Promise<[]> {
+    return Promise.resolve([]);
+  }
+  public deleteGroup(id: string, type: string): Promise<[]> {
+    return Promise.resolve([]);
+  }
+}

--- a/backend/packages/Upgrade/test/unit/controllers/mocks/ExperimentAssignmentServiceMock.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/mocks/ExperimentAssignmentServiceMock.ts
@@ -1,0 +1,25 @@
+import { Service } from 'typedi';
+import { ILogInput } from 'upgrade_types';
+
+@Service()
+export default class ExperimentAssignmentServieMock {
+  public markExperimentPoint(id: string, experimentPoint: string, condition: string, partitionId: string): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public getAllExperimentConditions(userId: string, experimentContext: string): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public dataLog(userId: string, value: ILogInput[]): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public blobDataLog(userId: string, blobData: any): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public clientFailedExperimentPoint(reasone: string,  experimentPoint: string, userId: string, experimentId: string): Promise<[]> {
+    return Promise.resolve([]);
+  }
+}

--- a/backend/packages/Upgrade/test/unit/controllers/mocks/ExperimentServiceMock.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/mocks/ExperimentServiceMock.ts
@@ -1,0 +1,62 @@
+import { Experiment } from 'packages/Upgrade/src/api/models/Experiment';
+import { User } from 'packages/Upgrade/src/api/models/User';
+import { Service } from 'typedi';
+
+@Service()
+export default class ExperimentServieMock {
+  public find(): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public findAllName(): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public getContextMetaData(): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public findPaginated(skip: number, take: number, sortParams?: any, searchParams?: any): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public getTotalCount(): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public getAllExperimentPartitions(): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public findOne(id: string): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public getExperimentalConditions(id: string): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public create(experiment: Experiment, currentUser: User): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public createMultipleExperiments(experiment: Experiment[]): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public delete(id: string, currentUser: User): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public update(id: string, experiment: Experiment, currentUser: User): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public updateState(id: string, state: string, currentUser: User, date?: any): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public importExperiment(experiment: Experiment, currentUser: User): Promise<[]> {
+    return Promise.resolve([]);
+  }
+}

--- a/backend/packages/Upgrade/test/unit/controllers/mocks/ExperimentUserServiceMock.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/mocks/ExperimentUserServiceMock.ts
@@ -1,0 +1,20 @@
+import { Service } from 'typedi';
+
+@Service()
+export default class ExperimentUserServiceMock {
+  public create(array: Array<any>): Promise<any> {
+    return Promise.resolve(array);
+  }
+
+  public updateGroupMembership(id: string, group: object): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public updateWorkingGroup(id: string, workingGroup: any): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public setAliasesForUser(userId: string, aliases: string[]): Promise<[]> {
+    return Promise.resolve([]);
+  }
+}

--- a/backend/packages/Upgrade/test/unit/controllers/mocks/FeatureFlagServiceMock.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/mocks/FeatureFlagServiceMock.ts
@@ -1,7 +1,7 @@
 import { Service } from 'typedi';
 
 @Service()
-export default class MockService {
+export default class FeatureFlagServiceMock {
   public find(): Promise<[]> {
     return Promise.resolve([]);
   }

--- a/backend/packages/Upgrade/test/unit/controllers/mocks/MetricServiceMock.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/mocks/MetricServiceMock.ts
@@ -1,0 +1,9 @@
+import { ISingleMetric, IGroupMetric } from 'upgrade_types';
+import { Service } from 'typedi';
+
+@Service()
+export default class MetricServiceMock {
+  public saveAllMetrics(metricUnit: Array<ISingleMetric | IGroupMetric>): Promise<[]> {
+    return Promise.resolve([]);
+  }
+}

--- a/backend/packages/Upgrade/test/unit/controllers/mocks/ScheduleJobMiddlewareMock.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/mocks/ScheduleJobMiddlewareMock.ts
@@ -1,0 +1,7 @@
+import * as express from 'express';
+
+export default class ScheduleJobMiddlewareMock {
+  public async use(req: express.Request, res: express.Response, next: express.NextFunction): Promise<any> {
+    next();
+  }
+}


### PR DESCRIPTION
In this PR,  I have added sample responses for Experiment and Experiment-client APIs. These includes responses such as 200, 404, 500.