### PR TITLE
Fix/issue 115 editing and deleting conditions instantly syncs post experiment rule page when saved

### DIFF
--- a/frontend/projects/abtesting/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
+++ b/frontend/projects/abtesting/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
@@ -185,6 +185,11 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
 
   removeConditionOrPartition(type: string, groupIndex: number) {
     this[type].removeAt(groupIndex);
+    const deletedConditionCode = this.experimentInfo.conditions.find(condition => condition.order === groupIndex+1).id;
+    delete this.experimentInfo.conditions[groupIndex]
+    if (this.experimentInfo.revertTo == deletedConditionCode) {
+      this.experimentInfo.revertTo = null;
+    }
     this.updateView();
   }
 

--- a/frontend/projects/abtesting/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
+++ b/frontend/projects/abtesting/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
@@ -60,7 +60,7 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
   contextMetaData: IContextMetaData | {} = {};
   contextMetaDataSub: Subscription;
   expPointAndIdErrors: string[] = [];
-
+  
   constructor(
     private _formBuilder: FormBuilder,
     private experimentService: ExperimentService,

--- a/frontend/projects/abtesting/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
+++ b/frontend/projects/abtesting/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
@@ -185,10 +185,14 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
 
   removeConditionOrPartition(type: string, groupIndex: number) {
     this[type].removeAt(groupIndex);
-    const deletedConditionCode = this.experimentInfo.conditions.find(condition => condition.order === groupIndex+1).id;
-    delete this.experimentInfo.conditions[groupIndex]
-    if (this.experimentInfo.revertTo == deletedConditionCode) {
-      this.experimentInfo.revertTo = null;
+    if (type === 'condition' && this.experimentInfo) {
+      const deletedCondition = this.experimentInfo.conditions.find(condition => condition.order === groupIndex + 1);
+      if (deletedCondition) {
+        delete this.experimentInfo.conditions[groupIndex];
+        if (this.experimentInfo.revertTo === deletedCondition.id) {
+          this.experimentInfo.revertTo = null;
+        }
+      }
     }
     this.updateView();
   }

--- a/frontend/projects/abtesting/src/app/features/dashboard/home/components/experiment-post-condition/experiment-post-condition.component.ts
+++ b/frontend/projects/abtesting/src/app/features/dashboard/home/components/experiment-post-condition/experiment-post-condition.component.ts
@@ -17,7 +17,6 @@ export class ExperimentPostConditionComponent implements OnInit, OnChanges {
   @Input() experimentInfo: ExperimentVM;
   @Input() newExperimentData: Partial<ExperimentVM>;
   @Output() emitExperimentDialogEvent = new EventEmitter<NewExperimentDialogData>();
-  @Input() experiment: ExperimentVM;
   postExperimentRuleForm: FormGroup;
   postExperimentRules = [
     { value: POST_EXPERIMENT_RULE.CONTINUE },
@@ -26,34 +25,34 @@ export class ExperimentPostConditionComponent implements OnInit, OnChanges {
   experimentConditions = [
     { value: 'default', id: 'default' }
   ];
-  newExperimentStatSub: Subscription;
+  experimentSub: Subscription;
 
   constructor(private experimentService: ExperimentService,
     @Inject(MAT_DIALOG_DATA) public data: any,
     private _formBuilder: FormBuilder) { }
 
   ngOnChanges() {
-      this.experimentConditions = [
-        { value: 'default', id: 'default' }
-      ];
-      if (this.experimentInfo) {
-        this.newExperimentStatSub = this.experimentService.selectExperimentById(this.experimentInfo.id).subscribe(stat => {
-          this.newExperimentData = stat;
-          this.experimentInfo = stat;
-        });
-      } else if (this.data) {
-        this.experimentInfo = this.data.experiment;
-        this.newExperimentData = this.data.experiment;
-      }
+    this.experimentConditions = [
+      { value: 'default', id: 'default' }
+    ];
+    if (this.experimentInfo) {
+      this.experimentSub = this.experimentService.selectExperimentById(this.experimentInfo.id).subscribe(experimentData => {
+        this.newExperimentData = experimentData;
+        this.experimentInfo = experimentData;
+      });
+    } else if (this.data) {
+      this.experimentInfo = this.data.experiment;
+      this.newExperimentData = this.data.experiment;
+    }
 
-      if (this.newExperimentData.conditions && this.newExperimentData.conditions.length) {
-        this.newExperimentData.conditions.map(value => {
-          const isConditionExist = this.experimentConditions.find((condition) => condition.id === value.id);
-          this.experimentConditions = isConditionExist
-            ? this.experimentConditions
-            : [ ...this.experimentConditions, { value: value.conditionCode, id: value.id }];
-        });
-      }
+    if (this.newExperimentData.conditions && this.newExperimentData.conditions.length) {
+      this.newExperimentData.conditions.map(value => {
+        const isConditionExist = this.experimentConditions.find((condition) => condition.id === value.id);
+        this.experimentConditions = isConditionExist
+          ? this.experimentConditions
+          : [ ...this.experimentConditions, { value: value.conditionCode, id: value.id }];
+      });
+    }
   }
 
   ngOnInit() {

--- a/frontend/projects/abtesting/src/app/features/dashboard/home/components/experiment-post-condition/experiment-post-condition.component.ts
+++ b/frontend/projects/abtesting/src/app/features/dashboard/home/components/experiment-post-condition/experiment-post-condition.component.ts
@@ -1,9 +1,11 @@
-import { Component, OnInit, ChangeDetectionStrategy, Input, Output, EventEmitter, OnChanges } from '@angular/core';
+import { Component, Inject, OnInit, ChangeDetectionStrategy, Input, Output, EventEmitter, OnChanges } from '@angular/core';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { ExperimentVM, POST_EXPERIMENT_RULE, NewExperimentDialogData, NewExperimentDialogEvents, NewExperimentPaths } from '../../../../../core/experiments/store/experiments.model';
 import { ExperimentFormValidators } from '../../validators/experiment-form.validators';
 import { ExperimentService } from '../../../../../core/experiments/experiments.service';
 import { Subscription } from 'rxjs';
+import { MAT_DIALOG_DATA } from '@angular/material';
+
 @Component({
   selector: 'home-experiment-post-condition',
   templateUrl: './experiment-post-condition.component.html',
@@ -27,28 +29,31 @@ export class ExperimentPostConditionComponent implements OnInit, OnChanges {
   newExperimentStatSub: Subscription;
 
   constructor(private experimentService: ExperimentService,
+    @Inject(MAT_DIALOG_DATA) public data: any,
     private _formBuilder: FormBuilder) { }
 
   ngOnChanges() {
-    this.experimentConditions = [
-      { value: 'default', id: 'default' }
-    ];
+      this.experimentConditions = [
+        { value: 'default', id: 'default' }
+      ];
+      if (this.experimentInfo) {
+        this.newExperimentStatSub = this.experimentService.selectExperimentById(this.experimentInfo.id).subscribe(stat => {
+          this.newExperimentData = stat;
+          this.experimentInfo = stat;
+        });
+      } else if (this.data) {
+        this.experimentInfo = this.data.experiment;
+        this.newExperimentData = this.data.experiment;
+      }
 
-    if (this.experimentInfo) {
-      this.newExperimentStatSub = this.experimentService.selectExperimentById(this.experimentInfo.id).subscribe(stat => {
-        this.newExperimentData = stat;
-        this.experimentInfo = stat;
-      });
-    }
-    
-    if (this.newExperimentData.conditions && this.newExperimentData.conditions.length) {
-      this.newExperimentData.conditions.map(value => {
-        const isConditionExist = this.experimentConditions.find((condition) => condition.id === value.id);
-        this.experimentConditions = isConditionExist
-          ? this.experimentConditions
-          : [ ...this.experimentConditions, { value: value.conditionCode, id: value.id }];
-      });
-    }
+      if (this.newExperimentData.conditions && this.newExperimentData.conditions.length) {
+        this.newExperimentData.conditions.map(value => {
+          const isConditionExist = this.experimentConditions.find((condition) => condition.id === value.id);
+          this.experimentConditions = isConditionExist
+            ? this.experimentConditions
+            : [ ...this.experimentConditions, { value: value.conditionCode, id: value.id }];
+        });
+      }
   }
 
   ngOnInit() {

--- a/frontend/projects/abtesting/src/app/features/dashboard/home/components/modal/new-experiment/new-experiment.component.ts
+++ b/frontend/projects/abtesting/src/app/features/dashboard/home/components/modal/new-experiment/new-experiment.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject, ViewChild, OnInit } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
+import { MatDialogRef, MatSnackBar, MAT_DIALOG_DATA } from '@angular/material';
 import {
   NewExperimentDialogEvents,
   NewExperimentDialogData,
@@ -22,7 +22,8 @@ export class NewExperimentComponent implements OnInit {
   constructor(
     private dialogRef: MatDialogRef<NewExperimentComponent>,
     private experimentService: ExperimentService,
-    @Inject(MAT_DIALOG_DATA) public data: any
+    @Inject(MAT_DIALOG_DATA) public data: any,
+    private _snackBar: MatSnackBar
   ) {
     if (this.data) {
       this.experimentInfo = this.data.experiment;
@@ -57,18 +58,22 @@ export class NewExperimentComponent implements OnInit {
         }
         break;
       case NewExperimentDialogEvents.UPDATE_EXPERIMENT:
+        this.onNoClick();
       case NewExperimentDialogEvents.SAVE_DATA:
         this.newExperimentData = {
           ...this.experimentInfo,
           ...this.newExperimentData,
           ...formData
         };
+        this.openSnackBar();
         this.experimentService.updateExperiment(this.newExperimentData);
-        this.onNoClick();
         break;
     }
   }
 
+  openSnackBar() {
+    this._snackBar.open(`Experiment changes are updated successfully!`, null, { duration: 2000 })
+  }
   stepChanged(event) {
     this.selectedStepperIndex = event.selectedIndex;
   }

--- a/frontend/projects/abtesting/src/app/features/dashboard/home/components/modal/new-experiment/new-experiment.component.ts
+++ b/frontend/projects/abtesting/src/app/features/dashboard/home/components/modal/new-experiment/new-experiment.component.ts
@@ -7,6 +7,7 @@ import {
   ExperimentVM
 } from '../../../../../../core/experiments/store/experiments.model';
 import { ExperimentService } from '../../../../../../core/experiments/experiments.service';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'home-new-experiment',
@@ -23,7 +24,8 @@ export class NewExperimentComponent implements OnInit {
     private dialogRef: MatDialogRef<NewExperimentComponent>,
     private experimentService: ExperimentService,
     @Inject(MAT_DIALOG_DATA) public data: any,
-    private _snackBar: MatSnackBar
+    private _snackBar: MatSnackBar,
+    private translate: TranslateService
   ) {
     if (this.data) {
       this.experimentInfo = this.data.experiment;
@@ -72,7 +74,7 @@ export class NewExperimentComponent implements OnInit {
   }
 
   openSnackBar() {
-    this._snackBar.open(`Experiment changes are updated successfully!`, null, { duration: 2000 })
+    this._snackBar.open(this.translate.instant('global.save-confirmation.message.text') , null, { duration: 2000 });
   }
   stepChanged(event) {
     this.selectedStepperIndex = event.selectedIndex;

--- a/frontend/projects/abtesting/src/assets/i18n/en.json
+++ b/frontend/projects/abtesting/src/assets/i18n/en.json
@@ -14,6 +14,7 @@
   "global.save.text": "SAVE",
   "global.delete.text": "DELETE",
   "global.delete-confirmation.message.text": "Type 'delete' to confirm deletion:",
+  "global.save-confirmation.message.text": "Experiment changes are updated successfully!",
   "global.delete-input-comparison.text": "delete",
   "global.delete.input-placeholder.text": "Type delete",
   "global.update.text": "UPDATE",


### PR DESCRIPTION
In this PR below things are done:

1. On editing a condition and saving it will not close the dialog box and let user to navigate to post experiment rule and select newly edited condition too.
2. On deleting a condition (while editing an experiment) which was assigned in post experiment rule will now default the selection to 'default' condition.
3. We have also kept a snackbar alert popup on save button on all modal pages while editing the experiment. This will let users know about changes being saved and not close the modal dialog box