### PR TITLE
Issue-129 - Query data not displayed on UI

### DIFF
--- a/frontend/projects/abtesting/src/app/core/analysis/store/analysis.selectors.ts
+++ b/frontend/projects/abtesting/src/app/core/analysis/store/analysis.selectors.ts
@@ -37,7 +37,7 @@ export const selectQueryResultById = createSelector(
   (state: AnalysisState, { queryId }) => {
     if (state.queryResult) {
       const queryResult = state.queryResult.filter(res => res.id === queryId);
-      return queryResult[0].result || [];
+      return queryResult.length && queryResult[0].result || [];
     }
     return [];
   }


### PR DESCRIPTION
Here the issue was in the selector which is selecting the query result based on the queryId passed to it. If the network request is not resolved and component is trying to get the data for it, it was throwing error as it is trying to read the result of matched query by queryId for the query result which is not available yet.