### PR TITLE
fix/issue 118- fixed infinite loader in condition table

### DIFF
--- a/frontend/projects/abtesting/src/app/core/experiments/store/experiments.reducer.ts
+++ b/frontend/projects/abtesting/src/app/core/experiments/store/experiments.reducer.ts
@@ -166,8 +166,8 @@ const reducer = createReducer(
   on(
     experimentsAction.actionFetchExperimentDetailStatSuccess,
     (state, { stat }) => {
-      state.stats[stat.id] = stat;
-      return state;
+      const updatedStat = state.stats[stat.id] = stat;
+      return { ...state, updatedStat };
     }
   )
 );

--- a/frontend/projects/abtesting/src/app/core/experiments/store/experiments.reducer.ts
+++ b/frontend/projects/abtesting/src/app/core/experiments/store/experiments.reducer.ts
@@ -166,7 +166,8 @@ const reducer = createReducer(
   on(
     experimentsAction.actionFetchExperimentDetailStatSuccess,
     (state, { stat }) => {
-      const updatedStat = state.stats[stat.id] = stat;
+      state.stats[stat.id] = stat;
+      const updatedStat = state.stats[stat.id];
       return { ...state, updatedStat };
     }
   )

--- a/frontend/projects/abtesting/src/app/features/dashboard/home/components/enrollment-condition-table/enrollment-condition-table.component.ts
+++ b/frontend/projects/abtesting/src/app/features/dashboard/home/components/enrollment-condition-table/enrollment-condition-table.component.ts
@@ -20,7 +20,7 @@ export class EnrollmentConditionTableComponent implements OnChanges, OnInit {
   ];
   displayedColumns: string[] = [];
   isStatLoading = true;
-  experimentConditionSub: Subscription;
+  experimentStateSub: Subscription;
 
   constructor(private experimentService: ExperimentService) {}
 
@@ -33,7 +33,7 @@ export class EnrollmentConditionTableComponent implements OnChanges, OnInit {
   }
 
   ngOnInit() {
-    this.experimentConditionSub = this.experimentService.experimentStatById$(this.experiment.id).subscribe(stat => {
+    this.experimentStateSub = this.experimentService.experimentStatById$(this.experiment.id).subscribe(stat => {
       this.experimentData = [];
       if (stat && stat.conditions) {
         this.isStatLoading = false;
@@ -84,7 +84,7 @@ export class EnrollmentConditionTableComponent implements OnChanges, OnInit {
   }
 
   ngOnDestroy() {
-    this.experimentConditionSub.unsubscribe();
+    this.experimentStateSub.unsubscribe();
   }
 
   get AssignmentUnit() {

--- a/frontend/projects/abtesting/src/app/features/dashboard/home/components/enrollment-condition-table/enrollment-condition-table.component.ts
+++ b/frontend/projects/abtesting/src/app/features/dashboard/home/components/enrollment-condition-table/enrollment-condition-table.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnChanges, SimpleChanges, OnInit } from '@angular/core';
 import { ASSIGNMENT_UNIT, ExperimentVM, EnrollmentByConditionOrPartitionData } from '../../../../../core/experiments/store/experiments.model';
 import { ExperimentService } from '../../../../../core/experiments/experiments.service';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'home-enrollment-condition-table',
@@ -19,6 +20,7 @@ export class EnrollmentConditionTableComponent implements OnChanges, OnInit {
   ];
   displayedColumns: string[] = [];
   isStatLoading = true;
+  experimentConditionSub: Subscription;
 
   constructor(private experimentService: ExperimentService) {}
 
@@ -31,7 +33,7 @@ export class EnrollmentConditionTableComponent implements OnChanges, OnInit {
   }
 
   ngOnInit() {
-    this.experimentService.experimentStatById$(this.experiment.id).subscribe(stat => {
+    this.experimentConditionSub = this.experimentService.experimentStatById$(this.experiment.id).subscribe(stat => {
       this.experimentData = [];
       if (stat && stat.conditions) {
         this.isStatLoading = false;
@@ -79,6 +81,10 @@ export class EnrollmentConditionTableComponent implements OnChanges, OnInit {
     return this.experiment.conditions.reduce((acc, condition) =>
       condition.id === conditionId ? acc = condition[key] : acc
       , null);
+  }
+
+  ngOnDestroy() {
+    this.experimentConditionSub.unsubscribe();
   }
 
   get AssignmentUnit() {


### PR DESCRIPTION
In this PR, I have fixed the infinite loader issue. This issue was occurring in ```Enrollments by Condition```  section whenever a user visits for the first time.