### PR TITLE
Fix/issue-121 All metric queries will not fail if one or more fails

### DIFF
--- a/backend/packages/Upgrade/src/api/services/QueryService.ts
+++ b/backend/packages/Upgrade/src/api/services/QueryService.ts
@@ -63,7 +63,7 @@ export class QueryService {
       await Promise.all(failedQuery);
     }
 
-    modifiedResponse = modifiedResponse.filter(res => res.length).map((res, index) => {
+    modifiedResponse = modifiedResponse.map((res, index) => {
       return { id: queryIds[index], result: res };
     });
 

--- a/backend/packages/Upgrade/src/api/services/QueryService.ts
+++ b/backend/packages/Upgrade/src/api/services/QueryService.ts
@@ -6,6 +6,7 @@ import { Query } from '../models/Query';
 import { LogRepository } from '../repositories/LogRepository';
 import { SERVER_ERROR } from 'upgrade_types';
 import { ErrorService } from './ErrorService';
+import { ExperimentError } from '../models/ExperimentError';
 
 @Service()
 export class QueryService {
@@ -52,7 +53,7 @@ export class QueryService {
           message: `Query Failed error: ${JSON.stringify(queryIds[index], undefined, 2)}`,
           name: 'Query Failed error',
           type: SERVER_ERROR.QUERY_FAILED,
-        } as any));
+        } as ExperimentError));
 
         return [];
       }
@@ -62,9 +63,9 @@ export class QueryService {
       await Promise.all(failedQuery);
     }
 
-    modifiedResponse = modifiedResponse.map((res, index) => {
-      return queryIds[index] ? { id: queryIds[index], result: res} : null;
-    }).filter(query => query);
+    modifiedResponse = modifiedResponse.filter(res => res.length).map((res, index) => {
+      return { id: queryIds[index], result: res };
+    });
 
     return modifiedResponse;
   }

--- a/backend/packages/Upgrade/src/api/services/QueryService.ts
+++ b/backend/packages/Upgrade/src/api/services/QueryService.ts
@@ -4,12 +4,15 @@ import { QueryRepository } from '../repositories/QueryRepository';
 import { Logger, LoggerInterface } from '../../decorators/Logger';
 import { Query } from '../models/Query';
 import { LogRepository } from '../repositories/LogRepository';
+import { SERVER_ERROR } from 'upgrade_types';
+import { ErrorService } from './ErrorService';
 
 @Service()
 export class QueryService {
   constructor(
     @OrmRepository() private queryRepository: QueryRepository,
     @OrmRepository() private logRepository: LogRepository,
+    public errorService: ErrorService,
     @Logger(__filename) private log: LoggerInterface
   ) {}
 
@@ -34,13 +37,35 @@ export class QueryService {
 
     const promiseResult = await Promise.all(promiseArray);
     const analysePromise = promiseResult.map((query) => this.logRepository.analysis(query));
-    let response = await Promise.all(analysePromise);
-    response = response.map((res, index) => {
-      return {
-        id: queryIds[index],
-        result: res,
-      };
+    const response = await Promise.allSettled(analysePromise);
+
+    const failedQuery = Array<Promise<any>>();
+
+    let modifiedResponse = response.map((query, index) => {
+      if (query.status === 'fulfilled') {
+        return query.value;
+      } else {
+        this.log.error('Error in Query Id ', queryIds[index]);
+        failedQuery.push(this.errorService.create({
+          endPoint: '/api/query/analyse',
+          errorCode: 500,
+          message: `Query Failed error: ${JSON.stringify(queryIds[index], undefined, 2)}`,
+          name: 'Query Failed error',
+          type: SERVER_ERROR.QUERY_FAILED,
+        } as any));
+
+        return [];
+      }
     });
-    return response;
+
+    if (failedQuery.length) {
+      await Promise.all(failedQuery);
+    }
+
+    modifiedResponse = modifiedResponse.map((res, index) => {
+      return queryIds[index] ? { id: queryIds[index], result: res} : null;
+    }).filter(query => query);
+
+    return modifiedResponse;
   }
 }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -29,12 +29,12 @@
       "es2015.collection",
       "es2015.generator",
       "es2015.iterable",
-      "es2015.promise",
       "es2015.proxy",
       "es2015.reflect",
       "es2015.symbol",
       "es2015.symbol.wellknown",
-      "esnext.asynciterable"
+      "esnext.asynciterable",
+      "ES2020.Promise"
     ]
   }
 }


### PR DESCRIPTION
In this PR, I have decoupled the metric queries. By this we can get response of successful queries even if one or more query fails. Also we will have database entry of failed queries and id of those failed query can be seen in log.