### PR TITLE
Consistent init call response

### DIFF
--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
@@ -131,7 +131,14 @@ export class ExperimentClientController {
   ): Promise<ExperimentUser> {
     request.logger.addFromDetails(__filename, 'init');
     request.logger.info({ stdout: 'Starting the init call for user', stack_trace: 'null' });
-    const document = await this.experimentUserService.create([experimentUser], request.logger);
+    var document = await this.experimentUserService.create( [experimentUser], request.logger );
+    ['createdAt', 'updatedAt', 'versionNumber'].forEach(key => delete document[0][key]);
+    if (document[0].group == null) {
+      delete document[0]['group'];
+    }
+    if (document[0].workingGroup == null) {
+      delete document[0]['workingGroup'];
+    }
     return document[0];
   }
 

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
@@ -131,7 +131,7 @@ export class ExperimentClientController {
   ): Promise<Pick<ExperimentUser, 'id' | 'group' | 'workingGroup'>> {
     request.logger.addFromDetails(__filename, 'init');
     request.logger.info({ stdout: 'Starting the init call for user', stack_trace: 'null' });
-    var userDocument = await this.experimentUserService.create( [experimentUser], request.logger );
+    const userDocument = await this.experimentUserService.create( [experimentUser], request.logger );
     if (!userDocument || !userDocument[0]) {
       request.logger.error({
         details: 'user document not present',
@@ -141,10 +141,9 @@ export class ExperimentClientController {
     // if reinit call is made with any of the below fields not included in the call,
     // then we will fetch the stored values of the field and return them in the response
     // for consistent init response with 3 fields ['userId', 'group', 'workingGroup']
-    var fetchedUserDocument = await this.experimentUserService.findOne(userDocument[0].id);
-    const { id, group, workingGroup } = fetchedUserDocument;
-    return { id, group, workingGroup };
-  }
+     const { id, group, workingGroup } = userDocument[0];
+     return { id, group, workingGroup };
+   }
 
   /**
    * @swagger

--- a/backend/packages/Upgrade/src/api/services/ExperimentUserService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentUserService.ts
@@ -54,7 +54,11 @@ export class ExperimentUserService {
 
     // wait for all assignment update to get complete
     await Promise.all(assignmentUpdated);
-    return updatedUsers;
+
+    // findAll user document here
+    const updatedUserDocument = await this.userRepository.findByIds(updatedUsers.map((user) => user.id));
+
+    return updatedUserDocument;
   }
 
   public async setAliasesForUser(userId: string, aliases: string[]): Promise<ExperimentUser[]> {


### PR DESCRIPTION
We have removed ['createdAt', 'updatedAt', 'versionNumber'] keys from the init call response as this is not expected in Java clientlib. Also, we only return the keys that are passed during the init call.

We have verified the init call response for the below cases:
1. Only userId is passed.
2. User with group and working group is passed.
3. User already exist.
4. With correct group/working group info.
5. UserId with updated group and working group info.