### PR TITLE
Fix/issue 165 - Add ClientSessionId to UpgradeClient and Header

### DIFF
--- a/clientlibs/js/src/UpgradeClient.ts
+++ b/clientlibs/js/src/UpgradeClient.ts
@@ -12,6 +12,7 @@ import setAltUserIds from './functions/setAltUserIds';
 import addMetrics from './functions/addMetrics';
 import getFeatureFlag from './functions/getFeatureFlag';
 import init from './functions/init';
+import * as uuid  from 'uuid';
 
 export default class UpgradeClient {
     // Endpoints URLs
@@ -31,16 +32,18 @@ export default class UpgradeClient {
     private hostUrl: string;
     // Use token if it is given in constructor
     private token: string;
+    private clientSessionId: string;
 
     private group: Map<string, Array<string>> = null;
     private workingGroup: Map<string, string> = null;
     private experimentConditionData: IExperimentAssignment[] = null;
     private featureFlags: IFeatureFlag[] = null;
 
-    constructor(userId: string, hostUrl: string, token?: string) {
+    constructor(userId: string, hostUrl: string, token?: string, clientSessionId?: string) {
         this.userId = userId;
         this.hostUrl = hostUrl;
         this.token = token;
+        this.clientSessionId = clientSessionId || uuid.v4();
         this.api = {
             init: `${hostUrl}/api/init`,
             getAllExperimentConditions: `${hostUrl}/api/assign`,
@@ -66,12 +69,12 @@ export default class UpgradeClient {
 
     async init(group?: Map<string, Array<string>>, workingGroup?: Map<string, string>): Promise<Interfaces.IUser> {
         this.validateClient();
-        return await init(this.api.init, this.userId, this.token, group, workingGroup);
+        return await init(this.api.init, this.userId, this.token, this.clientSessionId, group, workingGroup);
     }
 
     async setGroupMembership(group: Map<string, Array<string>>): Promise<Interfaces.IUser> {
         this.validateClient();
-        let response: Interfaces.IUser = await setGroupMembership(this.api.setGroupMemberShip, this.userId, this.token, group);
+        let response: Interfaces.IUser = await setGroupMembership(this.api.setGroupMemberShip, this.userId, this.token, this.clientSessionId, group);
         if (response.id) {
             // If it does not throw error from setGroupMembership
             this.group = group;
@@ -85,7 +88,7 @@ export default class UpgradeClient {
 
     async setWorkingGroup(workingGroup: Map<string, string>): Promise<Interfaces.IUser> {
         this.validateClient();
-        let response: Interfaces.IUser = await setWorkingGroup(this.api.setWorkingGroup, this.userId, this.token, workingGroup);
+        let response: Interfaces.IUser = await setWorkingGroup(this.api.setWorkingGroup, this.userId, this.token, this.clientSessionId, workingGroup);
         if (response.id) {
             // If it does not throw error from setWorkingGroup
             this.workingGroup = workingGroup;
@@ -99,7 +102,7 @@ export default class UpgradeClient {
 
     async getAllExperimentConditions(context: string): Promise<IExperimentAssignment[]> {
         this.validateClient();
-        const response = await getAllExperimentConditions(this.api.getAllExperimentConditions, this.userId, this.token, context);
+        const response = await getAllExperimentConditions(this.api.getAllExperimentConditions, this.userId, this.token, this.clientSessionId, context);
         if (Array.isArray(response)) {
             this.experimentConditionData = response;
         }
@@ -116,17 +119,17 @@ export default class UpgradeClient {
 
     async markExperimentPoint(experimentPoint: string, condition = null, partitionId?: string): Promise<Interfaces.IMarkExperimentPoint> {
         this.validateClient();
-        return await markExperimentPoint(this.api.markExperimentPoint, this.userId, this.token, experimentPoint, condition, partitionId);
+        return await markExperimentPoint(this.api.markExperimentPoint, this.userId, this.token, this.clientSessionId, experimentPoint, condition, partitionId);
     }
 
     async failedExperimentPoint(experimentPoint: string, reason: string, experimentId?: string): Promise<Interfaces.IFailedExperimentPoint> {
         this.validateClient();
-        return await failedExperimentPoint(this.api.failedExperimentPoint, this.token, experimentPoint, reason, this.userId, experimentId);
+        return await failedExperimentPoint(this.api.failedExperimentPoint, this.token, this.clientSessionId, experimentPoint, reason, this.userId, experimentId);
     }
 
     async getAllFeatureFlags(): Promise<IFeatureFlag[]> {
         this.validateClient();
-        const response = await getAllFeatureFlags(this.api.getAllFeatureFlag, this.token);
+        const response = await getAllFeatureFlags(this.api.getAllFeatureFlag, this.token, this.clientSessionId);
         if (response.length) {
             this.featureFlags = response;
         }
@@ -140,16 +143,16 @@ export default class UpgradeClient {
 
     async log(value: ILogInput[], sendAsAnalytics = false): Promise<Interfaces.ILog[]> {
         this.validateClient();
-        return await log(this.api.log, this.userId, this.token, value, sendAsAnalytics);
+        return await log(this.api.log, this.userId, this.token, this.clientSessionId, value, sendAsAnalytics);
     }
 
     async setAltUserIds(altUserIds: string[]): Promise<Interfaces.IExperimentUserAliases[]> {
         this.validateClient();
-        return await setAltUserIds(this.api.altUserIds, this.userId, this.token, altUserIds);
+        return await setAltUserIds(this.api.altUserIds, this.userId, this.token, this.clientSessionId, altUserIds);
     }
 
     async addMetrics(metrics: Array<ISingleMetric | IGroupMetric>): Promise<Interfaces.IMetric[]> {
         this.validateClient();
-        return await addMetrics(this.api.addMetrics, this.token, metrics);
+        return await addMetrics(this.api.addMetrics, this.token, this.clientSessionId, metrics);
     }
 }

--- a/clientlibs/js/src/UpgradeClient.ts
+++ b/clientlibs/js/src/UpgradeClient.ts
@@ -39,11 +39,11 @@ export default class UpgradeClient {
     private experimentConditionData: IExperimentAssignment[] = null;
     private featureFlags: IFeatureFlag[] = null;
 
-    constructor(userId: string, hostUrl: string, token?: string, clientSessionId?: string) {
+    constructor(userId: string, hostUrl: string, options?: {token?: string, clientSessionId?: string}) {
         this.userId = userId;
         this.hostUrl = hostUrl;
-        this.token = token;
-        this.clientSessionId = clientSessionId || uuid.v4();
+        this.token = options?.token;
+        this.clientSessionId = options?.clientSessionId || uuid.v4();
         this.api = {
             init: `${hostUrl}/api/init`,
             getAllExperimentConditions: `${hostUrl}/api/assign`,

--- a/clientlibs/js/src/common/fetchDataService.ts
+++ b/clientlibs/js/src/common/fetchDataService.ts
@@ -1,21 +1,24 @@
 import { Interfaces, Types } from '../identifiers';
 import * as fetch from 'isomorphic-fetch';
+import * as uuid  from 'uuid';
 
 // Call this function with url and data which is used in body of request
 export default async function fetchDataService(
   url: string,
   token: string,
+  clientSessionId: string,
   data: any,
   requestType: Types.REQUEST_TYPES,
   sendAsAnalytics: boolean = false,
   skipRetryOnStatusCodes: number[] = []
 ): Promise<Interfaces.IResponse> {
-  return await fetchData(url, token, data, requestType, sendAsAnalytics, skipRetryOnStatusCodes);
+  return await fetchData(url, token, clientSessionId, data, requestType, sendAsAnalytics, skipRetryOnStatusCodes);
 }
 
 async function fetchData(
   url: string,
   token: string,
+  clientSessionId: string,
   data: any,
   requestType: Types.REQUEST_TYPES,
   sendAsAnalytics = false,
@@ -26,7 +29,8 @@ async function fetchData(
   try {
 
     let headers: object = {
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      'Session-Id': clientSessionId || uuid.v4(),
     }
     if (!!token) {
       headers = {
@@ -34,7 +38,6 @@ async function fetchData(
         'Authorization': `Bearer ${token}`
       }
     }
-
 
     let options: Interfaces.IRequestOptions = {
       headers,
@@ -69,7 +72,7 @@ async function fetchData(
       if (retries > 0) {
         // Do retry after the backOff time
         await wait(backOff);
-        return await fetchData(url, token, data, requestType, sendAsAnalytics, skipRetryOnStatusCodes, retries - 1, backOff * 2);
+        return await fetchData(url, token, clientSessionId, data, requestType, sendAsAnalytics, skipRetryOnStatusCodes, retries - 1, backOff * 2);
       } else {
         return {
           status: false,

--- a/clientlibs/js/src/common/fetchDataService.ts
+++ b/clientlibs/js/src/common/fetchDataService.ts
@@ -31,6 +31,7 @@ async function fetchData(
     let headers: object = {
       'Content-Type': 'application/json',
       'Session-Id': clientSessionId || uuid.v4(),
+      'CurrentRetry': retries,
     }
     if (!!token) {
       headers = {

--- a/clientlibs/js/src/functions/addMetrics.ts
+++ b/clientlibs/js/src/functions/addMetrics.ts
@@ -5,10 +5,11 @@ import { ISingleMetric, IGroupMetric } from 'upgrade_types';
 export default async function addMetrics(
   url: string,
   token: string,
+  clientSessionId: string,
   metrics: Array<ISingleMetric | IGroupMetric>
 ): Promise<Interfaces.IMetric[]> {
   try {
-    const response = await fetchDataService(url, token, { metricUnit: metrics }, Types.REQUEST_TYPES.POST);
+    const response = await fetchDataService(url, token, clientSessionId, { metricUnit: metrics }, Types.REQUEST_TYPES.POST);
     if (response.status) {
       response.data = response.data.map(metric => {
         const { createdAt, updatedAt, versionNumber, ...rest } = metric;

--- a/clientlibs/js/src/functions/failedExperimentPoint.ts
+++ b/clientlibs/js/src/functions/failedExperimentPoint.ts
@@ -4,6 +4,7 @@ import fetchDataService from '../common/fetchDataService';
 export default async function failedExperimentPoint(
   url: string,
   token: string,
+  clientSessionId: string,
   experimentPoint: string,
   reason: string,
   userId: string,
@@ -21,7 +22,7 @@ export default async function failedExperimentPoint(
         experimentId,
       };
     }
-    const response = await fetchDataService(url, token, data, Types.REQUEST_TYPES.POST);
+    const response = await fetchDataService(url, token, clientSessionId, data, Types.REQUEST_TYPES.POST);
     if (response.status) {
       return {
         type: response.data.type,

--- a/clientlibs/js/src/functions/getAllExperimentConditions.ts
+++ b/clientlibs/js/src/functions/getAllExperimentConditions.ts
@@ -2,13 +2,19 @@ import fetchDataService from '../common/fetchDataService';
 import { IExperimentAssignment } from 'upgrade_types';
 import { Types } from '../identifiers';
 
-export default async function getAllExperimentConditions(url: string, userId: string, token: string, context: string): Promise<IExperimentAssignment[]> {
+export default async function getAllExperimentConditions(
+  url: string,
+  userId: string,
+  token: string,
+  clientSessionId: string,
+  context: string
+): Promise<IExperimentAssignment[]> {
   try {
     const params: any = {
       userId,
       context
     };
-    const experimentConditionResponse = await fetchDataService(url, token, params, Types.REQUEST_TYPES.POST);
+    const experimentConditionResponse = await fetchDataService(url, token, clientSessionId, params, Types.REQUEST_TYPES.POST);
     if (experimentConditionResponse.status) {
       experimentConditionResponse.data = experimentConditionResponse.data.map(data => {
         return {

--- a/clientlibs/js/src/functions/getAllfeatureFlags.ts
+++ b/clientlibs/js/src/functions/getAllfeatureFlags.ts
@@ -2,9 +2,9 @@ import fetchDataService from '../common/fetchDataService';
 import { Types } from '../identifiers';
 import { IFeatureFlag } from 'upgrade_types';
 
-export default async function getAllFeatureFlags(url: string, token: string): Promise<IFeatureFlag[]> {
+export default async function getAllFeatureFlags(url: string, token: string, clientSessionId: string): Promise<IFeatureFlag[]> {
   try {
-    const featureFlagResponse = await fetchDataService(url, token, {}, Types.REQUEST_TYPES.GET);
+    const featureFlagResponse = await fetchDataService(url, token, clientSessionId, {}, Types.REQUEST_TYPES.GET);
     if (featureFlagResponse.status) {
       return featureFlagResponse.data.map(flag => {
         const { createdAt, updatedAt, versionNumber, variations, ...rest } = flag;

--- a/clientlibs/js/src/functions/init.ts
+++ b/clientlibs/js/src/functions/init.ts
@@ -6,6 +6,7 @@ export default async function init(
   url: string,
   userId: string,
   token: string,
+  clientSessionId: string,
   group?: Map<string, Array<string>>,
   workingGroup?: Map<string, string>,
 ): Promise<Interfaces.IUser> {
@@ -36,7 +37,7 @@ export default async function init(
       }
     }
 
-    const response = await fetchDataService(url, token, data, Types.REQUEST_TYPES.POST);
+    const response = await fetchDataService(url, token, clientSessionId, data, Types.REQUEST_TYPES.POST);
     if (response.status) {
       return response.data;
     } else {

--- a/clientlibs/js/src/functions/log.ts
+++ b/clientlibs/js/src/functions/log.ts
@@ -6,6 +6,7 @@ export default async function log(
   url: string,
   userId: string,
   token: string,
+  clientSessionId: string,
   value: ILogInput[],
   sendAsAnalytics = false
 ): Promise<Interfaces.ILog[]> {
@@ -14,7 +15,7 @@ export default async function log(
       userId,
       value
     };
-    const logResponse = await fetchDataService(url, token, data, Types.REQUEST_TYPES.POST, sendAsAnalytics);
+    const logResponse = await fetchDataService(url, token, clientSessionId, data, Types.REQUEST_TYPES.POST, sendAsAnalytics);
     if (logResponse.status) {
       return logResponse.data;
     } else {

--- a/clientlibs/js/src/functions/markExperimentPoint.ts
+++ b/clientlibs/js/src/functions/markExperimentPoint.ts
@@ -1,7 +1,15 @@
 import { Interfaces, Types } from '../identifiers';
 import fetchDataService from '../common/fetchDataService';
 
-export default async function markExperimentPoint(url: string, userId: string, token: string, experimentPoint: string, condition: string|null, partitionId?: string): Promise<Interfaces.IMarkExperimentPoint> {
+export default async function markExperimentPoint(
+  url: string,
+  userId: string,
+  token: string,
+  clientSessionId: string,
+  experimentPoint: string,
+  condition: string|null,
+  partitionId?: string
+): Promise<Interfaces.IMarkExperimentPoint> {
   try {
     let data: any = {
       experimentPoint,
@@ -14,7 +22,7 @@ export default async function markExperimentPoint(url: string, userId: string, t
         partitionId
       }
     }
-    const response = await fetchDataService(url, token, data, Types.REQUEST_TYPES.POST);
+    const response = await fetchDataService(url, token, clientSessionId, data, Types.REQUEST_TYPES.POST);
     if (response.status) {
       return {
         userId,

--- a/clientlibs/js/src/functions/setAltUserIds.ts
+++ b/clientlibs/js/src/functions/setAltUserIds.ts
@@ -5,6 +5,7 @@ export default async function setAltUserIds(
   url: string,
   userId: string,
   token: string,
+  clientSessionId: string,
   altUserIds: string[]
 ): Promise<Interfaces.IExperimentUserAliases[]> {
   try {
@@ -13,7 +14,7 @@ export default async function setAltUserIds(
       aliases: altUserIds
     };
     const skipRetryOnStatusCodes = [500]; // Response status codes for which request retry should be skipped on failure
-    const response = await fetchDataService(url, token, data, Types.REQUEST_TYPES.POST, false, skipRetryOnStatusCodes);
+    const response = await fetchDataService(url, token, clientSessionId, data, Types.REQUEST_TYPES.POST, false, skipRetryOnStatusCodes);
     if (response.status) {
       return response.data;
     } else {

--- a/clientlibs/js/src/functions/setGroupMembership.ts
+++ b/clientlibs/js/src/functions/setGroupMembership.ts
@@ -2,13 +2,19 @@ import { Interfaces, Types } from '../identifiers';
 import fetchDataService from '../common/fetchDataService';
 import convertMapToObj from '../common/convertMapToObj';
 
-export default async function setGroupMembership(url: string, userId: string, token: string, group: Map<string, Array<string>>): Promise<Interfaces.IUser> {
+export default async function setGroupMembership(
+  url: string,
+  userId: string,
+  token: string,
+  clientSessionId: string,
+  group: Map<string, Array<string>>
+): Promise<Interfaces.IUser> {
   try {
     if (!(group instanceof Map)) {
       throw new Error('Group type should be Map<string, Array<string>>');
     }
     const groupObj = convertMapToObj(group);
-    const response = await fetchDataService(url, token, { id: userId, group: groupObj }, Types.REQUEST_TYPES.POST);
+    const response = await fetchDataService(url, token, clientSessionId, { id: userId, group: groupObj }, Types.REQUEST_TYPES.POST);
     if (response.status) {
       return response.data;
     } else {

--- a/clientlibs/js/src/functions/setWorkingGroup.ts
+++ b/clientlibs/js/src/functions/setWorkingGroup.ts
@@ -2,13 +2,19 @@ import { Interfaces, Types } from '../identifiers';
 import fetchDataService from '../common/fetchDataService';
 import convertMapToObj from '../common/convertMapToObj';
 
-export default async function setWorkingGroup(url: string, userId: string, token: string, workingGroup: Map<string, string>): Promise<Interfaces.IUser> {
+export default async function setWorkingGroup(
+  url: string,
+  userId: string,
+  token: string,
+  clientSessionId:string,
+  workingGroup: Map<string, string>
+): Promise<Interfaces.IUser> {
   try {
     if (!(workingGroup instanceof Map)) {
       throw new Error('Working group type should be Map<string, string>');
     }
     const workingGroupObj = convertMapToObj(workingGroup);
-    const response = await fetchDataService(url, token, { id: userId, workingGroup: workingGroupObj }, Types.REQUEST_TYPES.POST);
+    const response = await fetchDataService(url, token, clientSessionId, { id: userId, workingGroup: workingGroupObj }, Types.REQUEST_TYPES.POST);
     if (response.status) {
       return response.data;
     } else {


### PR DESCRIPTION
Session-Id and Retry Count are passed through the Request header.

The constructor of UpgradeClient is changed from `(userId, hostURL, token?)` to `(userID, hostURL, options? {token?, clientSessionId?})`. Token and ClientSessionId, both are optional so both are being passed through a option parameter.