### PR TITLE
fix for issue #199: api to clear db tables in demo app

### DIFF
--- a/backend/packages/Upgrade/.env.example
+++ b/backend/packages/Upgrade/.env.example
@@ -7,6 +7,7 @@ APP_HOST=localhost
 APP_PORT=3030
 APP_ROUTE_PREFIX=/api
 APP_BANNER=true
+APP_DEMO=true
 
 #
 # LOGGING

--- a/backend/packages/Upgrade/.env.test
+++ b/backend/packages/Upgrade/.env.test
@@ -7,6 +7,7 @@ APP_HOST=localhost
 APP_PORT=3030
 APP_ROUTE_PREFIX=/api
 APP_BANNER=true
+APP_DEMO=true
 
 #
 # LOGGING

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
@@ -1,4 +1,4 @@
-import { JsonController, Post, Body, UseBefore, Get, BodyParam, Req, InternalServerError } from 'routing-controllers';
+import { JsonController, Post, Body, UseBefore, Get, BodyParam, Req, InternalServerError, Delete } from 'routing-controllers';
 import { ExperimentService } from '../services/ExperimentService';
 import { ExperimentAssignmentService } from '../services/ExperimentAssignmentService';
 import { MarkExperimentValidator } from './validators/MarkExperimentValidator';
@@ -20,6 +20,8 @@ import { ExperimentUserAliasesValidator } from './validators/ExperimentUserAlias
 import { Metric } from '../models/Metric';
 import * as express from 'express';
 import { AppRequest } from '../../types';
+import { env } from '../../env';
+import { toBool } from '../../lib/env';
 
 /**
  * @swagger
@@ -654,5 +656,14 @@ export class ExperimentClientController {
   @Post('useraliases')
   public setUserAliases(@Body() user: ExperimentUserAliasesValidator): Promise<ExperimentUser[]> {
     return this.experimentUserService.setAliasesForUser(user.userId, user.aliases);
+  }
+
+  @Delete('clearDB')
+  public clearDB(): Promise<string> {
+    // if DEMO mode is enabled, then clear the database:
+    if(toBool(env.app.demo)) {
+      return this.experimentUserService.clearDB();
+    }
+    return Promise.resolve('DEMO mode is disabled. You cannot clear DB.');
   }
 }

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
@@ -21,7 +21,6 @@ import { Metric } from '../models/Metric';
 import * as express from 'express';
 import { AppRequest } from '../../types';
 import { env } from '../../env';
-import { toBool } from '../../lib/env';
 
 /**
  * @swagger
@@ -661,7 +660,7 @@ export class ExperimentClientController {
   @Delete('clearDB')
   public clearDB(): Promise<string> {
     // if DEMO mode is enabled, then clear the database:
-    if(toBool(env.app.demo)) {
+    if(env.app.demo) {
       return this.experimentUserService.clearDB();
     }
     return Promise.resolve('DEMO mode is disabled. You cannot clear DB.');

--- a/backend/packages/Upgrade/src/api/repositories/ExperimentRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/ExperimentRepository.ts
@@ -178,4 +178,19 @@ export class ExperimentRepository extends Repository<Experiment> {
 
     return result.raw;
   }
+
+  public async clearDB(entityManager: EntityManager): Promise<string> {
+    try {
+      const entities = entityManager.connection.entityMetadatas;
+      for (const entity of entities) {
+        if(!(['user', 'metric', 'setting', 'migrations'].includes(entity.tableName))) {
+          const repository = await entityManager.connection.getRepository(entity.name);
+          await repository.query(`TRUNCATE ${entity.tableName} CASCADE;`);
+        }
+      }
+      return 'DB truncate successful';
+    } catch (error) {
+      throw new Error('DB truncate error. DB truncate not allowed');
+    } 
+  }
 }

--- a/backend/packages/Upgrade/src/api/repositories/ExperimentRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/ExperimentRepository.ts
@@ -1,4 +1,4 @@
-import { EXPERIMENT_STATE } from 'upgrade_types';
+import { EXPERIMENT_STATE, SERVER_ERROR } from 'upgrade_types';
 import { Repository, EntityRepository, EntityManager, Brackets } from 'typeorm';
 import { Experiment } from '../models/Experiment';
 import repositoryError from './utils/repositoryError';
@@ -190,7 +190,9 @@ export class ExperimentRepository extends Repository<Experiment> {
       }
       return 'DB truncate successful';
     } catch (error) {
-      throw new Error('DB truncate error. DB truncate not allowed');
+      error = new Error('DB truncate error. DB truncate unsuccessful');
+      (error as any).type = SERVER_ERROR.QUERY_FAILED;
+      throw error;
     } 
   }
 }

--- a/backend/packages/Upgrade/src/api/services/ExperimentUserService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentUserService.ts
@@ -394,8 +394,8 @@ export class ExperimentUserService {
     }
   }
 
-  public clearDB(): Promise<string> {
-    getConnection().transaction(async (transactionalEntityManager) => {
+  public async clearDB(): Promise<string> {
+    await getConnection().transaction(async (transactionalEntityManager) => {
       await this.experimentRepository.clearDB(transactionalEntityManager);
     });
     return Promise.resolve('Cleared DB');

--- a/backend/packages/Upgrade/src/api/services/ExperimentUserService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentUserService.ts
@@ -8,7 +8,7 @@ import uuid from 'uuid/v4';
 import { ExperimentRepository } from '../repositories/ExperimentRepository';
 import { ASSIGNMENT_UNIT, CONSISTENCY_RULE, EXPERIMENT_STATE, SERVER_ERROR } from 'upgrade_types';
 import { IndividualAssignmentRepository } from '../repositories/IndividualAssignmentRepository';
-import { In, Not } from 'typeorm';
+import { getConnection, In, Not } from 'typeorm';
 import { IndividualExclusionRepository } from '../repositories/IndividualExclusionRepository';
 import { GroupExclusionRepository } from '../repositories/GroupExclusionRepository';
 import { Experiment } from '../models/Experiment';
@@ -392,5 +392,12 @@ export class ExperimentUserService {
     if (assignedExperimentIds.length > 0) {
       await this.individualAssignmentRepository.deleteExperimentsForUserId(userId, assignedExperimentIds);
     }
+  }
+
+  public clearDB(): Promise<string> {
+    getConnection().transaction(async (transactionalEntityManager) => {
+      await this.experimentRepository.clearDB(transactionalEntityManager);
+    });
+    return Promise.resolve('Cleared DB');
   }
 }

--- a/backend/packages/Upgrade/src/env.ts
+++ b/backend/packages/Upgrade/src/env.ts
@@ -39,6 +39,7 @@ export const env = {
       middlewares: getOsPaths('MIDDLEWARES'),
       interceptors: getOsPaths('INTERCEPTORS'),
     },
+    demo: getOsEnvOptional('APP_DEMO'),
   },
   log: {
     level: getOsEnv('LOG_LEVEL'),

--- a/backend/packages/Upgrade/src/env.ts
+++ b/backend/packages/Upgrade/src/env.ts
@@ -39,7 +39,7 @@ export const env = {
       middlewares: getOsPaths('MIDDLEWARES'),
       interceptors: getOsPaths('INTERCEPTORS'),
     },
-    demo: getOsEnvOptional('APP_DEMO'),
+    demo: toBool(getOsEnvOptional('APP_DEMO')) || false,
   },
   log: {
     level: getOsEnv('LOG_LEVEL'),


### PR DESCRIPTION
In this PR, we have added a DELETE API (`/api/clearDB`) to truncate the db tables excluding ['user', 'metric', 'setting', 'migrations'].
For this to be protected, you need to set an environment variable named `APP_DEMO=true` in the `.env` file to work.