### PR TITLE
fix for issue #200: Any domain allowed to login to upgrade with creator access

### DIFF
--- a/backend/packages/Upgrade/.env.example
+++ b/backend/packages/Upgrade/.env.example
@@ -60,7 +60,7 @@ MONITOR_PASSWORD=1234
 # Google Client Id
 #
 GOOGLE_CLIENT_ID=google_project_id
-DOMAIN_NAME = playpowerlabs.com
+DOMAIN_NAME =
 AUTH_CHECK=false
 SCHEDULER_STEP_FUNCTION=arn:aws:states:us-east-1:656500730782:stateMachine:ExperimentSchedular-development
 AWS_REGION=us-east-1

--- a/backend/packages/Upgrade/.env.test
+++ b/backend/packages/Upgrade/.env.test
@@ -60,7 +60,7 @@ MONITOR_PASSWORD=1234
 # Google Client Id
 #
 GOOGLE_CLIENT_ID=google_project_id
-DOMAIN_NAME = playpowerlabs.com
+DOMAIN_NAME =
 AUTH_CHECK=false
 SCHEDULER_STEP_FUNCTION=arn:aws:states:us-east-1:656500730782:stateMachine:ExperimentSchedular-development
 AWS_REGION=us-east-1

--- a/backend/packages/Upgrade/src/api/models/User.ts
+++ b/backend/packages/Upgrade/src/api/models/User.ts
@@ -21,7 +21,7 @@ export class User extends BaseModel {
   @Column({
     type: 'enum',
     enum: UserRole,
-    default: UserRole.READER,
+    default: UserRole.CREATOR,
     nullable: true,
   })
   public role: UserRole;

--- a/backend/packages/Upgrade/src/database/migrations/1637673843685-alterDefaultUserAsCreator.ts
+++ b/backend/packages/Upgrade/src/database/migrations/1637673843685-alterDefaultUserAsCreator.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class alterDefaultUserAsCreator1637673843685 implements MigrationInterface {
+    name = 'alterDefaultUserAsCreator1637673843685'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "public"."user" ALTER COLUMN "role" SET DEFAULT 'creator'`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "public"."user" ALTER COLUMN "role" SET DEFAULT 'reader'`);
+    }
+
+}

--- a/frontend/projects/upgrade/src/environments/environment.ts
+++ b/frontend/projects/upgrade/src/environments/environment.ts
@@ -14,7 +14,7 @@ export const environment = {
   i18nPrefix: '',
   appVersion: require('../../../../package.json').version,
   gapiClientId: '135765367152-pq4jhd3gra10jda9l6bpnmu9gqt48tup.apps.googleusercontent.com',
-  domainName: 'playpowerlabs.com',
+  domainName: '',
   api: {
     getAllExperiments: `${endpointApi}/experiments/paginated`,
     createNewExperiments: `${endpointApi}/experiments`,


### PR DESCRIPTION
In this PR, we have set domainName to blank, so that any domain's email ID can login to upgrade.

Also, we have provided `Creator` access to the new user for the demo. We have to revert this migration after the demo, so that we give the default `Reader` access to the new users.

You have to set `DOMAIN_NAME =` as blank in the` .env` file as mentioned in the `.env.example` file when you want Upgrade to not restrict to any specific domain to access the application. Else, if you want Upgrade to be accessible to any particular domain only, then please set `DOMAIN_NAME = domainName` in the` .env` and `environment.ts` files. For example: `DOMAIN_NAME = playpowerlabs.com` and `domainName: 'playpowerlabs.com'`