### PR TITLE
Fix/issue 164 PR for all other controllers then ExperimentClientController

### DIFF
--- a/backend/packages/Upgrade/src/api/controllers/CheckController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/CheckController.ts
@@ -1,4 +1,5 @@
-import { JsonController, Get } from 'routing-controllers';
+import { JsonController, Get, Req } from 'routing-controllers';
+import { AppRequest } from '../../types';
 import { CheckService } from '../services/CheckService';
 
 // TODO delete this after completing
@@ -6,7 +7,7 @@ import { CheckService } from '../services/CheckService';
 export class Demo {
   constructor(public check: CheckService) {}
   @Get('/groupAssignment')
-  public groupAssignment(): Promise<any> {
+  public groupAssignment(@Req() request: AppRequest): Promise<any> {
     return this.check.getAllGroupAssignments();
   }
 

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentUserController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentUserController.ts
@@ -47,8 +47,8 @@ export class UserController {
    *            description: Successful
    */
   @Get()
-  public find(): Promise<ExperimentUser[]> {
-    return this.userService.find();
+  public find( @Req() request: AppRequest ): Promise<ExperimentUser[]> {
+    return this.userService.find(request.logger);
   }
 
   /**
@@ -75,11 +75,11 @@ export class UserController {
    */
   @Get('/:id')
   @OnUndefined(UserNotFoundError)
-  public one(@Param('id') id: string): Promise<ExperimentUser> {
+  public one(@Param('id') id: string, @Req() request: AppRequest ): Promise<ExperimentUser> {
     if (!validator.isUUID(id)) {
       return Promise.reject(new Error(SERVER_ERROR.INCORRECT_PARAM_FORMAT + ' : id should be of type UUID.'));
     }
-    return this.userService.findOne(id);
+    return this.userService.findOne(id, request.logger);
   }
 
   /**
@@ -142,8 +142,9 @@ export class UserController {
   @Put('/:id')
   public update(
     @Param('id') id: string,
-    @Body({ validate: { validationError: { target: false, value: false } } }) user: ExperimentUser
+    @Body({ validate: { validationError: { target: false, value: false } } }) user: ExperimentUser, 
+    @Req() request: AppRequest 
   ): Promise<ExperimentUser> {
-    return this.userService.update(id, user);
+    return this.userService.update(id, user, request.logger);
   }
 }

--- a/backend/packages/Upgrade/src/api/controllers/LoginController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/LoginController.ts
@@ -1,4 +1,5 @@
-import { JsonController, Post, Body, Authorized } from 'routing-controllers';
+import { JsonController, Post, Body, Authorized, Req } from 'routing-controllers';
+import { AppRequest } from '../../types';
 import { User } from '../models/User';
 import { UserService } from '../services/UserService';
 
@@ -58,12 +59,12 @@ export class LoginController {
    *            description: User will be created if doesn't exist in the DB
    */
   @Post('/user')
-  public upsertUser(@Body() user: User): Promise<User> {
+  public upsertUser(@Body() user: User, @Req() request: AppRequest): Promise<User> {
     if (user.role) {
         // Create a user with default role reader if user doesn't exist as anyone with accepted google account domain can login
         // Role can be updated later by admin users only
         delete user.role;
     }
-    return this.userService.upsertUser(user);
+    return this.userService.upsertUser(user, request.logger);
   }
 }

--- a/backend/packages/Upgrade/src/api/controllers/MetricController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/MetricController.ts
@@ -1,6 +1,7 @@
-import { Authorized, JsonController, Get, Delete, Param, Post, BodyParam } from 'routing-controllers';
+import { Authorized, JsonController, Get, Delete, Param, Post, BodyParam, Req } from 'routing-controllers';
 import { MetricService } from '../services/MetricService';
 import { IMetricUnit, SERVER_ERROR, ISingleMetric, IGroupMetric } from 'upgrade_types';
+import { AppRequest } from '../../types';
 
 /**
  * @swagger
@@ -27,8 +28,8 @@ export class MetricController {
    *            description: Get all Metrics
    */
   @Get()
-  public getAllMetrics(): Promise<IMetricUnit[]> {
-    return this.metricService.getAllMetrics();
+  public getAllMetrics(@Req() request: AppRequest): Promise<IMetricUnit[]> {
+    return this.metricService.getAllMetrics(request.logger);
   }
 
   /**
@@ -56,8 +57,9 @@ export class MetricController {
    *            description: Filtered Metrics
    */
   @Post('/save')
-  public filterMetrics(@BodyParam('metricUnit') metricUnit: Array<ISingleMetric | IGroupMetric>): Promise<IMetricUnit[]> {
-    return this.metricService.upsertAllMetrics(metricUnit);
+  public filterMetrics(@BodyParam('metricUnit') metricUnit: Array<ISingleMetric | IGroupMetric>, 
+  @Req() request: AppRequest): Promise<IMetricUnit[]> {
+    return this.metricService.upsertAllMetrics(metricUnit, request.logger);
   }
 
   /**
@@ -81,10 +83,10 @@ export class MetricController {
    *            description: Delete metric by key
    */
   @Delete('/:key')
-  public delete(@Param('key') key: string): Promise<IMetricUnit[] | undefined> {
+  public delete(@Param('key') key: string, @Req() request: AppRequest): Promise<IMetricUnit[] | undefined> {
     if (!key) {
       return Promise.reject(new Error(SERVER_ERROR.MISSING_PARAMS + ' : key should not be null.'));
     }
-    return this.metricService.deleteMetric(key);
+    return this.metricService.deleteMetric(key, request.logger);
   }
 }

--- a/backend/packages/Upgrade/src/api/controllers/QueryController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/QueryController.ts
@@ -1,7 +1,8 @@
-import { Authorized, JsonController, Post, Body } from 'routing-controllers';
+import { Authorized, JsonController, Post, Body, Req } from 'routing-controllers';
 import { QueryService } from '../services/QueryService';
 import { DataLogAnalysisValidator } from './validators/DataLogAnalysisValidator';
 import { DataLogService } from '../services/DataLogService';
+import { AppRequest } from '../../types';
 
 /**
  * @swagger
@@ -44,8 +45,9 @@ export class QueryController {
   @Post('/analyse')
   public analyse(
     @Body({ validate: { validationError: { target: true, value: true } } })
-    dataLogParams: DataLogAnalysisValidator
+    dataLogParams: DataLogAnalysisValidator, 
+    @Req() request: AppRequest
   ): Promise<any> {
-    return this.queryService.analyse(dataLogParams.queryIds);
+    return this.queryService.analyse(dataLogParams.queryIds, request.logger);
   }
 }

--- a/backend/packages/Upgrade/src/api/controllers/ScheduledJobsController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ScheduledJobsController.ts
@@ -1,8 +1,9 @@
-import { JsonController, Post, Body, UseBefore } from 'routing-controllers';
+import { JsonController, Post, Body, UseBefore, Req } from 'routing-controllers';
 import { ScheduledJobsParamsValidator } from './validators/ScheduledJobsParamsValidator';
 import { ScheduledJobService } from '../services/ScheduledJobService';
 import { ScheduleJobMiddleware } from '../middlewares/ScheduleJobMiddleware';
 import bodyParser from 'body-parser';
+import { AppRequest } from '../../types';
 
 @JsonController('/scheduledJobs')
 @UseBefore(ScheduleJobMiddleware)
@@ -40,9 +41,10 @@ export class ScheduledJobsController {
   @Post('/start')
   public async startExperiment(
     @Body({ validate: { validationError: { target: true, value: true } } })
-    scheduledParams: ScheduledJobsParamsValidator
+    scheduledParams: ScheduledJobsParamsValidator, 
+    @Req() request: AppRequest
   ): Promise<any> {
-    return this.scheduledJobService.startExperiment(scheduledParams.id);
+    return this.scheduledJobService.startExperiment(scheduledParams.id, request.logger);
   }
 
   /**
@@ -75,9 +77,10 @@ export class ScheduledJobsController {
   @Post('/end')
   public async endExperiment(
     @Body({ validate: { validationError: { target: true, value: true } } })
-    scheduledParams: ScheduledJobsParamsValidator
+    scheduledParams: ScheduledJobsParamsValidator, 
+    @Req() request: AppRequest
   ): Promise<any> {
-    return this.scheduledJobService.endExperiment(scheduledParams.id);
+    return this.scheduledJobService.endExperiment(scheduledParams.id, request.logger);
   }
 
   /**
@@ -96,7 +99,7 @@ export class ScheduledJobsController {
    *            description: Clear audit and error logs
    */
   @Post('/clearLogs')
-  public async clearLogs(): Promise<boolean> {
-    return this.scheduledJobService.clearLogs();
+  public async clearLogs(@Req() request: AppRequest): Promise<boolean> {
+    return this.scheduledJobService.clearLogs(request.logger);
   }
 }

--- a/backend/packages/Upgrade/src/api/controllers/SettingController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/SettingController.ts
@@ -1,8 +1,8 @@
-import { JsonController, Post, Body, Get, Authorized } from 'routing-controllers';
+import { JsonController, Post, Body, Get, Authorized, Req } from 'routing-controllers';
 import { SettingService } from '../services/SettingService';
 import { Setting } from '../models/Setting';
 import { SettingParamsValidator } from './validators/SettingParamsValidator';
-import { UpgradeLogger } from '../../lib/logger/UpgradeLogger';
+import { AppRequest } from '../../types';
 
 /**
  * @swagger
@@ -30,8 +30,8 @@ export class SettingController {
    *            description: Project settings
    */
   @Get()
-  public getSetting(): Promise<Setting> {
-    return this.settingService.getClientCheck(new UpgradeLogger());
+  public getSetting(@Req() request: AppRequest): Promise<Setting> {
+    return this.settingService.getClientCheck(request.logger);
   }
 
   /**
@@ -64,9 +64,9 @@ export class SettingController {
   @Post()
   public upsertSetting(
     @Body({ validate: { validationError: { target: true, value: true } } })
-    settingParams: SettingParamsValidator
+    settingParams: SettingParamsValidator,
+    @Req() request: AppRequest
   ): Promise<Setting> {
-    console.log('settingParams', settingParams);
-    return this.settingService.setClientCheck(settingParams.toCheckAuth, settingParams.toFilterMetric);
+    return this.settingService.setClientCheck(settingParams.toCheckAuth, settingParams.toFilterMetric, request.logger);
   }
 }

--- a/backend/packages/Upgrade/src/api/controllers/SupportToolController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/SupportToolController.ts
@@ -1,7 +1,8 @@
-import { JsonController, Post, Body } from 'routing-controllers';
+import { JsonController, Post, Body, Req } from 'routing-controllers';
 import { SupportGetAssignmentParamsValidator } from './validators/SupportGetAssignmentParamsValidator';
 import { IExperimentAssignment } from 'upgrade_types';
 import { SupportService } from '../services/SupportService';
+import { AppRequest } from '../../types';
 
 /**
  * @swagger
@@ -44,8 +45,9 @@ export class SupportToolController {
   @Post('/assignment')
   public getAssignments(
     @Body({ validate: { validationError: { target: true, value: true } } })
-    assignmentParams: SupportGetAssignmentParamsValidator
+    assignmentParams: SupportGetAssignmentParamsValidator, 
+    @Req() request: AppRequest
   ): Promise<IExperimentAssignment[]> {
-    return this.supportService.getAssignments(assignmentParams.userId, assignmentParams.context);
+    return this.supportService.getAssignments(assignmentParams.userId, assignmentParams.context, request.logger);
   }
 }

--- a/backend/packages/Upgrade/src/api/controllers/VersionController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/VersionController.ts
@@ -1,6 +1,6 @@
-import { JsonController, Get, Authorized } from 'routing-controllers';
-import { Logger, LoggerInterface } from '../../decorators/Logger';
+import { JsonController, Get, Authorized, Req } from 'routing-controllers';
 import { env } from '../../env';
+import { AppRequest } from '../../types';
 
 /**
  * @swagger
@@ -12,7 +12,7 @@ import { env } from '../../env';
 @Authorized()
 @JsonController('/version')
 export class VersionController {
-    constructor(@Logger(__filename) private log: LoggerInterface) { }
+    constructor() { }
 
     /**
      * @swagger
@@ -26,8 +26,8 @@ export class VersionController {
      *            description: Get Server Version
      */
     @Get('/')
-    public async getVersionNumber(): Promise<string> {
-        this.log.info('Request recieved for version');
+    public async getVersionNumber(@Req() request: AppRequest): Promise<string> {
+        request.logger.info({ message: 'Request recieved for version' });
         return env.app.version;
     }
 }

--- a/backend/packages/Upgrade/src/api/middlewares/ClientLibMiddleware.ts
+++ b/backend/packages/Upgrade/src/api/middlewares/ClientLibMiddleware.ts
@@ -1,6 +1,7 @@
 import { ErrorWithType } from './../errors/ErrorWithType';
 import * as express from 'express';
 import { ExpressMiddlewareInterface } from 'routing-controllers';
+import { LoggerInterface, Logger } from '../../decorators/Logger';
 import { SettingService } from '../services/SettingService';
 import { SERVER_ERROR } from 'upgrade_types';
 import * as jwt from 'jsonwebtoken';
@@ -9,7 +10,7 @@ import { env } from '../../env';
 import { AppRequest } from '../../types';
 
 export class ClientLibMiddleware implements ExpressMiddlewareInterface {
-  constructor(public settingService: SettingService) {}
+  constructor(@Logger(__filename) private log: LoggerInterface, public settingService: SettingService) {}
 
   public async use(req: AppRequest, res: express.Response, next: express.NextFunction): Promise<any> {
     try {
@@ -45,6 +46,7 @@ export class ClientLibMiddleware implements ExpressMiddlewareInterface {
         delete decodeToken.exp;
 
         if (isequal(decodeToken, { APIKey: key })) {
+          this.log.info('');
           next();
         } else {
           const error = new Error('Provided token is invalid');

--- a/backend/packages/Upgrade/src/api/middlewares/ClientLibMiddleware.ts
+++ b/backend/packages/Upgrade/src/api/middlewares/ClientLibMiddleware.ts
@@ -1,7 +1,6 @@
 import { ErrorWithType } from './../errors/ErrorWithType';
 import * as express from 'express';
 import { ExpressMiddlewareInterface } from 'routing-controllers';
-import { LoggerInterface, Logger } from '../../decorators/Logger';
 import { SettingService } from '../services/SettingService';
 import { SERVER_ERROR } from 'upgrade_types';
 import * as jwt from 'jsonwebtoken';
@@ -10,7 +9,7 @@ import { env } from '../../env';
 import { AppRequest } from '../../types';
 
 export class ClientLibMiddleware implements ExpressMiddlewareInterface {
-  constructor(@Logger(__filename) private log: LoggerInterface, public settingService: SettingService) {}
+  constructor(public settingService: SettingService) {}
 
   public async use(req: AppRequest, res: express.Response, next: express.NextFunction): Promise<any> {
     try {
@@ -53,7 +52,6 @@ export class ClientLibMiddleware implements ExpressMiddlewareInterface {
           throw error;
         }
       } else {
-        this.log.info('Next');
         next();
       }
     } catch (error) {

--- a/backend/packages/Upgrade/src/api/middlewares/ClientLibMiddleware.ts
+++ b/backend/packages/Upgrade/src/api/middlewares/ClientLibMiddleware.ts
@@ -13,7 +13,7 @@ import { Service } from 'typedi';
 export class ClientLibMiddleware implements ExpressMiddlewareInterface {
   constructor(public settingService: SettingService) {}
 
-  public async use(req: AppRequest, res: express.Response, next: express.NextFunction): Promise<any> {
+  public async use(req: AppRequest, res: AppRequest, next: express.NextFunction): Promise<any> {
     try {
       const authorization = req.header('authorization');
       const token = authorization && authorization.replace('Bearer ', '').trim();

--- a/backend/packages/Upgrade/src/api/middlewares/ClientLibMiddleware.ts
+++ b/backend/packages/Upgrade/src/api/middlewares/ClientLibMiddleware.ts
@@ -1,16 +1,17 @@
 import { ErrorWithType } from './../errors/ErrorWithType';
 import * as express from 'express';
 import { ExpressMiddlewareInterface } from 'routing-controllers';
-import { LoggerInterface, Logger } from '../../decorators/Logger';
 import { SettingService } from '../services/SettingService';
 import { SERVER_ERROR } from 'upgrade_types';
 import * as jwt from 'jsonwebtoken';
 import isequal from 'lodash.isequal';
 import { env } from '../../env';
 import { AppRequest } from '../../types';
+import { Service } from 'typedi';
 
+@Service()
 export class ClientLibMiddleware implements ExpressMiddlewareInterface {
-  constructor(@Logger(__filename) private log: LoggerInterface, public settingService: SettingService) {}
+  constructor(public settingService: SettingService) {}
 
   public async use(req: AppRequest, res: express.Response, next: express.NextFunction): Promise<any> {
     try {
@@ -46,7 +47,6 @@ export class ClientLibMiddleware implements ExpressMiddlewareInterface {
         delete decodeToken.exp;
 
         if (isequal(decodeToken, { APIKey: key })) {
-          this.log.info('');
           next();
         } else {
           const error = new Error('Provided token is invalid');

--- a/backend/packages/Upgrade/src/api/middlewares/ErrorHandlerMiddleware.ts
+++ b/backend/packages/Upgrade/src/api/middlewares/ErrorHandlerMiddleware.ts
@@ -19,8 +19,6 @@ export class ErrorHandlerMiddleware implements ExpressErrorMiddlewareInterface {
     next: express.NextFunction
   ): Promise<void> {
     // It seems like some decorators handle setting the response (i.e. class-validators)
-    req.logger.info({ message: 'Insert Error in database', stack: error.stack});
-
     let message: string;
     let type: SERVER_ERROR;
 
@@ -107,7 +105,7 @@ export class ErrorHandlerMiddleware implements ExpressErrorMiddlewareInterface {
     experimentError.endPoint = req.originalUrl;
     experimentError.errorCode = error.httpCode;
     experimentError.type = type;
-
+    req.logger.error(experimentError);
     experimentError.type
       ? await this.errorService.create(experimentError, req.logger)
       : await Promise.resolve(error);

--- a/backend/packages/Upgrade/src/api/middlewares/ScheduleJobMiddleware.ts
+++ b/backend/packages/Upgrade/src/api/middlewares/ScheduleJobMiddleware.ts
@@ -4,18 +4,17 @@ import { ExpressMiddlewareInterface } from 'routing-controllers';
 import * as jwt from 'jsonwebtoken';
 import isequal from 'lodash.isequal';
 import { env } from '../../env';
-import { LoggerInterface, Logger } from '../../decorators/Logger';
 import { SERVER_ERROR } from 'upgrade_types';
 
 export class ScheduleJobMiddleware implements ExpressMiddlewareInterface {
-  constructor(@Logger(__filename) private log: LoggerInterface) {}
+  constructor() {}
 
   public use(req: express.Request, res: express.Response, next: express.NextFunction): any {
     try {
       const authorization = req.header('authorization');
       const token = authorization && authorization.replace('Bearer ', '').trim();
       if (!token) {
-        this.log.warn('Token is not present in request header');
+        req.logger.warn({ message: 'Token is not present in request header' });
         const error = new Error('Token is not present in request header');
         (error as any).type = SERVER_ERROR.TOKEN_NOT_PRESENT;
         throw error;

--- a/backend/packages/Upgrade/src/api/services/AnalyticsService.ts
+++ b/backend/packages/Upgrade/src/api/services/AnalyticsService.ts
@@ -24,12 +24,12 @@ import { MonitoredExperimentPointLogRepository } from '../repositories/MonitorEx
 import { In } from 'typeorm';
 import fs from 'fs';
 import { SERVER_ERROR } from 'upgrade_types';
-import { Logger, LoggerInterface } from '../../decorators/Logger';
 import { env } from '../../env';
 import { METRICS_JOIN_TEXT } from './MetricService';
 import { ErrorService } from './ErrorService';
 import { ExperimentAuditLogRepository } from '../repositories/ExperimentAuditLogRepository';
 import { UserRepository } from '../repositories/UserRepository';
+import { UpgradeLogger } from '../../lib/logger/UpgradeLogger';
 
 interface IEnrollmentStatByDate {
   date: string;
@@ -59,14 +59,13 @@ export class AnalyticsService {
     private userRepository: UserRepository,
     public awsService: AWSService,
     public errorService: ErrorService,
-    @Logger(__filename) private log: LoggerInterface
   ) {}
 
-  public async getEnrollments(experimentIds: string[]): Promise<any> {
+  public async getEnrollments(experimentIds: string[], logger: UpgradeLogger): Promise<any> {
     return this.analyticsRepository.getEnrollments(experimentIds);
   }
 
-  public async getDetailEnrollment(experimentId: string): Promise<IExperimentEnrollmentDetailStats> {
+  public async getDetailEnrollment(experimentId: string, logger: UpgradeLogger): Promise<IExperimentEnrollmentDetailStats> {
     const promiseArray = await Promise.all([
       this.experimentRepository.findOne(experimentId, { relations: ['conditions', 'partitions'] }),
       this.analyticsRepository.getDetailEnrollment(experimentId),
@@ -81,12 +80,12 @@ export class AnalyticsService {
       groupExclusion,
     ] = promiseArray[1];
 
-    this.log.info('individualEnrollmentByCondition', individualEnrollmentByCondition);
-    this.log.info('individualEnrollmentConditionAndPartition', individualEnrollmentConditionAndPartition);
-    this.log.info('groupEnrollmentByCondition', groupEnrollmentByCondition);
-    this.log.info('groupEnrollmentConditionAndPartition', groupEnrollmentConditionAndPartition);
-    this.log.info('individualExclusion', individualExclusion);
-    this.log.info('groupExclusion', groupExclusion);
+    logger.info({ message : `individualEnrollmentByCondition ${individualEnrollmentByCondition}` });
+    logger.info({ message : `individualEnrollmentConditionAndPartition ${individualEnrollmentConditionAndPartition}` });
+    logger.info({ message : `groupEnrollmentByCondition ${groupEnrollmentByCondition}` });
+    logger.info({ message : `groupEnrollmentConditionAndPartition ${groupEnrollmentConditionAndPartition}` });
+    logger.info({ message : `individualExclusion ${individualExclusion}` });
+    logger.info({ message : `groupExclusion ${groupExclusion}` });
 
     return {
       id: experimentId,
@@ -136,7 +135,8 @@ export class AnalyticsService {
   public async getEnrollmentStatsByDate(
     experimentId: string,
     dateRange: DATE_RANGE,
-    clientOffset: number
+    clientOffset: number, 
+    logger: UpgradeLogger
   ): Promise<IEnrollmentStatByDate[]> {
     const keyToReturn = {};
     switch (dateRange) {
@@ -237,8 +237,8 @@ export class AnalyticsService {
     });
   }
 
-  public async getCSVData(experimentId: string, email: string): Promise<string> {
-    this.log.info('Inside getCSVData', experimentId, email);
+  public async getCSVData(experimentId: string, email: string, logger: UpgradeLogger): Promise<string> {
+    logger.info({ message : `Inside getCSVData ${experimentId} , ${email}` });
     try {
       const timeStamp = new Date().toISOString();
       const folderPath = 'src/api/assets/files/';
@@ -317,7 +317,7 @@ export class AnalyticsService {
         },
       ];
 
-      this.log.info('Exporting Experiment Data');
+      logger.info({ message : 'Exporting Experiment Data' });
       let csv = new ObjectsToCsv(csvRows);
       const take = 50;
       for (let i = 1; i <= promiseData[2]; i = i + take) {
@@ -387,8 +387,9 @@ export class AnalyticsService {
               relations: ['monitoredExperimentPoint'],
             })
             .catch((error) => {
-              this.log.error('Error in finding monitored log document');
+              error.message = `Error while finding monitored experiment point logs document for export: ${error.message}`;
               error.type = SERVER_ERROR.QUERY_FAILED;
+              logger.error(error);
               throw error;
             }),
           this.experimentUserRepository
@@ -396,8 +397,9 @@ export class AnalyticsService {
               where: { id: In(experimentUsersArray) },
             })
             .catch((error) => {
-              this.log.error('Error in finding user documents in experimentUserRepository');
+              error.message = `Error while finding experiment user document for export in experimentUserRepository: ${error.message}`;
               error.type = SERVER_ERROR.QUERY_FAILED;
+              logger.error(error);
               throw error;
             }),
           ,
@@ -502,7 +504,7 @@ export class AnalyticsService {
       throw error;
     }
 
-    this.log.info('Completing experiment data export');
+    logger.info({ message : 'Completing experiment data export' });
 
     return '';
   }

--- a/backend/packages/Upgrade/src/api/services/AnalyticsService.ts
+++ b/backend/packages/Upgrade/src/api/services/AnalyticsService.ts
@@ -80,12 +80,12 @@ export class AnalyticsService {
       groupExclusion,
     ] = promiseArray[1];
 
-    logger.info({ message : `individualEnrollmentByCondition ${individualEnrollmentByCondition}` });
-    logger.info({ message : `individualEnrollmentConditionAndPartition ${individualEnrollmentConditionAndPartition}` });
-    logger.info({ message : `groupEnrollmentByCondition ${groupEnrollmentByCondition}` });
-    logger.info({ message : `groupEnrollmentConditionAndPartition ${groupEnrollmentConditionAndPartition}` });
-    logger.info({ message : `individualExclusion ${individualExclusion}` });
-    logger.info({ message : `groupExclusion ${groupExclusion}` });
+    logger.info({ message : 'individualEnrollmentByCondition', data: individualEnrollmentByCondition });
+    logger.info({ message : 'individualEnrollmentConditionAndPartition', data: individualEnrollmentConditionAndPartition });
+    logger.info({ message : 'groupEnrollmentByCondition', data: groupEnrollmentByCondition });
+    logger.info({ message : 'groupEnrollmentConditionAndPartition', data: groupEnrollmentConditionAndPartition });
+    logger.info({ message : 'individualExclusion', data: individualExclusion });
+    logger.info({ message : 'groupExclusion', data: groupExclusion });
 
     return {
       id: experimentId,

--- a/backend/packages/Upgrade/src/api/services/DataLogService.ts
+++ b/backend/packages/Upgrade/src/api/services/DataLogService.ts
@@ -1,9 +1,10 @@
 import { Service } from 'typedi';
-import { Logger, LoggerInterface } from '../../decorators/Logger';
+import { UpgradeLogger } from '../../lib/logger/UpgradeLogger';
 
 @Service()
 export class DataLogService {
-  constructor(@Logger(__filename) private log: LoggerInterface) {
-    this.log.info('test');
+  constructor() {
+    const logger =  new UpgradeLogger();
+    logger.info({ message: 'test logger' });
   }
 }

--- a/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
@@ -225,7 +225,7 @@ export class ExperimentAssignmentService {
   ): Promise<IExperimentAssignment[]> {
     const { logger, userDoc } = requestContext;
     logger.info({ message: `getAllExperimentConditions: User: ${userId}` });
-    const previewUser: PreviewUser = await this.previewUserService.findOne(userId);
+    const previewUser: PreviewUser = await this.previewUserService.findOne(userId, logger);
     const experimentUser: ExperimentUser = userDoc;
 
     // throw error if user not defined
@@ -499,8 +499,8 @@ export class ExperimentAssignmentService {
     } catch (err) {
       const error = err as ErrorWithType;
       error.details = 'Error in assignment'
-      logger.error({ message: error, stack: error.stack });
       error.type = SERVER_ERROR.ASSIGNMENT_ERROR;
+      logger.error(error);
       throw error;
     }
   }

--- a/backend/packages/Upgrade/src/api/services/ExperimentUserService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentUserService.ts
@@ -2,7 +2,6 @@ import { UpgradeLogger } from './../../lib/logger/UpgradeLogger';
 import { Service } from 'typedi';
 import { OrmRepository } from 'typeorm-typedi-extensions';
 import { ExperimentUserRepository } from '../repositories/ExperimentUserRepository';
-import { Logger, LoggerInterface } from '../../decorators/Logger';
 import { ExperimentUser } from '../models/ExperimentUser';
 import { ExperimentRepository } from '../repositories/ExperimentRepository';
 import { ASSIGNMENT_UNIT, CONSISTENCY_RULE, EXPERIMENT_STATE, SERVER_ERROR } from 'upgrade_types';
@@ -20,16 +19,17 @@ export class ExperimentUserService {
     @OrmRepository() private individualAssignmentRepository: IndividualAssignmentRepository,
     @OrmRepository() private individualExclusionRepository: IndividualExclusionRepository,
     @OrmRepository() private groupExclusionRepository: GroupExclusionRepository,
-    @Logger(__filename) private log: LoggerInterface
   ) {}
 
-  public find(): Promise<ExperimentUser[]> {
-    this.log.info(`Find all users`);
-    return this.userRepository.find();
+  public find(logger: UpgradeLogger): Promise<ExperimentUser[]> {
+    if (logger) {
+      logger.info({ message: `Find all users` });
+    }
+      return this.userRepository.find();
   }
 
-  public findOne(id: string): Promise<ExperimentUser> {
-    this.log.info(`Find user by id => ${id}`);
+  public findOne(id: string, logger: UpgradeLogger): Promise<ExperimentUser> {
+    logger.info({ message: `Find user by id => ${id}` });
     return this.userRepository.findOne({ id });
   }
 
@@ -179,8 +179,8 @@ export class ExperimentUserService {
     return this.userRepository.save(newDocument);
   }
 
-  public update(id: string, user: ExperimentUser): Promise<ExperimentUser> {
-    this.log.info('Update a user => ', user.toString());
+  public update(id: string, user: ExperimentUser, logger: UpgradeLogger): Promise<ExperimentUser> {
+    logger.info({ message: `Update a user ${user.toString()}` });
     user.id = id;
     return this.userRepository.save(user);
   }
@@ -216,7 +216,9 @@ export class ExperimentUserService {
   }
 
   public async getOriginalUserDoc(userId: string, logger: UpgradeLogger): Promise<ExperimentUser | null> {
-    logger.info({ message: `Find original user for userId ${userId}` });
+    if (logger) {
+      logger.info({ message: `Find original user for userId ${userId}` });
+    }
     const userDoc = await this.userRepository.find({
       where: { id: userId },
       relations: ['originalUser'],

--- a/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
+++ b/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
@@ -1,5 +1,4 @@
 import { Service } from 'typedi';
-import { Logger, LoggerInterface } from '../../decorators/Logger';
 import { FeatureFlag } from '../models/FeatureFlag';
 import { OrmRepository } from 'typeorm-typedi-extensions';
 import { FeatureFlagRepository } from '../repositories/FeatureFlagRepository';
@@ -19,7 +18,6 @@ import { UpgradeLogger } from '../../lib/logger/UpgradeLogger';
 @Service()
 export class FeatureFlagService {
   constructor(
-    @Logger(__filename) private log: LoggerInterface,
     @OrmRepository() private featureFlagRepository: FeatureFlagRepository,
     @OrmRepository() private flagVariationRepository: FlagVariationRepository
   ) {}
@@ -29,8 +27,8 @@ export class FeatureFlagService {
     return this.featureFlagRepository.find({ relations: ['variations'] });
   }
 
-  public create(flag: FeatureFlag, currentUser: User): Promise<FeatureFlag> {
-    this.log.info('Create a new feature flag');
+  public create(flag: FeatureFlag, currentUser: User, logger: UpgradeLogger): Promise<FeatureFlag> {
+    logger.info({ message : 'Create a new feature flag' });
     return this.addFeatureFlagInDB(flag, currentUser);
   }
 
@@ -41,10 +39,11 @@ export class FeatureFlagService {
   public findPaginated(
     skip: number,
     take: number,
+    logger: UpgradeLogger,
     searchParams?: IFeatureFlagSearchParams,
     sortParams?: IFeatureFlagSortParams
   ): Promise<FeatureFlag[]> {
-    this.log.info('Find paginated Feature flags');
+    logger.info({ message : 'Find paginated Feature flags' });
 
     let queryBuilder = this.featureFlagRepository
       .createQueryBuilder('feature_flag')
@@ -66,8 +65,8 @@ export class FeatureFlagService {
     return queryBuilder.getMany();
   }
 
-  public async delete(featureFlagId: string, currentUser: User): Promise<FeatureFlag | undefined> {
-    this.log.info('Delete Feature Flag => ', featureFlagId);
+  public async delete(featureFlagId: string, logger: UpgradeLogger): Promise<FeatureFlag | undefined> {
+    logger.info({ message : `Delete Feature Flag => ${featureFlagId}` });
     const featureFlag = await this.featureFlagRepository.find({
       where: { id: featureFlagId },
       relations: ['variations'],
@@ -82,14 +81,14 @@ export class FeatureFlagService {
     return undefined;
   }
 
-  public async updateState(flagId: string, status: boolean): Promise<FeatureFlag> {
+  public async updateState(flagId: string, status: boolean, logger: UpgradeLogger): Promise<FeatureFlag> {
     // TODO: Add log for updating flag state
     const updatedState = await this.featureFlagRepository.updateState(flagId, status);
     return updatedState;
   }
 
-  public update(id: string, flag: FeatureFlag, currentUser: User): Promise<FeatureFlag> {
-    this.log.info('Update a Feature Flag => ', flag.toString());
+  public update(id: string, flag: FeatureFlag, currentUser: User, logger: UpgradeLogger): Promise<FeatureFlag> {
+    logger.info({ message : `Update a Feature Flag => ${flag.toString()}` });
     // TODO add entry in log of updating feature flag
     return this.updateFeatureFlagInDB(flag, currentUser);
   }

--- a/backend/packages/Upgrade/src/api/services/MetricService.ts
+++ b/backend/packages/Upgrade/src/api/services/MetricService.ts
@@ -1,5 +1,4 @@
 import { Service } from 'typedi';
-import { Logger, LoggerInterface } from '../../decorators/Logger';
 import { OrmRepository } from 'typeorm-typedi-extensions';
 import { MetricRepository } from '../repositories/MetricRepository';
 import { Metric } from '../models/Metric';
@@ -12,13 +11,12 @@ export const METRICS_JOIN_TEXT = '@__@';
 @Service()
 export class MetricService {
   constructor(
-    @Logger(__filename) private log: LoggerInterface,
     @OrmRepository() private metricRepository: MetricRepository,
     public settingService: SettingService
   ) {}
 
-  public async getAllMetrics(): Promise<IMetricUnit[]> {
-    this.log.info('Get all metrics');
+  public async getAllMetrics( logger: UpgradeLogger): Promise<IMetricUnit[]> {
+    logger.info({ message : 'Get all metrics' });
     // check permission for metrics
     const metricData = await this.metricRepository.find();
     return this.metricDocumentToJson(metricData);
@@ -26,26 +24,26 @@ export class MetricService {
 
   public async saveAllMetrics(metrics: Array<IGroupMetric | ISingleMetric>, logger: UpgradeLogger): Promise<Metric[]> {
     logger.info({ message: 'Save all metrics' });
-    return await this.addAllMetrics(metrics);
+    return await this.addAllMetrics(metrics, logger);
   }
 
-  public async upsertAllMetrics(metrics: Array<IGroupMetric | ISingleMetric>): Promise<IMetricUnit[]> {
-    this.log.info('Upsert all metrics');
-    const upsertedMetrics = await this.addAllMetrics(metrics);
+  public async upsertAllMetrics(metrics: Array<IGroupMetric | ISingleMetric>, logger: UpgradeLogger): Promise<IMetricUnit[]> {
+    logger.info({ message : 'Upsert all metrics' });
+    const upsertedMetrics = await this.addAllMetrics(metrics, logger);
     return this.metricDocumentToJson(upsertedMetrics);
   }
 
-  public async deleteMetric(key: string): Promise<IMetricUnit[]> {
-    this.log.info('Delete metric by key ', key);
+  public async deleteMetric(key: string, logger: UpgradeLogger): Promise<IMetricUnit[]> {
+    logger.info({ message : `Delete metric by key ${key}` });
     await this.metricRepository.deleteMetricsByKeys(key, METRICS_JOIN_TEXT);
     const rootKey = key.split(METRICS_JOIN_TEXT);
     const updatedMetric = await this.metricRepository.getMetricsByKeys(rootKey[0], METRICS_JOIN_TEXT);
     return this.metricDocumentToJson(updatedMetric);
   }
 
-  private async addAllMetrics(metrics: Array<IGroupMetric | ISingleMetric>): Promise<Metric[]> {
+  private async addAllMetrics(metrics: Array<IGroupMetric | ISingleMetric>, logger: UpgradeLogger): Promise<Metric[]> {
     // check permission for metrics
-    const isAllowed = await this.checkMetricsPermission();
+    const isAllowed = await this.checkMetricsPermission(logger);
     if (!isAllowed) {
       const error = new Error('Metrics filter not enabled');
       (error as any).type = SERVER_ERROR.INVALID_TOKEN;
@@ -62,8 +60,8 @@ export class MetricService {
     return this.metricRepository.save(metricDoc);
   }
 
-  private async checkMetricsPermission(): Promise<boolean> {
-    const setting = await this.settingService.getClientCheck(new UpgradeLogger());
+  private async checkMetricsPermission(logger: UpgradeLogger): Promise<boolean> {
+    const setting = await this.settingService.getClientCheck(logger);
     return setting.toFilterMetric;
   }
 

--- a/backend/packages/Upgrade/src/api/services/SettingService.ts
+++ b/backend/packages/Upgrade/src/api/services/SettingService.ts
@@ -1,5 +1,4 @@
 import { Service } from 'typedi';
-import { Logger, LoggerInterface } from '../../decorators/Logger';
 import { OrmRepository } from 'typeorm-typedi-extensions';
 import { SettingRepository } from '../repositories/SettingRepository';
 import { Setting } from '../models/Setting';
@@ -8,12 +7,11 @@ import { UpgradeLogger } from '../../lib/logger/UpgradeLogger';
 @Service()
 export class SettingService {
   constructor(
-    @Logger(__filename) private log: LoggerInterface,
     @OrmRepository() private settingRepository: SettingRepository
   ) {}
 
-  public async setClientCheck(checkAuth: boolean | null, filterMetric: boolean | null): Promise<Setting> {
-    this.log.info(`Update project setting: checkAuth ${checkAuth}, filterMetric ${filterMetric}`);
+  public async setClientCheck(checkAuth: boolean | null, filterMetric: boolean | null, logger: UpgradeLogger): Promise<Setting> {
+    logger.info({ message: `Update project setting: checkAuth ${checkAuth}, filterMetric ${filterMetric}` });
     const settingDoc: Setting = await this.settingRepository.findOne();
     const newDoc = {
       ...settingDoc,

--- a/backend/packages/Upgrade/src/api/services/SupportService.ts
+++ b/backend/packages/Upgrade/src/api/services/SupportService.ts
@@ -1,5 +1,4 @@
 import { Service } from 'typedi';
-import { Logger, LoggerInterface } from '../../decorators/Logger';
 import { ExperimentAssignmentService } from './ExperimentAssignmentService';
 import { IExperimentAssignment } from 'upgrade_types';
 import { UpgradeLogger } from '../../lib/logger/UpgradeLogger';
@@ -8,15 +7,16 @@ import { ExperimentUserService } from './ExperimentUserService';
 @Service()
 export class SupportService {
   constructor(
-    @Logger(__filename) private log: LoggerInterface,
     public experimentAssignmentService: ExperimentAssignmentService,
     public experimentUserService: ExperimentUserService
   ) {}
 
-  public async getAssignments(userId: string, context: string): Promise<IExperimentAssignment[]> {
-    this.log.info('Get all assignments');
+  public async getAssignments(userId: string, context: string, logger: UpgradeLogger): Promise<IExperimentAssignment[]> {
+    if (logger) {
+      logger.info({ message: 'Get all assignments' });
+    }
     // getOriginalUserDoc
-    let experimentUserDoc = await this.experimentUserService.getOriginalUserDoc(userId, new UpgradeLogger());
+    let experimentUserDoc = await this.experimentUserService.getOriginalUserDoc(userId, logger);
     return this.experimentAssignmentService.getAllExperimentConditions(
       userId,
       context,

--- a/backend/packages/Upgrade/src/api/services/UserService.ts
+++ b/backend/packages/Upgrade/src/api/services/UserService.ts
@@ -1,30 +1,30 @@
 import { Service } from 'typedi';
 import { OrmRepository } from 'typeorm-typedi-extensions';
-import { Logger, LoggerInterface } from '../../decorators/Logger';
 import { UserRepository } from '../repositories/UserRepository';
 import { User } from '../models/User';
 import { UserRole } from 'upgrade_types';
 import { IUserSearchParams, IUserSortParams, USER_SEARCH_SORT_KEY } from '../controllers/validators/UserPaginatedParamsValidator';
 import { systemUserDoc } from '../../init/seed/systemUser';
+import { UpgradeLogger } from '../../lib/logger/UpgradeLogger';
 
 @Service()
 export class UserService {
   constructor(
     @OrmRepository() private userRepository: UserRepository,
-    @Logger(__filename) private log: LoggerInterface
   ) {}
 
-  public async upsertUser(user: User): Promise<User> {
-    this.log.info('Upsert a new user => ', JSON.stringify(user, undefined, 2));
+  public async upsertUser(user: User, logger: UpgradeLogger): Promise<User> {
+    logger.info({ message: `Upsert a new user => ${JSON.stringify(user, undefined, 2)}` });
     return this.userRepository.upsertUser(user);
   }
 
-  public find(): Promise<User[]> {
+  public find(logger: UpgradeLogger): Promise<User[]> {
+    logger.info({ message: 'Find all users' });
     return this.userRepository.find();
   }
 
-  public async getTotalCount(): Promise<number> {
-    this.log.info('Find a count of total users');
+  public async getTotalCount(logger: UpgradeLogger): Promise<number> {
+    logger.info({ message: 'Find a count of total users' });
     const totalUsers = await this.userRepository.count() - 1; // Subtract system User
     return totalUsers;
   }
@@ -32,10 +32,11 @@ export class UserService {
   public async findPaginated(
     skip: number,
     take: number,
+    logger: UpgradeLogger,
     searchParams?: IUserSearchParams,
     sortParams?: IUserSortParams
   ): Promise<any[]> {
-    this.log.info(`Find paginated Users`);
+    logger.info({ message: `Find paginated Users` });
     let queryBuilder  = this.userRepository
     .createQueryBuilder('users');
 

--- a/backend/packages/Upgrade/src/auth/AuthService.ts
+++ b/backend/packages/Upgrade/src/auth/AuthService.ts
@@ -4,7 +4,6 @@ import { OrmRepository } from 'typeorm-typedi-extensions';
 
 import { User } from '../api/models/User';
 import { UserRepository } from '../api/repositories/UserRepository';
-import { Logger, LoggerInterface } from '../decorators/Logger';
 import { OAuth2Client } from 'google-auth-library';
 import { env } from '../env';
 import { SERVER_ERROR } from 'upgrade_types';
@@ -12,12 +11,11 @@ import { SERVER_ERROR } from 'upgrade_types';
 @Service()
 export class AuthService {
   constructor(
-    @Logger(__filename) private log: LoggerInterface,
     @OrmRepository() private userRepository: UserRepository
   ) {}
 
   public parseBasicAuthFromRequest(req: express.Request): string {
-    this.log.info('Inside parseBasicAuthFromRequest');
+    req.logger.info({ message: 'Inside parseBasicAuthFromRequest' });
 
     const authorization = req.header('authorization');
     return authorization && authorization.replace('Bearer ', '').trim();
@@ -25,14 +23,14 @@ export class AuthService {
 
   public async validateUser(token: string, request: express.Request): Promise<User> {
     const client = new OAuth2Client(env.google.clientId);
-    this.log.info(`Validating ID Token`);
+    request.logger.info({ message: 'Validating ID Token' });
     const ticket = await client.verifyIdToken({
       idToken: token,
       audience: env.google.clientId, // Specify the CLIENT_ID of the app that accesses the backend
       // Or, if multiple clients access the backend:
       // [CLIENT_ID_1, CLIENT_ID_2, CLIENT_ID_3]
     });
-    this.log.info(`Token Validated`);
+    request.logger.info({ message: 'Token Validated' });
 
     const payload = ticket.getPayload();
 
@@ -40,15 +38,15 @@ export class AuthService {
     const email = payload.email;
     const hd = payload.hd;
 
-    this.log.info('hd', hd);
-    this.log.info('env.google.domainName', env.google.domainName);
-    this.log.info(`Validating domain name`);
+    request.logger.info({ message: `hd ${hd}` });
+    request.logger.info({ message: `env.google.domainName ${env.google.domainName}` });
+    request.logger.info({ message: 'Validating domain name' });
     if (env.google.domainName && env.google.domainName !== '' && env.google.domainName !== hd) {
       const error: any = new Error(`User domain is not same as required ${env.google.domainName}`);
       error.type = SERVER_ERROR.USER_NOT_FOUND;
       throw error;
     }
-    this.log.info(`Domain name validated`);
+    request.logger.info({ message: 'Domain name validated' });
 
     if (this.isLoginUserRequestPath(request)) {
       // No need to fetch user document
@@ -59,7 +57,7 @@ export class AuthService {
     // add local cache for validating user for each request
     const document = await this.userRepository.find({ email });
     if (document.length === 0) {
-      this.log.info(`User not found in database`);
+      request.logger.info({ message: 'User not found in database' });
       const error: any = 'User not found in the database';
       error.type = SERVER_ERROR.USER_NOT_FOUND;
       throw error;

--- a/backend/packages/Upgrade/src/init/seed/EnableMetricFiltering.ts
+++ b/backend/packages/Upgrade/src/init/seed/EnableMetricFiltering.ts
@@ -7,5 +7,5 @@ export async function enableMetricFiltering(): Promise<Setting> {
   const settingService: SettingService = Container.get(SettingService);
   const settingDoc = await settingService.getClientCheck(new UpgradeLogger());
   // always enable metrics filter
-  return settingService.setClientCheck(settingDoc.toCheckAuth, true);
+  return settingService.setClientCheck(settingDoc.toCheckAuth, true, new UpgradeLogger());
 }

--- a/backend/packages/Upgrade/src/init/seed/systemUser.ts
+++ b/backend/packages/Upgrade/src/init/seed/systemUser.ts
@@ -2,6 +2,7 @@ import { User } from '../../api/models/User';
 import Container from 'typedi';
 import { UserService } from '../../api/services/UserService';
 import { env } from '../../env';
+import { UpgradeLogger } from '../../lib/logger/UpgradeLogger';
 
 export const systemUserDoc = {
   email: 'system@gmail.com',
@@ -17,8 +18,8 @@ export function CreateSystemUser(): Promise<User> {
   // Create default admin user in system
   if (env.initialization.adminUsers && env.initialization.adminUsers.length) {
     env.initialization.adminUsers.forEach(async (adminUser) => {
-      await userService.upsertUser(adminUser as any);
+      await userService.upsertUser(adminUser as any, new UpgradeLogger());
     });
   }
-  return userService.upsertUser(systemUserDoc as any);
+  return userService.upsertUser(systemUserDoc as any, new UpgradeLogger());
 }

--- a/backend/packages/Upgrade/test/integration/EndingCriteria/GroupAndParticipants.ts
+++ b/backend/packages/Upgrade/test/integration/EndingCriteria/GroupAndParticipants.ts
@@ -15,12 +15,12 @@ export default async function GroupAndParticipants() {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = groupAndParticipantsExperiment;
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -61,10 +61,10 @@ export default async function GroupAndParticipants() {
 
   // change experiment status to Enrolling
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -117,7 +117,7 @@ export default async function GroupAndParticipants() {
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName2, experimentPoint2);
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -146,7 +146,7 @@ export default async function GroupAndParticipants() {
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[3].id, experimentName1, experimentPoint1);
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -169,7 +169,7 @@ export default async function GroupAndParticipants() {
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[3].id, experimentName2, experimentPoint2);
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -198,7 +198,7 @@ export default async function GroupAndParticipants() {
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[4].id, experimentName1, experimentPoint1);
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -221,7 +221,7 @@ export default async function GroupAndParticipants() {
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[4].id, experimentName2, experimentPoint2);
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -250,7 +250,7 @@ export default async function GroupAndParticipants() {
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[5].id, experimentName1, experimentPoint1);
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -273,7 +273,7 @@ export default async function GroupAndParticipants() {
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[4].id, experimentName2, experimentPoint2);
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/EndingCriteria/ParticipantsOnly.ts
+++ b/backend/packages/Upgrade/test/integration/EndingCriteria/ParticipantsOnly.ts
@@ -15,12 +15,12 @@ export default async function ParticipantsOnly() {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = participantsOnlyExperiment;
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -60,10 +60,10 @@ export default async function ParticipantsOnly() {
 
   // change experiment status to Enrolling
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -92,7 +92,7 @@ export default async function ParticipantsOnly() {
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[1].id, experimentName1, experimentPoint1);
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -116,7 +116,7 @@ export default async function ParticipantsOnly() {
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[1].id, experimentName2, experimentPoint2);
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -145,7 +145,7 @@ export default async function ParticipantsOnly() {
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName1, experimentPoint1);
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -168,7 +168,7 @@ export default async function ParticipantsOnly() {
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName2, experimentPoint2);
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/EndingCriteria/index.ts
+++ b/backend/packages/Upgrade/test/integration/EndingCriteria/index.ts
@@ -11,7 +11,7 @@ const initialChecks = async () => {
   const checkService = Container.get<CheckService>(CheckService);
 
   // check all the tables are empty
-  const users = await userService.find();
+  const users = await userService.find(new UpgradeLogger());
   expect(users.length).toEqual(0);
 
   const monitoredPoints = await checkService.getAllMarkedExperimentPoints();
@@ -33,7 +33,7 @@ const initialChecks = async () => {
   await userService.create(experimentUsers as any, new UpgradeLogger());
 
   // get all user here
-  const userList = await userService.find();
+  const userList = await userService.find(new UpgradeLogger());
   expect(userList.length).toBe(experimentUsers.length);
   experimentUsers.map((user) => {
     expect(userList).toContainEqual(user);

--- a/backend/packages/Upgrade/test/integration/Experiment/auditLogs/Main.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/auditLogs/Main.ts
@@ -9,6 +9,7 @@ import { AuditService } from '../../../../src/api/services/AuditService';
 import { EXPERIMENT_STATE, EXPERIMENT_LOG_TYPE } from 'upgrade_types';
 import { UserService } from '../../../../src/api/services/UserService';
 import { systemUser } from '../../mockData/user/index';
+import { UpgradeLogger } from '../../../../src/lib/logger/UpgradeLogger';
 
 export default async function UpdateExperimentState(): Promise<void> {
   // const logger = new WinstonLogger(__filename);
@@ -17,14 +18,14 @@ export default async function UpdateExperimentState(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = scheduleJobUpdateExperiment;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  const experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  const experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -52,7 +53,7 @@ export default async function UpdateExperimentState(): Promise<void> {
     ...experimentObject,
     name: 'Updated Experiment',
   };
-  const updateExperiment = await experimentService.update(updatedExperiment.id, updatedExperiment as any, user);
+  const updateExperiment = await experimentService.update(updatedExperiment.id, updatedExperiment as any, user, new UpgradeLogger());
 
   expect(updateExperiment).toEqual(
     // expect.arrayContaining([
@@ -79,7 +80,7 @@ export default async function UpdateExperimentState(): Promise<void> {
 
   // change experiment status to Enrolling
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   await new Promise(r => setTimeout(r, 1000));
 

--- a/backend/packages/Upgrade/test/integration/Experiment/conditionAndPartition/Condition.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/conditionAndPartition/Condition.ts
@@ -4,6 +4,7 @@ import { ExperimentService } from '../../../../src/api/services/ExperimentServic
 import { Container } from 'typedi';
 import { UserService } from '../../../../src/api/services/UserService';
 import { systemUser } from '../../mockData/user/index';
+import { UpgradeLogger } from '../../../../src/lib/logger/UpgradeLogger';
 
 export default async function NoPartitionPoint(): Promise<void> {
   // const logger = new WinstonLogger(__filename);
@@ -13,11 +14,11 @@ export default async function NoPartitionPoint(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  const experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  const experiments = await experimentService.find(new UpgradeLogger());
 
   // sort conditions
   experiments[0].conditions.sort((a,b) => {
@@ -69,7 +70,7 @@ export default async function NoPartitionPoint(): Promise<void> {
     newExperimentDoc.conditions[index] = newCondition;
   });
 
-  const updatedExperimentDoc = await experimentService.update(newExperimentDoc.id, newExperimentDoc as any, user);
+  const updatedExperimentDoc = await experimentService.update(newExperimentDoc.id, newExperimentDoc as any, user, new UpgradeLogger());
 
   expect(updatedExperimentDoc.conditions).toEqual(
     expect.arrayContaining([

--- a/backend/packages/Upgrade/test/integration/Experiment/conditionAndPartition/Partition.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/conditionAndPartition/Partition.ts
@@ -4,6 +4,7 @@ import { ExperimentService } from '../../../../src/api/services/ExperimentServic
 import { Container } from 'typedi';
 import { UserService } from '../../../../src/api/services/UserService';
 import { systemUser } from '../../mockData/user/index';
+import { UpgradeLogger } from '../../../../src/lib/logger/UpgradeLogger';
 
 export default async function NoPartitionPoint(): Promise<void> {
   // const logger = new WinstonLogger(__filename);
@@ -13,11 +14,11 @@ export default async function NoPartitionPoint(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  const experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  const experiments = await experimentService.find(new UpgradeLogger());
 
   // sort partitions
   experiments[0].partitions.sort((a,b) => {
@@ -73,7 +74,7 @@ export default async function NoPartitionPoint(): Promise<void> {
     newExperimentDoc.partitions[index] = newPartition;
   });
 
-  const updatedExperimentDoc = await experimentService.update(newExperimentDoc.id, newExperimentDoc as any, user);
+  const updatedExperimentDoc = await experimentService.update(newExperimentDoc.id, newExperimentDoc as any, user, new UpgradeLogger());
 
   expect(updatedExperimentDoc.partitions).toEqual(
     expect.arrayContaining([

--- a/backend/packages/Upgrade/test/integration/Experiment/conditionAndPartition/index.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/conditionAndPartition/index.ts
@@ -11,7 +11,7 @@ const initialChecks = async () => {
   const checkService = Container.get<CheckService>(CheckService);
 
   // check all the tables are empty
-  const users = await userService.find();
+  const users = await userService.find(new UpgradeLogger());
   expect(users.length).toEqual(0);
 
   const monitoredPoints = await checkService.getAllMarkedExperimentPoints();
@@ -33,7 +33,7 @@ const initialChecks = async () => {
   await userService.create(experimentUsers as any, new UpgradeLogger());
 
   // get all user here
-  const userList = await userService.find();
+  const userList = await userService.find(new UpgradeLogger());
   expect(userList.length).toBe(experimentUsers.length);
   experimentUsers.map((user) => {
     expect(userList).toContainEqual(user);

--- a/backend/packages/Upgrade/test/integration/Experiment/conditionalStateChange/GroupUserCount.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/conditionalStateChange/GroupUserCount.ts
@@ -20,7 +20,7 @@ export default async function GroupUserCount(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject: any = groupAssignmentWithGroupConsistencyExperiment;
@@ -30,8 +30,8 @@ export default async function GroupUserCount(): Promise<void> {
   };
 
   // create experiment 1
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -61,10 +61,10 @@ export default async function GroupUserCount(): Promise<void> {
 
   // change experiment status to Enrolling
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -85,7 +85,7 @@ export default async function GroupUserCount(): Promise<void> {
   markedExperimentPoint = await markExperimentPoint(experimentUsers[1].id, experimentName, experimentPoint, condition, new UpgradeLogger());
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[1].id, experimentName, experimentPoint);
 
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -114,7 +114,7 @@ export default async function GroupUserCount(): Promise<void> {
   markedExperimentPoint = await markExperimentPoint(experimentUsers[2].id, experimentName, experimentPoint, condition, new UpgradeLogger());
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName, experimentPoint);
 
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -135,7 +135,7 @@ export default async function GroupUserCount(): Promise<void> {
   markedExperimentPoint = await markExperimentPoint(experimentUsers[3].id, experimentName, experimentPoint, condition, new UpgradeLogger());
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[3].id, experimentName, experimentPoint);
 
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -156,7 +156,7 @@ export default async function GroupUserCount(): Promise<void> {
   markedExperimentPoint = await markExperimentPoint(experimentUsers[4].id, experimentName, experimentPoint, condition, new UpgradeLogger());
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[4].id, experimentName, experimentPoint);
 
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -177,7 +177,7 @@ export default async function GroupUserCount(): Promise<void> {
   markedExperimentPoint = await markExperimentPoint(experimentUsers[5].id, experimentName, experimentPoint, condition, new UpgradeLogger());
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[5].id, experimentName, experimentPoint);
 
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/Experiment/conditionalStateChange/IndividualUserCount.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/conditionalStateChange/IndividualUserCount.ts
@@ -20,7 +20,7 @@ export default async function IndividualUserCount(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject: any = individualAssignmentExperiment;
@@ -29,8 +29,8 @@ export default async function IndividualUserCount(): Promise<void> {
   };
 
   // create experiment 1
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -57,10 +57,10 @@ export default async function IndividualUserCount(): Promise<void> {
 
   // change experiment status to Enrolling
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -81,7 +81,7 @@ export default async function IndividualUserCount(): Promise<void> {
   markedExperimentPoint = await markExperimentPoint(experimentUsers[1].id, experimentName, experimentPoint, condition, new UpgradeLogger());
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[1].id, experimentName, experimentPoint);
 
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -110,7 +110,7 @@ export default async function IndividualUserCount(): Promise<void> {
   markedExperimentPoint = await markExperimentPoint(experimentUsers[2].id, experimentName, experimentPoint, condition, new UpgradeLogger());
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName, experimentPoint);
 
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -131,7 +131,7 @@ export default async function IndividualUserCount(): Promise<void> {
   markedExperimentPoint = await markExperimentPoint(experimentUsers[3].id, experimentName, experimentPoint, condition, new UpgradeLogger());
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[3].id, experimentName, experimentPoint);
 
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/Experiment/conditionalStateChange/index.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/conditionalStateChange/index.ts
@@ -11,7 +11,7 @@ const initialChecks = async () => {
   const checkService = Container.get<CheckService>(CheckService);
 
   // check all the tables are empty
-  const users = await userService.find();
+  const users = await userService.find(new UpgradeLogger());
   expect(users.length).toEqual(0);
 
   const monitoredPoints = await checkService.getAllMarkedExperimentPoints();
@@ -33,7 +33,7 @@ const initialChecks = async () => {
   await userService.create(experimentUsers as any, new UpgradeLogger());
 
   // get all user here
-  const userList = await userService.find();
+  const userList = await userService.find(new UpgradeLogger());
   expect(userList.length).toBe(experimentUsers.length);
   experimentUsers.map((user) => {
     expect(userList).toContainEqual(user);

--- a/backend/packages/Upgrade/test/integration/Experiment/dataLog/CreateLog.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/dataLog/CreateLog.ts
@@ -26,11 +26,11 @@ export default async function CreateLog(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
   const logRepository = getRepository(Log);
 
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -46,7 +46,7 @@ export default async function CreateLog(): Promise<void> {
   const experimentName = experimentObject.partitions[0].expId;
   const experimentPoint = experimentObject.partitions[0].expPoint;
 
-  await settingService.setClientCheck(false, true);
+  await settingService.setClientCheck(false, true, new UpgradeLogger());
 
   await metricService.saveAllMetrics(metrics as any, new UpgradeLogger());
 
@@ -216,7 +216,7 @@ export default async function CreateLog(): Promise<void> {
     ],
   };
 
-  await experimentService.update(experimentObject.id, experimentObject as any, user);
+  await experimentService.update(experimentObject.id, experimentObject as any, user, new UpgradeLogger());
 
   // log data here
   await experimentAssignmentService.dataLog(experimentUser.id, jsonData, { logger: new UpgradeLogger(), userDoc: experimentUserDoc});

--- a/backend/packages/Upgrade/test/integration/Experiment/dataLog/LogOperations.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/dataLog/LogOperations.ts
@@ -28,11 +28,11 @@ export default async function LogOperations(): Promise<void> {
   const settingService = Container.get<SettingService>(SettingService);
   const queryService = Container.get<QueryService>(QueryService);
 
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -48,7 +48,7 @@ export default async function LogOperations(): Promise<void> {
   const experimentName = experimentObject.partitions[0].expId;
   const experimentPoint = experimentObject.partitions[0].expPoint;
 
-  await settingService.setClientCheck(false, true);
+  await settingService.setClientCheck(false, true, new UpgradeLogger());
 
   await metricService.saveAllMetrics(metrics as any, new UpgradeLogger());
 
@@ -57,10 +57,10 @@ export default async function LogOperations(): Promise<void> {
 
   // change experiment status to Enrolling
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -204,7 +204,7 @@ export default async function LogOperations(): Promise<void> {
     ],
   };
 
-  await experimentService.update(experimentObject.id, experimentObject as any, user);
+  await experimentService.update(experimentObject.id, experimentObject as any, user, new UpgradeLogger());
   // getOriginalUserDoc
   let experimentUserDoc = await experimentUserService.getOriginalUserDoc(experimentUsers[0].id, new UpgradeLogger());
   // log data here
@@ -332,7 +332,7 @@ experimentUserDoc = await experimentUserService.getOriginalUserDoc(experimentUse
     },
   ], { logger: new UpgradeLogger(), userDoc: experimentUserDoc});
 
-  const allQuery = await queryService.find();
+  const allQuery = await queryService.find(new UpgradeLogger());
   expect(allQuery).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -498,7 +498,7 @@ experimentUserDoc = await experimentUserService.getOriginalUserDoc(experimentUse
   // tslint:disable-next-line:prefer-for-of
   for (let i = 0; i < allQuery.length; i++) {
     const query = allQuery[i];
-    const queryResult = await queryService.analyse([query.id]);
+    const queryResult = await queryService.analyse([query.id], new UpgradeLogger());
     const res = reduceResult(queryResult[0].result);
     let expectedValue;
     // Used for console output

--- a/backend/packages/Upgrade/test/integration/Experiment/dataLog/RepeatedMeasure.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/dataLog/RepeatedMeasure.ts
@@ -30,11 +30,11 @@ export default async function RepeatedMeasure(): Promise<void> {
   const queryService = Container.get<QueryService>(QueryService);
   const logRepository = getRepository(Log);
 
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -50,16 +50,16 @@ export default async function RepeatedMeasure(): Promise<void> {
   const experimentName = experimentObject.partitions[0].expId;
   const experimentPoint = experimentObject.partitions[0].expPoint;
 
-  await settingService.setClientCheck(false, true);
+  await settingService.setClientCheck(false, true, new UpgradeLogger());
 
   await metricService.saveAllMetrics(metrics as any, new UpgradeLogger());
 
   // change experiment status to Enrolling
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -192,7 +192,7 @@ export default async function RepeatedMeasure(): Promise<void> {
     ],
   };
 
-  await experimentService.update(experimentObject.id, experimentObject as any, user);
+  await experimentService.update(experimentObject.id, experimentObject as any, user, new UpgradeLogger());
 
   const experimentUser = experimentUsers[0];
 
@@ -267,15 +267,15 @@ export default async function RepeatedMeasure(): Promise<void> {
   });
   expect(logData.length).toEqual(2);
 
-  const queries = await queryService.find();
+  const queries = await queryService.find(new UpgradeLogger());
   // now do the query
-  let queryResult = await queryService.analyse([queries[0].id]);
+  let queryResult = await queryService.analyse([queries[0].id], new UpgradeLogger());
   expect(parseInt(queryResult[0].result[0].result, 10)).toEqual(20);
 
-  queryResult = await queryService.analyse([queries[1].id]);
+  queryResult = await queryService.analyse([queries[1].id], new UpgradeLogger());
   expect(parseInt(queryResult[0].result[0].result, 10)).toEqual(10);
 
-  queryResult = await queryService.analyse([queries[2].id]);
+  queryResult = await queryService.analyse([queries[2].id], new UpgradeLogger());
   expect(parseInt(queryResult[0].result[0].result, 10)).toEqual(15);
 
   // create log for second user
@@ -306,19 +306,19 @@ export default async function RepeatedMeasure(): Promise<void> {
   });
   expect(logData.length).toEqual(3);
 
-  queryResult = await queryService.analyse([queries[0].id]);
+  queryResult = await queryService.analyse([queries[0].id], new UpgradeLogger());
   let totalSum = queryResult[0].result.reduce((acc, { result }) => {
     return acc + parseInt(result, 10);
   }, 0);
   expect(parseInt(totalSum, 10)).toEqual(30);
 
-  queryResult = await queryService.analyse([queries[1].id]);
+  queryResult = await queryService.analyse([queries[1].id], new UpgradeLogger());
   totalSum = queryResult[0].result.reduce((acc, { result }) => {
     return acc + parseInt(result, 10);
   }, 0);
   expect(parseInt(totalSum, 10)).toEqual(20);
 
-  queryResult = await queryService.analyse([queries[2].id]);
+  queryResult = await queryService.analyse([queries[2].id], new UpgradeLogger());
   totalSum = queryResult[0].result.reduce((acc, { result }) => {
     return acc + parseInt(result, 10);
   }, 0);
@@ -345,19 +345,19 @@ export default async function RepeatedMeasure(): Promise<void> {
   ];
 
   await experimentAssignmentService.dataLog(experimentUsers[1].id, jsonData, { logger: new UpgradeLogger(), userDoc: experimentUserDoc});
-  queryResult = await queryService.analyse([queries[0].id]);
+  queryResult = await queryService.analyse([queries[0].id], new UpgradeLogger());
   totalSum = queryResult[0].result.reduce((acc, { result }) => {
     return acc + parseInt(result, 10);
   }, 0);
   expect(parseInt(totalSum, 10)).toEqual(40);
 
-  queryResult = await queryService.analyse([queries[1].id]);
+  queryResult = await queryService.analyse([queries[1].id], new UpgradeLogger());
   totalSum = queryResult[0].result.reduce((acc, { result }) => {
     return acc + parseInt(result, 10);
   }, 0);
   expect(parseInt(totalSum, 10)).toEqual(20);
 
-  queryResult = await queryService.analyse([queries[2].id]);
+  queryResult = await queryService.analyse([queries[2].id], new UpgradeLogger());
   totalSum = queryResult[0].result.reduce((acc, { result }) => {
     return acc + parseInt(result, 10);
   }, 0);

--- a/backend/packages/Upgrade/test/integration/Experiment/dataLog/index.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/dataLog/index.ts
@@ -12,7 +12,7 @@ const initialChecks = async () => {
   const checkService = Container.get<CheckService>(CheckService);
 
   // check all the tables are empty
-  const users = await userService.find();
+  const users = await userService.find(new UpgradeLogger());
   expect(users.length).toEqual(0);
 
   const monitoredPoints = await checkService.getAllMarkedExperimentPoints();
@@ -34,7 +34,7 @@ const initialChecks = async () => {
   await userService.create(experimentUsers as any, new UpgradeLogger());
 
   // get all user here
-  const userList = await userService.find();
+  const userList = await userService.find(new UpgradeLogger());
   expect(userList.length).toBe(experimentUsers.length);
   experimentUsers.map((user) => {
     expect(userList).toContainEqual(user);

--- a/backend/packages/Upgrade/test/integration/Experiment/delete/DeleteAssignmentsOnExperimentDelete.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/delete/DeleteAssignmentsOnExperimentDelete.ts
@@ -20,14 +20,14 @@ export default async function UpdateExperimentState(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = scheduleJobUpdateExperiment;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -54,10 +54,10 @@ export default async function UpdateExperimentState(): Promise<void> {
 
   // change experiment status to Enrolling
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -77,7 +77,7 @@ export default async function UpdateExperimentState(): Promise<void> {
   let individualAssignments = await individualAssignmentRepository.find();
   expect(individualAssignments.length).toEqual(1);
 
-  await experimentService.delete(experimentId, user);
+  await experimentService.delete(experimentId, user, new UpgradeLogger());
 
   individualAssignments = await individualAssignmentRepository.find();
   expect(individualAssignments.length).toEqual(0);

--- a/backend/packages/Upgrade/test/integration/Experiment/delete/index.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/delete/index.ts
@@ -10,7 +10,7 @@ const initialChecks = async () => {
   const checkService = Container.get<CheckService>(CheckService);
 
   // check all the tables are empty
-  const users = await userService.find();
+  const users = await userService.find(new UpgradeLogger());
   expect(users.length).toEqual(0);
 
   const monitoredPoints = await checkService.getAllMarkedExperimentPoints();
@@ -32,7 +32,7 @@ const initialChecks = async () => {
   await userService.create(experimentUsers as any, new UpgradeLogger());
 
   // get all user here
-  const userList = await userService.find();
+  const userList = await userService.find(new UpgradeLogger());
   expect(userList.length).toBe(experimentUsers.length);
   experimentUsers.map((user) => {
     expect(userList).toContainEqual(user);

--- a/backend/packages/Upgrade/test/integration/Experiment/enrollmentCode/ExperimentExperimentEnrollmentCode.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/enrollmentCode/ExperimentExperimentEnrollmentCode.ts
@@ -18,14 +18,14 @@ export default async function testCase(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = individualAssignmentExperimentConsistencyRuleExperiemnt;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -74,10 +74,10 @@ export default async function testCase(): Promise<void> {
 
   // change experiment status to Enrolling
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -135,10 +135,10 @@ export default async function testCase(): Promise<void> {
     ENROLLMENT_CODE.INCLUDED
   );
 
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -197,10 +197,10 @@ export default async function testCase(): Promise<void> {
   );
 
   // change back to ENROLLING
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/Experiment/enrollmentCode/GroupExperimentEnrollmentCode.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/enrollmentCode/GroupExperimentEnrollmentCode.ts
@@ -18,14 +18,14 @@ export default async function testCase(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = groupAssignmentWithGroupConsistencyExperiment;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -59,10 +59,10 @@ export default async function testCase(): Promise<void> {
 
   // change experiment status to Enrolling
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -120,10 +120,10 @@ export default async function testCase(): Promise<void> {
     ENROLLMENT_CODE.INCLUDED
   );
 
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -182,10 +182,10 @@ export default async function testCase(): Promise<void> {
   );
 
   // change back to ENROLLING
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/Experiment/enrollmentCode/IndividualExperimentEnrollmentCode.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/enrollmentCode/IndividualExperimentEnrollmentCode.ts
@@ -18,14 +18,14 @@ export default async function testCase(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = individualAssignmentExperiment;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -74,10 +74,10 @@ export default async function testCase(): Promise<void> {
 
   // change experiment status to Enrolling
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -135,10 +135,10 @@ export default async function testCase(): Promise<void> {
     ENROLLMENT_CODE.INCLUDED
   );
 
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -197,10 +197,10 @@ export default async function testCase(): Promise<void> {
   );
 
   // change back to ENROLLING
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/Experiment/enrollmentCode/index.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/enrollmentCode/index.ts
@@ -12,7 +12,7 @@ const initialChecks = async () => {
   const checkService = Container.get<CheckService>(CheckService);
 
   // check all the tables are empty
-  const users = await userService.find();
+  const users = await userService.find(new UpgradeLogger());
   expect(users.length).toEqual(0);
 
   const monitoredPoints = await checkService.getAllMarkedExperimentPoints();
@@ -34,7 +34,7 @@ const initialChecks = async () => {
   await userService.create(experimentUsers as any, new UpgradeLogger());
 
   // get all user here
-  const userList = await userService.find();
+  const userList = await userService.find(new UpgradeLogger());
   expect(userList.length).toBe(experimentUsers.length);
   experimentUsers.map((user) => {
     expect(userList).toContainEqual(user);

--- a/backend/packages/Upgrade/test/integration/Experiment/experimentContext/ExperimentContextAssignments.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/experimentContext/ExperimentContextAssignments.ts
@@ -20,7 +20,7 @@ export default async function testCase(): Promise<void> {
   const individualAssignmentRepository = getRepository(IndividualAssignment);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
   const context1 = 'login';
   const context2 = 'about';
 
@@ -29,8 +29,8 @@ export default async function testCase(): Promise<void> {
   experimentObject1.context = [context1];
 
   // create experiment 1
-  await experimentService.create(experimentObject1 as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject1 as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -47,8 +47,8 @@ export default async function testCase(): Promise<void> {
   const experimentObject2 = secondExperiment;
   experimentObject2.context = [context2];
   // create experiment 2
-  await experimentService.create(experimentObject2 as any, user);
-  experiments = await experimentService.find();
+  await experimentService.create(experimentObject2 as any, user, new UpgradeLogger());
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -64,11 +64,11 @@ export default async function testCase(): Promise<void> {
 
   // change experiment status to Enrolling
   const [experiment1, experiment2] = experiments;
-  await experimentService.updateState(experiment1.id, EXPERIMENT_STATE.ENROLLING, user);
-  await experimentService.updateState(experiment2.id, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experiment1.id, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
+  await experimentService.updateState(experiment2.id, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/Experiment/experimentContext/index.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/experimentContext/index.ts
@@ -10,7 +10,7 @@ const initialChecks = async () => {
   const checkService = Container.get<CheckService>(CheckService);
 
   // check all the tables are empty
-  const users = await userService.find();
+  const users = await userService.find(new UpgradeLogger());
   expect(users.length).toEqual(0);
 
   const monitoredPoints = await checkService.getAllMarkedExperimentPoints();
@@ -32,7 +32,7 @@ const initialChecks = async () => {
   await userService.create(experimentUsers as any, new UpgradeLogger());
 
   // get all user here
-  const userList = await userService.find();
+  const userList = await userService.find(new UpgradeLogger());
   expect(userList.length).toBe(experimentUsers.length);
   experimentUsers.map((user) => {
     expect(userList).toContainEqual(user);

--- a/backend/packages/Upgrade/test/integration/Experiment/incorrectGroup/IncorrectGroup.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/incorrectGroup/IncorrectGroup.ts
@@ -20,22 +20,22 @@ export default async function testCase(): Promise<void> {
   const experimentClientController = Container.get<ExperimentClientController>(ExperimentClientController);
   const userService = Container.get<UserService>(UserService);
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // create individual and group experiment
   const experimentObject1 = individualAssignmentExperiment;
   const experimentName1 = experimentObject1.partitions[0].expId;
   const experimentPoint1 = experimentObject1.partitions[0].expPoint;
   // const condition1 = experimentObject1.conditions[0].conditionCode;
-  await experimentService.create(experimentObject1 as any, user);
+  await experimentService.create(experimentObject1 as any, user, new UpgradeLogger());
 
   const experimentObject2 = groupAssignmentWithIndividualConsistencyExperimentSecond;
   const experimentName2 = experimentObject2.partitions[0].expId;
   const experimentPoint2 = experimentObject2.partitions[0].expPoint;
   // const condition2 = experimentObject2.conditions[0].conditionCode;
-  await experimentService.create(experimentObject2 as any, user);
+  await experimentService.create(experimentObject2 as any, user, new UpgradeLogger());
 
-  let experiments = await experimentService.find();
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -57,11 +57,11 @@ export default async function testCase(): Promise<void> {
 
   // change experiment status to Enrolling
   const [experiment1, experiment2] = experiments;
-  await experimentService.updateState(experiment1.id, EXPERIMENT_STATE.ENROLLING, user);
-  await experimentService.updateState(experiment2.id, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experiment1.id, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
+  await experimentService.updateState(experiment2.id, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -92,9 +92,9 @@ export default async function testCase(): Promise<void> {
   const experimentObject3 = groupAssignmentWithIndividualConsistencyExperimentThird;
   const experimentName3 = experimentObject3.partitions[0].expId;
   const experimentPoint3 = experimentObject3.partitions[0].expPoint;
-  await experimentService.create(experimentObject3 as any, user);
+  await experimentService.create(experimentObject3 as any, user, new UpgradeLogger());
 
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -107,8 +107,8 @@ export default async function testCase(): Promise<void> {
     ])
   );
 
-  await experimentService.updateState(experimentObject3.id, EXPERIMENT_STATE.ENROLLING, user);
-  experiments = await experimentService.find();
+  await experimentService.updateState(experimentObject3.id, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -127,7 +127,7 @@ export default async function testCase(): Promise<void> {
   const experimentUserDoc = await experimentClientController.getUserDoc(experimentUsers[0].id, new UpgradeLogger());
   // remove user group
   await experimentUserService.updateGroupMembership(experimentUsers[0].id, group, { logger: new UpgradeLogger(), userDoc: experimentUserDoc});
-  const experimentUser = await experimentUserService.findOne(experimentUsers[0].id);
+  const experimentUser = await experimentUserService.findOne(experimentUsers[0].id, new UpgradeLogger());
   expect(experimentUser.group).not.toHaveProperty("teacher");
 
   // call getAllExperiment

--- a/backend/packages/Upgrade/test/integration/Experiment/incorrectGroup/IncorrectWorkingGroup.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/incorrectGroup/IncorrectWorkingGroup.ts
@@ -20,22 +20,22 @@ export default async function testCase(): Promise<void> {
   const experimentClientController = Container.get<ExperimentClientController>(ExperimentClientController);
   const userService = Container.get<UserService>(UserService);
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // create individual and group experiment
   const experimentObject1 = individualAssignmentExperiment;
   const experimentName1 = experimentObject1.partitions[0].expId;
   const experimentPoint1 = experimentObject1.partitions[0].expPoint;
   // const condition1 = experimentObject1.conditions[0].conditionCode;
-  await experimentService.create(experimentObject1 as any, user);
+  await experimentService.create(experimentObject1 as any, user, new UpgradeLogger());
 
   const experimentObject2 = groupAssignmentWithIndividualConsistencyExperimentSecond;
   const experimentName2 = experimentObject2.partitions[0].expId;
   const experimentPoint2 = experimentObject2.partitions[0].expPoint;
   // const condition2 = experimentObject2.conditions[0].conditionCode;
-  await experimentService.create(experimentObject2 as any, user);
+  await experimentService.create(experimentObject2 as any, user, new UpgradeLogger());
 
-  let experiments = await experimentService.find();
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -57,11 +57,11 @@ export default async function testCase(): Promise<void> {
 
   // change experiment status to Enrolling
   const [experiment1, experiment2] = experiments;
-  await experimentService.updateState(experiment1.id, EXPERIMENT_STATE.ENROLLING, user);
-  await experimentService.updateState(experiment2.id, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experiment1.id, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
+  await experimentService.updateState(experiment2.id, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -92,9 +92,9 @@ export default async function testCase(): Promise<void> {
   const experimentObject3 = groupAssignmentWithIndividualConsistencyExperimentThird;
   const experimentName3 = experimentObject3.partitions[0].expId;
   const experimentPoint3 = experimentObject3.partitions[0].expPoint;
-  await experimentService.create(experimentObject3 as any, user);
+  await experimentService.create(experimentObject3 as any, user, new UpgradeLogger());
 
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -107,8 +107,8 @@ export default async function testCase(): Promise<void> {
     ])
   );
 
-  await experimentService.updateState(experimentObject3.id, EXPERIMENT_STATE.ENROLLING, user);
-  experiments = await experimentService.find();
+  await experimentService.updateState(experimentObject3.id, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -127,7 +127,7 @@ export default async function testCase(): Promise<void> {
   const experimentUserDoc = await experimentClientController.getUserDoc(experimentUsers[0].id, new UpgradeLogger());
   // remove user group
   await experimentUserService.updateWorkingGroup(experimentUsers[0].id, workingGroup, { logger: new UpgradeLogger(), userDoc: experimentUserDoc});
-  const experimentUser = await experimentUserService.findOne(experimentUsers[0].id);
+  const experimentUser = await experimentUserService.findOne(experimentUsers[0].id, new UpgradeLogger());
   expect(experimentUser.workingGroup).not.toHaveProperty("teacher");
 
   // call getAllExperiment

--- a/backend/packages/Upgrade/test/integration/Experiment/incorrectGroup/NoGroup.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/incorrectGroup/NoGroup.ts
@@ -21,22 +21,22 @@ export default async function testCase(): Promise<void> {
   const experimentClientController = Container.get<ExperimentClientController>(ExperimentClientController);
   const userService = Container.get<UserService>(UserService);
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // create individual and group experiment
   const experimentObject1 = individualAssignmentExperiment;
   const experimentName1 = experimentObject1.partitions[0].expId;
   const experimentPoint1 = experimentObject1.partitions[0].expPoint;
   // const condition1 = experimentObject1.conditions[0].conditionCode;
-  await experimentService.create(experimentObject1 as any, user);
+  await experimentService.create(experimentObject1 as any, user, new UpgradeLogger());
 
   const experimentObject2 = groupAssignmentWithIndividualConsistencyExperimentSecond;
   const experimentName2 = experimentObject2.partitions[0].expId;
   const experimentPoint2 = experimentObject2.partitions[0].expPoint;
   // const condition2 = experimentObject2.conditions[0].conditionCode;
-  await experimentService.create(experimentObject2 as any, user);
+  await experimentService.create(experimentObject2 as any, user, new UpgradeLogger());
 
-  let experiments = await experimentService.find();
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -58,11 +58,11 @@ export default async function testCase(): Promise<void> {
 
   // change experiment status to Enrolling
   const [experiment1, experiment2] = experiments;
-  await experimentService.updateState(experiment1.id, EXPERIMENT_STATE.ENROLLING, user);
-  await experimentService.updateState(experiment2.id, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experiment1.id, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
+  await experimentService.updateState(experiment2.id, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -93,9 +93,9 @@ export default async function testCase(): Promise<void> {
   const experimentObject3 = groupAssignmentWithIndividualConsistencyExperimentThird;
   const experimentName3 = experimentObject3.partitions[0].expId;
   const experimentPoint3 = experimentObject3.partitions[0].expPoint;
-  await experimentService.create(experimentObject3 as any, user);
+  await experimentService.create(experimentObject3 as any, user, new UpgradeLogger());
 
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -108,8 +108,8 @@ export default async function testCase(): Promise<void> {
     ])
   );
 
-  await experimentService.updateState(experimentObject3.id, EXPERIMENT_STATE.ENROLLING, user);
-  experiments = await experimentService.find();
+  await experimentService.updateState(experimentObject3.id, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -125,7 +125,7 @@ export default async function testCase(): Promise<void> {
   const experimentUserDoc = await experimentClientController.getUserDoc(experimentUsers[0].id, new UpgradeLogger());
   // remove user group
   await experimentUserService.updateGroupMembership(experimentUsers[0].id, null, { logger: new UpgradeLogger(), userDoc: experimentUserDoc});
-  const experimentUser = await experimentUserService.findOne(experimentUsers[0].id);
+  const experimentUser = await experimentUserService.findOne(experimentUsers[0].id, new UpgradeLogger());
   expect(experimentUser.group).toBeNull();
 
   // call getAllExperiment

--- a/backend/packages/Upgrade/test/integration/Experiment/incorrectGroup/NoWorkingGroup.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/incorrectGroup/NoWorkingGroup.ts
@@ -20,22 +20,22 @@ export default async function testCase(): Promise<void> {
   const experimentClientController = Container.get<ExperimentClientController>(ExperimentClientController);
   const userService = Container.get<UserService>(UserService);
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // create individual and group experiment
   const experimentObject1 = individualAssignmentExperiment;
   const experimentName1 = experimentObject1.partitions[0].expId;
   const experimentPoint1 = experimentObject1.partitions[0].expPoint;
   // const condition1 = experimentObject1.conditions[0].conditionCode;
-  await experimentService.create(experimentObject1 as any, user);
+  await experimentService.create(experimentObject1 as any, user, new UpgradeLogger());
 
   const experimentObject2 = groupAssignmentWithIndividualConsistencyExperimentSecond;
   const experimentName2 = experimentObject2.partitions[0].expId;
   const experimentPoint2 = experimentObject2.partitions[0].expPoint;
   // const condition2 = experimentObject2.conditions[0].conditionCode;
-  await experimentService.create(experimentObject2 as any, user);
+  await experimentService.create(experimentObject2 as any, user, new UpgradeLogger());
 
-  let experiments = await experimentService.find();
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -57,11 +57,11 @@ export default async function testCase(): Promise<void> {
 
   // change experiment status to Enrolling
   const [experiment1, experiment2] = experiments;
-  await experimentService.updateState(experiment1.id, EXPERIMENT_STATE.ENROLLING, user);
-  await experimentService.updateState(experiment2.id, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experiment1.id, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
+  await experimentService.updateState(experiment2.id, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -92,9 +92,9 @@ export default async function testCase(): Promise<void> {
   const experimentObject3 = groupAssignmentWithIndividualConsistencyExperimentThird;
   const experimentName3 = experimentObject3.partitions[0].expId;
   const experimentPoint3 = experimentObject3.partitions[0].expPoint;
-  await experimentService.create(experimentObject3 as any, user);
+  await experimentService.create(experimentObject3 as any, user, new UpgradeLogger());
 
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -107,8 +107,8 @@ export default async function testCase(): Promise<void> {
     ])
   );
 
-  await experimentService.updateState(experimentObject3.id, EXPERIMENT_STATE.ENROLLING, user);
-  experiments = await experimentService.find();
+  await experimentService.updateState(experimentObject3.id, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -124,7 +124,7 @@ export default async function testCase(): Promise<void> {
   const experimentUserDoc = await experimentClientController.getUserDoc(experimentUsers[0].id, new UpgradeLogger());
   // remove user group
   await experimentUserService.updateWorkingGroup(experimentUsers[0].id, null, { logger: new UpgradeLogger(), userDoc: experimentUserDoc});
-  const experimentUser = await experimentUserService.findOne(experimentUsers[0].id);
+  const experimentUser = await experimentUserService.findOne(experimentUsers[0].id, new UpgradeLogger());
   expect(experimentUser.workingGroup).toBeNull();
 
   // call getAllExperiment

--- a/backend/packages/Upgrade/test/integration/Experiment/incorrectGroup/index.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/incorrectGroup/index.ts
@@ -13,7 +13,7 @@ const initialChecks = async () => {
   const checkService = Container.get<CheckService>(CheckService);
 
   // check all the tables are empty
-  const users = await userService.find();
+  const users = await userService.find(new UpgradeLogger());
   expect(users.length).toEqual(0);
 
   const monitoredPoints = await checkService.getAllMarkedExperimentPoints();
@@ -35,7 +35,7 @@ const initialChecks = async () => {
   await userService.create(experimentUsers as any, new UpgradeLogger());
 
   // get all user here
-  const userList = await userService.find();
+  const userList = await userService.find(new UpgradeLogger());
   expect(userList.length).toBe(experimentUsers.length);
   experimentUsers.map((user) => {
     expect(userList).toContainEqual(user);

--- a/backend/packages/Upgrade/test/integration/Experiment/markExperimentPoint/NoExperiment.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/markExperimentPoint/NoExperiment.ts
@@ -22,7 +22,7 @@ export default async function NoExperiment(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   const experimentName = experimentObject.partitions[0].expId;
   const experimentPoint = experimentObject.partitions[0].expPoint;
@@ -38,8 +38,8 @@ export default async function NoExperiment(): Promise<void> {
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[0].id, experimentName, experimentPoint);
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -53,10 +53,10 @@ export default async function NoExperiment(): Promise<void> {
   );
 
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/Experiment/markExperimentPoint/index.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/markExperimentPoint/index.ts
@@ -10,7 +10,7 @@ const initialChecks = async () => {
   const checkService = Container.get<CheckService>(CheckService);
 
   // check all the tables are empty
-  const users = await userService.find();
+  const users = await userService.find(new UpgradeLogger());
   expect(users.length).toEqual(0);
 
   const monitoredPoints = await checkService.getAllMarkedExperimentPoints();
@@ -32,7 +32,7 @@ const initialChecks = async () => {
   await userService.create(experimentUsers as any, new UpgradeLogger());
 
   // get all user here
-  const userList = await userService.find();
+  const userList = await userService.find(new UpgradeLogger());
   expect(userList.length).toBe(experimentUsers.length);
   experimentUsers.map(user => {
     expect(userList).toContainEqual(user);

--- a/backend/packages/Upgrade/test/integration/Experiment/metric/MetricCRUD.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/metric/MetricCRUD.ts
@@ -11,7 +11,7 @@ export default async function MetricCRUD(): Promise<void> {
   const metricService = Container.get<MetricService>(MetricService);
   const settingService = Container.get<SettingService>(SettingService);
 
-  await settingService.setClientCheck(false, true);
+  await settingService.setClientCheck(false, true, new UpgradeLogger());
 
   // create metrics service
 
@@ -20,7 +20,7 @@ export default async function MetricCRUD(): Promise<void> {
   let findMetric = await metricRepository.find();
   expect(findMetric.length).toEqual(32);
 
-  await metricService.deleteMetric('totalProblemsCompleted');
+  await metricService.deleteMetric('totalProblemsCompleted', new UpgradeLogger());
   findMetric = await metricRepository.find();
   expect(findMetric.length).toEqual(31);
 }

--- a/backend/packages/Upgrade/test/integration/Experiment/onlyExperimentPoint/NoPartitionPoint.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/onlyExperimentPoint/NoPartitionPoint.ts
@@ -4,6 +4,7 @@ import { ExperimentService } from '../../../../src/api/services/ExperimentServic
 import { Container } from 'typedi';
 import { UserService } from '../../../../src/api/services/UserService';
 import { systemUser } from '../../mockData/user/index';
+import { UpgradeLogger } from '../../../../src/lib/logger/UpgradeLogger';
 
 export default async function NoPartitionPoint(): Promise<void> {
   // const logger = new WinstonLogger(__filename);
@@ -13,11 +14,11 @@ export default async function NoPartitionPoint(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  const experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  const experiments = await experimentService.find(new UpgradeLogger());
 
   // sort conditions
   experiments[0].conditions.sort((a,b) => {
@@ -104,7 +105,7 @@ export default async function NoPartitionPoint(): Promise<void> {
     const newPartition = {...partition, order: index + 1};
     newExperimentDoc.partitions[index] = newPartition;
   });
-  const updatedExperimentDoc = await experimentService.update(newExperimentDoc.id, newExperimentDoc as any, user);
+  const updatedExperimentDoc = await experimentService.update(newExperimentDoc.id, newExperimentDoc as any, user, new UpgradeLogger());
 
   // check the conditions
   expect(updatedExperimentDoc.conditions).toEqual(
@@ -129,7 +130,7 @@ export default async function NoPartitionPoint(): Promise<void> {
   );
 
   // get all experimental conditions
-  const experimentCondition = await experimentService.getExperimentalConditions(updatedExperimentDoc.id);
+  const experimentCondition = await experimentService.getExperimentalConditions(updatedExperimentDoc.id, new UpgradeLogger());
   expect(experimentCondition.length).toEqual(updatedExperimentDoc.conditions.length);
 
   // check the partitions
@@ -155,14 +156,14 @@ export default async function NoPartitionPoint(): Promise<void> {
   );
 
   // get all experimental partitions
-  const experimentPartition = await experimentService.getExperimentPartitions(updatedExperimentDoc.id);
+  const experimentPartition = await experimentService.getExperimentPartitions(updatedExperimentDoc.id, new UpgradeLogger());
   expect(experimentPartition.length).toEqual(updatedExperimentDoc.partitions.length);
 
   // delete the experiment
-  await experimentService.delete(updatedExperimentDoc.id, user);
-  const allExperiments = await experimentService.find();
+  await experimentService.delete(updatedExperimentDoc.id, user, new UpgradeLogger());
+  const allExperiments = await experimentService.find(new UpgradeLogger());
   expect(allExperiments.length).toEqual(0);
 
-  const experimentPartitions = await experimentService.getAllExperimentPartitions();
+  const experimentPartitions = await experimentService.getAllExperimentPartitions(new UpgradeLogger());
   expect(experimentPartitions.length).toEqual(0);
 }

--- a/backend/packages/Upgrade/test/integration/Experiment/onlyExperimentPoint/index.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/onlyExperimentPoint/index.ts
@@ -10,7 +10,7 @@ const initialChecks = async () => {
   const checkService = Container.get<CheckService>(CheckService);
 
   // check all the tables are empty
-  const users = await userService.find();
+  const users = await userService.find(new UpgradeLogger());
   expect(users.length).toEqual(0);
 
   const monitoredPoints = await checkService.getAllMarkedExperimentPoints();
@@ -32,7 +32,7 @@ const initialChecks = async () => {
   await userService.create(experimentUsers as any, new UpgradeLogger());
 
   // get all user here
-  const userList = await userService.find();
+  const userList = await userService.find(new UpgradeLogger());
   expect(userList.length).toBe(experimentUsers.length);
   experimentUsers.map(user => {
     expect(userList).toContainEqual(user);

--- a/backend/packages/Upgrade/test/integration/Experiment/query/QueryCRUD.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/query/QueryCRUD.ts
@@ -20,18 +20,18 @@ export default async function QueryCRUD(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
   const experimentService = Container.get<ExperimentService>(ExperimentService);
 
-  await settingService.setClientCheck(false, true);
+  await settingService.setClientCheck(false, true, new UpgradeLogger());
 
   // create an experiment
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   let experimentObject = individualAssignmentExperiment;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  const experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  const experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -68,9 +68,9 @@ export default async function QueryCRUD(): Promise<void> {
     queries: [query],
   };
 
-  await experimentService.update(experimentObject.id, experimentObject as any, user);
+  await experimentService.update(experimentObject.id, experimentObject as any, user, new UpgradeLogger());
 
-  let allQuery = await queryService.find();
+  let allQuery = await queryService.find(new UpgradeLogger());
   expect(allQuery).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -89,8 +89,8 @@ export default async function QueryCRUD(): Promise<void> {
     queries: [],
   };
 
-  await experimentService.update(experimentObject.id, experimentObject as any, user);
+  await experimentService.update(experimentObject.id, experimentObject as any, user, new UpgradeLogger());
 
-  allQuery = await queryService.find();
+  allQuery = await queryService.find(new UpgradeLogger());
   expect(allQuery.length).toEqual(0);
 }

--- a/backend/packages/Upgrade/test/integration/Experiment/scheduleJob/CompleteEndExperiment.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/scheduleJob/CompleteEndExperiment.ts
@@ -7,6 +7,7 @@ import { SCHEDULE_TYPE } from '../../../../src/api/models/ScheduledJob';
 import { EXPERIMENT_STATE } from 'upgrade_types';
 import { UserService } from '../../../../src/api/services/UserService';
 import { systemUser } from '../../mockData/user/index';
+import { UpgradeLogger } from '../../../../src/lib/logger/UpgradeLogger';
 
 export default async function CompleteEndExperiment(): Promise<void> {
   const logger = new WinstonLogger(__filename);
@@ -15,14 +16,14 @@ export default async function CompleteEndExperiment(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = scheduleJobEndExperiment;
 
   // create experiment
-  await experimentService.create(scheduleJobEndExperiment as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(scheduleJobEndExperiment as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -36,7 +37,7 @@ export default async function CompleteEndExperiment(): Promise<void> {
   );
 
   await new Promise(r => setTimeout(r, 1000));
-  let endExperiment = await scheduledJobService.getAllEndExperiment();
+  let endExperiment = await scheduledJobService.getAllEndExperiment(new UpgradeLogger());
 
   expect(endExperiment).toEqual(
     expect.arrayContaining([
@@ -53,8 +54,8 @@ export default async function CompleteEndExperiment(): Promise<void> {
     state: EXPERIMENT_STATE.ENROLLMENT_COMPLETE,
   };
 
-  await experimentService.update(updatedExperiment.id, updatedExperiment, user);
-  experiments = await experimentService.find();
+  await experimentService.update(updatedExperiment.id, updatedExperiment, user, new UpgradeLogger());
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -68,6 +69,6 @@ export default async function CompleteEndExperiment(): Promise<void> {
   );
 
   await new Promise(r => setTimeout(r, 1000));
-  endExperiment = await scheduledJobService.getAllEndExperiment();
+  endExperiment = await scheduledJobService.getAllEndExperiment(new UpgradeLogger());
   expect(endExperiment.length).toEqual(0);
 }

--- a/backend/packages/Upgrade/test/integration/Experiment/scheduleJob/CompleteStartExperiment.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/scheduleJob/CompleteStartExperiment.ts
@@ -7,6 +7,7 @@ import { SCHEDULE_TYPE } from '../../../../src/api/models/ScheduledJob';
 import { EXPERIMENT_STATE } from 'upgrade_types';
 import { UserService } from '../../../../src/api/services/UserService';
 import { systemUser } from '../../mockData/user/index';
+import { UpgradeLogger } from '../../../../src/lib/logger/UpgradeLogger';
 
 export default async function DeleteStartExperiment(): Promise<void> {
   const logger = new WinstonLogger(__filename);
@@ -15,14 +16,14 @@ export default async function DeleteStartExperiment(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = scheduleJobStartExperiment;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -36,7 +37,7 @@ export default async function DeleteStartExperiment(): Promise<void> {
   );
 
   await new Promise(r => setTimeout(r, 1000));
-  let startExperiment = await scheduledJobService.getAllStartExperiment();
+  let startExperiment = await scheduledJobService.getAllStartExperiment(new UpgradeLogger());
 
   expect(startExperiment).toEqual(
     expect.arrayContaining([
@@ -48,8 +49,8 @@ export default async function DeleteStartExperiment(): Promise<void> {
     ])
   );
 
-  await experimentService.delete(experiments[0].id, user);
+  await experimentService.delete(experiments[0].id, user, new UpgradeLogger());
 
-  startExperiment = await scheduledJobService.getAllStartExperiment();
+  startExperiment = await scheduledJobService.getAllStartExperiment(new UpgradeLogger());
   expect(startExperiment.length).toEqual(0);
 }

--- a/backend/packages/Upgrade/test/integration/Experiment/scheduleJob/DeleteEndExperiment.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/scheduleJob/DeleteEndExperiment.ts
@@ -7,6 +7,7 @@ import { SCHEDULE_TYPE } from '../../../../src/api/models/ScheduledJob';
 import { EXPERIMENT_STATE } from 'upgrade_types';
 import { UserService } from '../../../../src/api/services/UserService';
 import { systemUser } from '../../mockData/user/index';
+import { UpgradeLogger } from '../../../../src/lib/logger/UpgradeLogger';
 
 export default async function DeleteEndExperiment(): Promise<void> {
   const logger = new WinstonLogger(__filename);
@@ -15,14 +16,14 @@ export default async function DeleteEndExperiment(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = scheduleJobEndExperiment;
 
   // create experiment
-  await experimentService.create(scheduleJobEndExperiment as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(scheduleJobEndExperiment as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -36,7 +37,7 @@ export default async function DeleteEndExperiment(): Promise<void> {
   );
 
   await new Promise(r => setTimeout(r, 1000));
-  let endExperiment = await scheduledJobService.getAllEndExperiment();
+  let endExperiment = await scheduledJobService.getAllEndExperiment(new UpgradeLogger());
 
   expect(endExperiment).toEqual(
     expect.arrayContaining([
@@ -48,9 +49,9 @@ export default async function DeleteEndExperiment(): Promise<void> {
     ])
   );
 
-  await experimentService.delete(experiments[0].id, user);
+  await experimentService.delete(experiments[0].id, user, new UpgradeLogger());
 
-  endExperiment = await scheduledJobService.getAllEndExperiment();
+  endExperiment = await scheduledJobService.getAllEndExperiment(new UpgradeLogger());
   expect(endExperiment.length).toEqual(0);
 
   // const updatedExperiment = {

--- a/backend/packages/Upgrade/test/integration/Experiment/scheduleJob/DeleteStartExperiment.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/scheduleJob/DeleteStartExperiment.ts
@@ -7,6 +7,7 @@ import { SCHEDULE_TYPE } from '../../../../src/api/models/ScheduledJob';
 import { EXPERIMENT_STATE } from 'upgrade_types';
 import { UserService } from '../../../../src/api/services/UserService';
 import { systemUser } from '../../mockData/user/index';
+import { UpgradeLogger } from '../../../../src/lib/logger/UpgradeLogger';
 
 export default async function DeleteStartExperiment(): Promise<void> {
   const logger = new WinstonLogger(__filename);
@@ -15,14 +16,14 @@ export default async function DeleteStartExperiment(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = scheduleJobStartExperiment;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -36,7 +37,7 @@ export default async function DeleteStartExperiment(): Promise<void> {
   );
 
   await new Promise(r => setTimeout(r, 1000));
-  let startExperiment = await scheduledJobService.getAllStartExperiment();
+  let startExperiment = await scheduledJobService.getAllStartExperiment(new UpgradeLogger());
 
   expect(startExperiment).toEqual(
     expect.arrayContaining([
@@ -53,8 +54,8 @@ export default async function DeleteStartExperiment(): Promise<void> {
     state: EXPERIMENT_STATE.ENROLLING,
   };
 
-  await experimentService.update(updatedExperiment.id, updatedExperiment, user);
-  experiments = await experimentService.find();
+  await experimentService.update(updatedExperiment.id, updatedExperiment, user, new UpgradeLogger());
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -68,6 +69,6 @@ export default async function DeleteStartExperiment(): Promise<void> {
   );
 
   await new Promise(r => setTimeout(r, 1000));
-  startExperiment = await scheduledJobService.getAllStartExperiment();
+  startExperiment = await scheduledJobService.getAllStartExperiment(new UpgradeLogger());
   expect(startExperiment.length).toEqual(0);
 }

--- a/backend/packages/Upgrade/test/integration/Experiment/scheduleJob/EndExperiment.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/scheduleJob/EndExperiment.ts
@@ -9,6 +9,7 @@ import { systemUser } from '../../mockData/user/index';
 import { EXPERIMENT_STATE } from 'upgrade_types';
 import { AuditService } from '../../../../src/api/services/AuditService';
 import { systemUserDoc } from '../../../../src/init/seed/systemUser';
+import { UpgradeLogger } from '../../../../src/lib/logger/UpgradeLogger';
 
 export default async function EndExperiment(): Promise<void> {
   const logger = new WinstonLogger(__filename);
@@ -18,14 +19,14 @@ export default async function EndExperiment(): Promise<void> {
   const auditService = Container.get<AuditService>(AuditService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = scheduleJobEndExperiment;
 
   // create experiment
-  await experimentService.create(scheduleJobEndExperiment as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(scheduleJobEndExperiment as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -39,7 +40,7 @@ export default async function EndExperiment(): Promise<void> {
   );
 
   await new Promise((r) => setTimeout(r, 1000));
-  const endExperiment = await scheduledJobService.getAllEndExperiment();
+  const endExperiment = await scheduledJobService.getAllEndExperiment(new UpgradeLogger());
 
   expect(endExperiment).toEqual(
     expect.arrayContaining([
@@ -52,10 +53,10 @@ export default async function EndExperiment(): Promise<void> {
   );
 
   // call scheduled service to update state for enrolling
-  await scheduledJobService.endExperiment(endExperiment[0].id);
+  await scheduledJobService.endExperiment(endExperiment[0].id, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -72,10 +73,10 @@ export default async function EndExperiment(): Promise<void> {
 
   expect(auditLog[0].user).toEqual(expect.objectContaining(systemUserDoc));
 
-  experiments = await experimentService.find();
-  await experimentService.updateState(experiments[0].id, EXPERIMENT_STATE.ENROLLING, user);
+  experiments = await experimentService.find(new UpgradeLogger());
+  await experimentService.updateState(experiments[0].id, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   // change to enrolling
   expect(experiments).toEqual(
     expect.arrayContaining([

--- a/backend/packages/Upgrade/test/integration/Experiment/scheduleJob/StartExperiment.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/scheduleJob/StartExperiment.ts
@@ -9,6 +9,7 @@ import { systemUser } from '../../mockData/user/index';
 import { EXPERIMENT_STATE } from 'upgrade_types';
 import { AuditService } from '../../../../src/api/services/AuditService';
 import { systemUserDoc } from '../../../../src/init/seed/systemUser';
+import { UpgradeLogger } from '../../../../src/lib/logger/UpgradeLogger';
 
 export default async function StartExperiment(): Promise<void> {
   const logger = new WinstonLogger(__filename);
@@ -18,14 +19,14 @@ export default async function StartExperiment(): Promise<void> {
   const auditService = Container.get<AuditService>(AuditService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = scheduleJobStartExperiment;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -40,10 +41,10 @@ export default async function StartExperiment(): Promise<void> {
 
   // change experiment status to SCHEDULED
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.SCHEDULED, user, experiments[0].startOn);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.SCHEDULED, user, new UpgradeLogger(), experiments[0].startOn);
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -57,7 +58,7 @@ export default async function StartExperiment(): Promise<void> {
   );
 
   await new Promise(r => setTimeout(r, 1000));
-  const startExperiment = await scheduledJobService.getAllStartExperiment();
+  const startExperiment = await scheduledJobService.getAllStartExperiment(new UpgradeLogger());
 
   expect(startExperiment).toEqual(
     expect.arrayContaining([
@@ -70,10 +71,10 @@ export default async function StartExperiment(): Promise<void> {
   );
 
   // call scheduled service to update state for enrolling
-  await scheduledJobService.startExperiment(startExperiment[0].id);
+  await scheduledJobService.startExperiment(startExperiment[0].id, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/Experiment/scheduleJob/UpdateExperimentState.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/scheduleJob/UpdateExperimentState.ts
@@ -7,6 +7,7 @@ import { SCHEDULE_TYPE } from '../../../../src/api/models/ScheduledJob';
 import { EXPERIMENT_STATE } from 'upgrade_types';
 import { UserService } from '../../../../src/api/services/UserService';
 import { systemUser } from '../../mockData/user/index';
+import { UpgradeLogger } from '../../../../src/lib/logger/UpgradeLogger';
 
 export default async function UpdateExperimentState(): Promise<void> {
   // const logger = new WinstonLogger(__filename);
@@ -15,14 +16,14 @@ export default async function UpdateExperimentState(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = scheduleJobUpdateExperiment;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -35,7 +36,7 @@ export default async function UpdateExperimentState(): Promise<void> {
     ])
   );
 
-  let startExperiment = await scheduledJobService.getAllStartExperiment();
+  let startExperiment = await scheduledJobService.getAllStartExperiment(new UpgradeLogger());
 
   expect(startExperiment).toEqual(
     expect.arrayContaining([
@@ -47,7 +48,7 @@ export default async function UpdateExperimentState(): Promise<void> {
     ])
   );
 
-  let endExperiment = await scheduledJobService.getAllEndExperiment();
+  let endExperiment = await scheduledJobService.getAllEndExperiment(new UpgradeLogger());
 
   expect(endExperiment).toEqual(
     expect.arrayContaining([
@@ -61,12 +62,12 @@ export default async function UpdateExperimentState(): Promise<void> {
 
   // change experiment status to Enrolling
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   await new Promise(r => setTimeout(r, 1000));
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -81,10 +82,10 @@ export default async function UpdateExperimentState(): Promise<void> {
 
   await new Promise(r => setTimeout(r, 1000));
 
-  startExperiment = await scheduledJobService.getAllStartExperiment();
+  startExperiment = await scheduledJobService.getAllStartExperiment(new UpgradeLogger());
   expect(startExperiment.length).toEqual(0);
 
-  endExperiment = await scheduledJobService.getAllEndExperiment();
+  endExperiment = await scheduledJobService.getAllEndExperiment(new UpgradeLogger());
 
   expect(endExperiment).toEqual(
     expect.arrayContaining([
@@ -97,11 +98,11 @@ export default async function UpdateExperimentState(): Promise<void> {
   );
 
   // change experiment status to Enrollment Complete
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
 
   await new Promise(r => setTimeout(r, 1000));
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -114,6 +115,6 @@ export default async function UpdateExperimentState(): Promise<void> {
     ])
   );
 
-  endExperiment = await scheduledJobService.getAllEndExperiment();
+  endExperiment = await scheduledJobService.getAllEndExperiment(new UpgradeLogger());
   expect(endExperiment.length).toEqual(0);
 }

--- a/backend/packages/Upgrade/test/integration/Experiment/update/ExperimentEndDate.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/update/ExperimentEndDate.ts
@@ -5,6 +5,7 @@ import { individualAssignmentExperiment } from '../../mockData/experiment/index'
 import { UserService } from '../../../../src/api/services/UserService';
 import { systemUser } from '../../mockData/user/index';
 import { EXPERIMENT_STATE } from 'upgrade_types';
+import { UpgradeLogger } from '../../../../src/lib/logger/UpgradeLogger';
 
 export default async function ExperimentEndDate(): Promise<void> {
   // const logger = new WinstonLogger(__filename);
@@ -14,11 +15,11 @@ export default async function ExperimentEndDate(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // create experiment
-  await experimentService.create(individualAssignmentExperiment as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(individualAssignmentExperiment as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -34,33 +35,33 @@ export default async function ExperimentEndDate(): Promise<void> {
   expect(experiments[0].stateTimeLogs).toHaveLength(0);
 
   const experiment = { ...experiments[0], state: EXPERIMENT_STATE.ENROLLMENT_COMPLETE };
-  await experimentService.updateState(experiment.id, EXPERIMENT_STATE.ENROLLING, user);
-  await experimentService.updateState(experiment.id, experiment.state, user);
+  await experimentService.updateState(experiment.id, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
+  await experimentService.updateState(experiment.id, experiment.state, user, new UpgradeLogger());
 
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   
   expect(experiments[0].stateTimeLogs).toHaveLength(2);
   expect(experiments[0].stateTimeLogs.filter(state => state.toState === EXPERIMENT_STATE.ENROLLMENT_COMPLETE).map((timelogs) => timelogs.timeLog)).toHaveLength(1);
 
-  await experimentService.delete(experiment.id, user);
+  await experimentService.delete(experiment.id, user, new UpgradeLogger());
 
   // with updated state
-  await experimentService.create({ ...individualAssignmentExperiment } as any, user);
-  experiments = await experimentService.find();
+  await experimentService.create({ ...individualAssignmentExperiment } as any, user, new UpgradeLogger());
+  experiments = await experimentService.find(new UpgradeLogger());
 
   expect(experiments[0].stateTimeLogs).toHaveLength(0);
 
-  await experimentService.updateState(experiment.id, EXPERIMENT_STATE.ENROLLING, user);
-  await experimentService.updateState(experiment.id, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user);
-  experiments = await experimentService.find();
+  await experimentService.updateState(experiment.id, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
+  await experimentService.updateState(experiment.id, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
+  experiments = await experimentService.find(new UpgradeLogger());
 
   expect(experiments[0].stateTimeLogs).toHaveLength(2);
   expect(experiments[0].stateTimeLogs.filter(state => state.toState === EXPERIMENT_STATE.ENROLLMENT_COMPLETE).map((timelogs) => timelogs.timeLog)).toHaveLength(1);
 
   // with second entry
-  await experimentService.updateState(experiment.id, EXPERIMENT_STATE.ENROLLING, user);
-  await experimentService.updateState(experiment.id, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user);
-  experiments = await experimentService.find();
+  await experimentService.updateState(experiment.id, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
+  await experimentService.updateState(experiment.id, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
+  experiments = await experimentService.find(new UpgradeLogger());
 
   expect(experiments[0].stateTimeLogs).toHaveLength(4);
   expect(experiments[0].stateTimeLogs.filter(state => state.toState === EXPERIMENT_STATE.ENROLLMENT_COMPLETE).map((timelogs) => timelogs.timeLog)).toHaveLength(2);

--- a/backend/packages/Upgrade/test/integration/Experiment/update/UpdateExperiment.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/update/UpdateExperiment.ts
@@ -5,6 +5,7 @@ import { individualAssignmentExperiment } from '../../mockData/experiment/index'
 import { UserService } from '../../../../src/api/services/UserService';
 import { systemUser } from '../../mockData/user/index';
 import { EXPERIMENT_STATE } from 'upgrade_types';
+import { UpgradeLogger } from '../../../../src/lib/logger/UpgradeLogger';
 
 export default async function UpdateExperiment(): Promise<void> {
   // const logger = new WinstonLogger(__filename);
@@ -14,11 +15,11 @@ export default async function UpdateExperiment(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // create experiment
-  await experimentService.create(individualAssignmentExperiment as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(individualAssignmentExperiment as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
 
   // sort conditions
   experiments[0].conditions.sort((a,b) => {
@@ -107,7 +108,7 @@ export default async function UpdateExperiment(): Promise<void> {
     newExperimentDoc.partitions[index] = newCondition;
   });
 
-  const updatedExperimentDoc = await experimentService.update(newExperimentDoc.id, newExperimentDoc as any, user);
+  const updatedExperimentDoc = await experimentService.update(newExperimentDoc.id, newExperimentDoc as any, user, new UpgradeLogger());
   // check the conditions
   expect(updatedExperimentDoc.conditions).toEqual(
     expect.arrayContaining([
@@ -131,7 +132,7 @@ export default async function UpdateExperiment(): Promise<void> {
   );
 
   // get all experimental conditions
-  const experimentCondition = await experimentService.getExperimentalConditions(updatedExperimentDoc.id);
+  const experimentCondition = await experimentService.getExperimentalConditions(updatedExperimentDoc.id, new UpgradeLogger());
   expect(experimentCondition.length).toEqual(updatedExperimentDoc.conditions.length);
 
   // check the partitions
@@ -157,10 +158,10 @@ export default async function UpdateExperiment(): Promise<void> {
   );
 
   // get all experimental partitions
-  const experimentPartition = await experimentService.getExperimentPartitions(updatedExperimentDoc.id);
+  const experimentPartition = await experimentService.getExperimentPartitions(updatedExperimentDoc.id, new UpgradeLogger());
   expect(experimentPartition.length).toEqual(updatedExperimentDoc.partitions.length);
 
   // update the experiment state
-  await experimentService.updateState(updatedExperimentDoc.id, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user);
-  experiments = await experimentService.find();
+  await experimentService.updateState(updatedExperimentDoc.id, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
+  experiments = await experimentService.find(new UpgradeLogger());
 }

--- a/backend/packages/Upgrade/test/integration/ExperimentAssignment/PreviewForcedAssigned.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentAssignment/PreviewForcedAssigned.ts
@@ -22,20 +22,20 @@ export default async function testCase(): Promise<void> {
   const previewService = Container.get<PreviewUserService>(PreviewUserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // create preview user
-  await previewService.create(previewUsers[0]);
-  await previewService.create(previewUsers[1]);
-  await previewService.create(previewUsers[2]);
-  await previewService.create(previewUsers[3]);
+  await previewService.create(previewUsers[0], new UpgradeLogger());
+  await previewService.create(previewUsers[1], new UpgradeLogger());
+  await previewService.create(previewUsers[2], new UpgradeLogger());
+  await previewService.create(previewUsers[3], new UpgradeLogger());
 
   // experiment object
   const experimentObject = individualAssignmentExperiment;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -62,10 +62,10 @@ export default async function testCase(): Promise<void> {
 
   // change experiment status to PREVIEW
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.PREVIEW, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.PREVIEW, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -79,8 +79,8 @@ export default async function testCase(): Promise<void> {
   );
 
   // get preview user
-  let previewUser1 = await previewService.findOne(previewUsers[0].id);
-  let previewUser2 = await previewService.findOne(previewUsers[1].id);
+  let previewUser1 = await previewService.findOne(previewUsers[0].id, new UpgradeLogger());
+  let previewUser2 = await previewService.findOne(previewUsers[1].id, new UpgradeLogger());
   expect((previewUser1.assignments && previewUser1.assignments.length) || 0).toEqual(0);
 
   const assignedConditionUser1 = experiments[0].conditions[0];
@@ -94,9 +94,10 @@ export default async function testCase(): Promise<void> {
         experimentCondition: { id: assignedConditionUser1.id },
       },
     ],
-  } as any);
+  } as any,
+  new UpgradeLogger());
 
-  previewUser1 = await previewService.findOne(previewUsers[0].id);
+  previewUser1 = await previewService.findOne(previewUsers[0].id, new UpgradeLogger());
   expect((previewUser1.assignments && previewUser1.assignments.length) || 0).toEqual(1);
 
   // get all experiment condition for user 2
@@ -131,9 +132,10 @@ export default async function testCase(): Promise<void> {
         experimentCondition: { id: assignedConditionUser2.id },
       },
     ],
-  } as any);
+  } as any,
+  new UpgradeLogger());
 
-  previewUser2 = await previewService.findOne(previewUsers[1].id);
+  previewUser2 = await previewService.findOne(previewUsers[1].id, new UpgradeLogger());
   expect((previewUser2.assignments && previewUser2.assignments.length) || 0).toEqual(1);
 
   // get all experiment condition for user 3
@@ -144,10 +146,10 @@ export default async function testCase(): Promise<void> {
   markedExperimentPoint = await markExperimentPoint(previewUsers[2].id, experimentName, experimentPoint, condition, new UpgradeLogger());
   checkMarkExperimentPointForUser(markedExperimentPoint, previewUsers[2].id, experimentName, experimentPoint);
 
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -172,14 +174,15 @@ export default async function testCase(): Promise<void> {
   await previewService.upsertExperimentConditionAssignment({
     ...previewUser1,
     assignments: [],
-  } as any);
+  } as any,
+  new UpgradeLogger());
 
   // check assignment is the one assigned
   expect(experimentConditionAssignments[0].assignedCondition.conditionCode).toEqual(
     assignedConditionUser2.conditionCode
   );
 
-  previewUser1 = await previewService.findOne(previewUsers[0].id);
+  previewUser1 = await previewService.findOne(previewUsers[0].id, new UpgradeLogger());
   expect((previewUser1.assignments && previewUser1.assignments.length) || 0).toEqual(0);
 
   // get all experiment condition for user 1

--- a/backend/packages/Upgrade/test/integration/ExperimentAssignment/PreviewScenario1.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentAssignment/PreviewScenario1.ts
@@ -22,20 +22,20 @@ export default async function testCase(): Promise<void> {
   const previewService = Container.get<PreviewUserService>(PreviewUserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // create preview user
-  await previewService.create(previewUsers[0]);
-  await previewService.create(previewUsers[1]);
-  await previewService.create(previewUsers[2]);
-  await previewService.create(previewUsers[3]);
+  await previewService.create(previewUsers[0], new UpgradeLogger());
+  await previewService.create(previewUsers[1], new UpgradeLogger());
+  await previewService.create(previewUsers[2], new UpgradeLogger());
+  await previewService.create(previewUsers[3], new UpgradeLogger());
 
   // experiment object
   const experimentObject = individualAssignmentExperiment;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -62,10 +62,10 @@ export default async function testCase(): Promise<void> {
 
   // change experiment status to PREVIEW
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.PREVIEW, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.PREVIEW, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -102,10 +102,10 @@ export default async function testCase(): Promise<void> {
   markedExperimentPoint = await markExperimentPoint(previewUsers[2].id, experimentName, experimentPoint, condition, new UpgradeLogger());
   checkMarkExperimentPointForUser(markedExperimentPoint, previewUsers[2].id, experimentName, experimentPoint);
 
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/ExperimentAssignment/PreviewScenario2.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentAssignment/PreviewScenario2.ts
@@ -18,12 +18,12 @@ export default async function testCase(): Promise<void> {
   const previewService = Container.get<PreviewUserService>(PreviewUserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // create preview user
-  await previewService.create(previewUsers[0]);
-  await previewService.create(previewUsers[1]);
-  await previewService.create(previewUsers[2]);
+  await previewService.create(previewUsers[0], new UpgradeLogger());
+  await previewService.create(previewUsers[1], new UpgradeLogger());
+  await previewService.create(previewUsers[2], new UpgradeLogger());
 
   // experiment object
   const experimentObject = individualAssignmentExperimentConsistencyRuleExperiemnt;
@@ -33,8 +33,8 @@ export default async function testCase(): Promise<void> {
   const condition = experimentObject.conditions[0].conditionCode;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -57,10 +57,10 @@ export default async function testCase(): Promise<void> {
 
   // change experiment status to Preview
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.PREVIEW, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.PREVIEW, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -98,10 +98,10 @@ export default async function testCase(): Promise<void> {
   checkMarkExperimentPointForUser(markedExperimentPoint, previewUsers[2].id, experimentName, experimentPoint);
 
   // change experiment status to complete
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/ExperimentAssignment/PreviewScenario3.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentAssignment/PreviewScenario3.ts
@@ -19,12 +19,12 @@ export default async function testCase(): Promise<void> {
   const previewService = Container.get<PreviewUserService>(PreviewUserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // create preview user
-  await previewService.create(previewUsers[0]);
-  await previewService.create(previewUsers[1]);
-  await previewService.create(previewUsers[2]);
+  await previewService.create(previewUsers[0], new UpgradeLogger());
+  await previewService.create(previewUsers[1], new UpgradeLogger());
+  await previewService.create(previewUsers[2], new UpgradeLogger());
 
   // experiment object
   const experimentObject = groupAssignmentWithGroupConsistencyExperiment;
@@ -34,8 +34,8 @@ export default async function testCase(): Promise<void> {
   const condition = experimentObject.conditions[0].conditionCode;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -58,10 +58,10 @@ export default async function testCase(): Promise<void> {
 
   // change experiment status to Enrolling
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.PREVIEW, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.PREVIEW, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -99,10 +99,10 @@ export default async function testCase(): Promise<void> {
   checkMarkExperimentPointForUser(markedExperimentPoint, previewUsers[2].id, experimentName, experimentPoint);
 
   // change experiment status to complete
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/ExperimentAssignment/PreviewScenario4.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentAssignment/PreviewScenario4.ts
@@ -22,12 +22,12 @@ export default async function testCase(): Promise<void> {
   const previewService = Container.get<PreviewUserService>(PreviewUserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // create preview user
-  await previewService.create(previewUsers[0]);
-  await previewService.create(previewUsers[1]);
-  await previewService.create(previewUsers[2]);
+  await previewService.create(previewUsers[0], new UpgradeLogger());
+  await previewService.create(previewUsers[1], new UpgradeLogger());
+  await previewService.create(previewUsers[2], new UpgradeLogger());
 
   // experiment object
   const experimentObject = groupAssignmentWithIndividulaConsistencyExperiment;
@@ -37,8 +37,8 @@ export default async function testCase(): Promise<void> {
   const condition = experimentObject.conditions[0].conditionCode;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -61,10 +61,10 @@ export default async function testCase(): Promise<void> {
 
   // change experiment status to Enrolling
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.PREVIEW, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.PREVIEW, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -102,10 +102,10 @@ export default async function testCase(): Promise<void> {
   checkMarkExperimentPointForUser(markedExperimentPoint, previewUsers[2].id, experimentName, experimentPoint);
 
   // change experiment status to complete
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/ExperimentAssignment/PreviewScenario5.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentAssignment/PreviewScenario5.ts
@@ -18,13 +18,13 @@ export default async function testCase(): Promise<void> {
   const previewService = Container.get<PreviewUserService>(PreviewUserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // create preview user
-  await previewService.create(previewUsers[0]);
-  await previewService.create(previewUsers[1]);
-  await previewService.create(previewUsers[2]);
-  await previewService.create(previewUsers[3]);
+  await previewService.create(previewUsers[0], new UpgradeLogger());
+  await previewService.create(previewUsers[1], new UpgradeLogger());
+  await previewService.create(previewUsers[2], new UpgradeLogger());
+  await previewService.create(previewUsers[3], new UpgradeLogger());
 
   // experiment object
   const experimentObject = groupAssignmentWithExperimentConsistencyExperiment;
@@ -34,8 +34,8 @@ export default async function testCase(): Promise<void> {
   const condition = experimentObject.conditions[0].conditionCode;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -58,10 +58,10 @@ export default async function testCase(): Promise<void> {
 
   // change experiment status to Enrolling
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.PREVIEW, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.PREVIEW, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -99,10 +99,10 @@ export default async function testCase(): Promise<void> {
   checkMarkExperimentPointForUser(markedExperimentPoint, previewUsers[2].id, experimentName, experimentPoint);
 
   // change experiment status to complete
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/ExperimentAssignment/RevertToCondition.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentAssignment/RevertToCondition.ts
@@ -16,14 +16,14 @@ export default async function testCase(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = revertToCondition;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -50,10 +50,10 @@ export default async function testCase(): Promise<void> {
 
   // change experiment status to Enrolling
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -91,10 +91,10 @@ export default async function testCase(): Promise<void> {
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName, experimentPoint);
 
   // change experiment status to complete
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/ExperimentAssignment/RevertToDefault.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentAssignment/RevertToDefault.ts
@@ -20,14 +20,14 @@ export default async function testCase(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = revertToDefault;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -54,10 +54,10 @@ export default async function testCase(): Promise<void> {
 
   // change experiment status to Enrolling
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -95,10 +95,10 @@ export default async function testCase(): Promise<void> {
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName, experimentPoint);
 
   // change experiment status to complete
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario1.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario1.ts
@@ -22,14 +22,14 @@ export default async function testCase(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = individualAssignmentExperiment;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -56,10 +56,10 @@ export default async function testCase(): Promise<void> {
 
   // change experiment status to Enrolling
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -97,10 +97,10 @@ export default async function testCase(): Promise<void> {
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName, experimentPoint);
 
   // change experiment status to complete
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario10.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario10.ts
@@ -18,7 +18,7 @@ export default async function testCase(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = groupAssignmentWithExperimentConsistencyExperimentSwitchAfterAssignment;
@@ -38,7 +38,7 @@ export default async function testCase(): Promise<void> {
     class: '1',
   }, { logger: new UpgradeLogger(), userDoc: experimentUserDoc});
   experimentUserDoc = await experimentUserService.getOriginalUserDoc(experimentUsers[0].id, new UpgradeLogger());
-  let experimentUser = await experimentUserService.findOne(experimentUserDoc.id);
+  let experimentUser = await experimentUserService.findOne(experimentUserDoc.id, new UpgradeLogger());
   let objectToCheck = {
     ...experimentUsers[0],
     group: {
@@ -69,7 +69,7 @@ export default async function testCase(): Promise<void> {
     class: '2',
   }, { logger: new UpgradeLogger(), userDoc: experimentUserDoc});
   experimentUserDoc = await experimentUserService.getOriginalUserDoc(experimentUsers[1].id, new UpgradeLogger());
-  experimentUser = await experimentUserService.findOne(experimentUserDoc.id);
+  experimentUser = await experimentUserService.findOne(experimentUserDoc.id, new UpgradeLogger());
   objectToCheck = {
     ...experimentUsers[1],
     group: {
@@ -100,7 +100,7 @@ export default async function testCase(): Promise<void> {
     class: '2',
   }, { logger: new UpgradeLogger(), userDoc: experimentUserDoc});
   experimentUserDoc = await experimentUserService.getOriginalUserDoc(experimentUsers[2].id, new UpgradeLogger());
-  experimentUser = await experimentUserService.findOne(experimentUserDoc.id);
+  experimentUser = await experimentUserService.findOne(experimentUserDoc.id, new UpgradeLogger());
   objectToCheck = {
     ...experimentUsers[2],
     group: {
@@ -131,7 +131,7 @@ export default async function testCase(): Promise<void> {
     class: '1',
   }, { logger: new UpgradeLogger(), userDoc: experimentUserDoc});
   experimentUserDoc = await experimentUserService.getOriginalUserDoc(experimentUsers[3].id, new UpgradeLogger());
-  experimentUser = await experimentUserService.findOne(experimentUserDoc.id);
+  experimentUser = await experimentUserService.findOne(experimentUserDoc.id, new UpgradeLogger());
   objectToCheck = {
     ...experimentUsers[3],
     group: {
@@ -152,8 +152,8 @@ export default async function testCase(): Promise<void> {
   expect(experimentUser).toEqual(objectToCheck);
 
   // ===============  create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -175,10 +175,10 @@ export default async function testCase(): Promise<void> {
 
   // change experiment status to Enrolling
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -217,7 +217,7 @@ export default async function testCase(): Promise<void> {
     class: '2',
   }, { logger: new UpgradeLogger(), userDoc: experimentUserDoc});
   experimentUserDoc = await experimentUserService.getOriginalUserDoc(experimentUsers[0].id, new UpgradeLogger());
-  experimentUser = await experimentUserService.findOne(experimentUserDoc.id);
+  experimentUser = await experimentUserService.findOne(experimentUserDoc.id, new UpgradeLogger());
   objectToCheck = {
     ...experimentUsers[0],
     group: {
@@ -264,10 +264,10 @@ export default async function testCase(): Promise<void> {
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName, experimentPoint);
 
   // change experiment status to complete
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario2.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario2.ts
@@ -16,7 +16,7 @@ export default async function testCase(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = individualAssignmentExperimentConsistencyRuleExperiemnt;
@@ -26,8 +26,8 @@ export default async function testCase(): Promise<void> {
   const condition = experimentObject.conditions[0].conditionCode;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -50,10 +50,10 @@ export default async function testCase(): Promise<void> {
 
   // change experiment status to Enrolling
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -91,10 +91,10 @@ export default async function testCase(): Promise<void> {
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName, experimentPoint);
 
   // change experiment status to complete
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario3.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario3.ts
@@ -20,7 +20,7 @@ export default async function testCase(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = groupAssignmentWithGroupConsistencyExperiment;
@@ -30,8 +30,8 @@ export default async function testCase(): Promise<void> {
   const condition = experimentObject.conditions[0].conditionCode;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -54,10 +54,10 @@ export default async function testCase(): Promise<void> {
 
   // change experiment status to Enrolling
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -95,10 +95,10 @@ export default async function testCase(): Promise<void> {
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName, experimentPoint);
 
   // change experiment status to complete
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario4.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario4.ts
@@ -20,7 +20,7 @@ export default async function testCase(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = groupAssignmentWithIndividulaConsistencyExperiment;
@@ -30,8 +30,8 @@ export default async function testCase(): Promise<void> {
   const condition = experimentObject.conditions[0].conditionCode;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -54,10 +54,10 @@ export default async function testCase(): Promise<void> {
 
   // change experiment status to Enrolling
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -95,10 +95,10 @@ export default async function testCase(): Promise<void> {
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName, experimentPoint);
 
   // change experiment status to complete
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario5.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario5.ts
@@ -16,7 +16,7 @@ export default async function testCase(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = groupAssignmentWithExperimentConsistencyExperiment;
@@ -25,8 +25,8 @@ export default async function testCase(): Promise<void> {
   const experimentPoint = experimentObject.partitions[0].expPoint;
   const condition = experimentObject.conditions[0].conditionCode;
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -49,10 +49,10 @@ export default async function testCase(): Promise<void> {
 
   // change experiment status to Enrolling
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -90,10 +90,10 @@ export default async function testCase(): Promise<void> {
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName, experimentPoint);
 
   // change experiment status to complete
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario6.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario6.ts
@@ -22,7 +22,7 @@ export default async function testCase(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = groupAssignmentWithGroupConsistencyExperimentSwitchBeforeAssignment;
@@ -39,7 +39,7 @@ export default async function testCase(): Promise<void> {
     class: '2',
   }, { logger: new UpgradeLogger(), userDoc: experimentUserDoc});
   experimentUserDoc = await experimentUserService.getOriginalUserDoc(experimentUsers[0].id, new UpgradeLogger());
-  let experimentUser = await experimentUserService.findOne(experimentUserDoc.id);
+  let experimentUser = await experimentUserService.findOne(experimentUserDoc.id, new UpgradeLogger());
   let objectToCheck = {
     ...experimentUsers[0],
     group: {
@@ -64,8 +64,8 @@ export default async function testCase(): Promise<void> {
   const condition = experimentObject.conditions[0].conditionCode;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -96,7 +96,7 @@ export default async function testCase(): Promise<void> {
     class: '1',
   },{ logger: new UpgradeLogger(), userDoc: experimentUserDoc});
   experimentUserDoc = await experimentUserService.getOriginalUserDoc(experimentUsers[0].id, new UpgradeLogger());
-  experimentUser = await experimentUserService.findOne(experimentUserDoc.id);;
+  experimentUser = await experimentUserService.findOne(experimentUserDoc.id, new UpgradeLogger());;
   objectToCheck = {
     ...experimentUsers[0],
     group: {
@@ -118,10 +118,10 @@ export default async function testCase(): Promise<void> {
   // change experiment status to scheduled
   let experimentId = experiments[0].id;
   const date = new Date();
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.SCHEDULED, user, date);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.SCHEDULED, user, new UpgradeLogger(), date);
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -144,10 +144,10 @@ export default async function testCase(): Promise<void> {
 
   // change experiment status to Enrolling
   experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -184,10 +184,10 @@ export default async function testCase(): Promise<void> {
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName, experimentPoint);
 
   // change experiment status to complete
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario8.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario8.ts
@@ -18,7 +18,7 @@ export default async function testCase(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = groupAssignmentWithGroupConsistencyExperimentSwitchAfterAssignment;
@@ -38,7 +38,7 @@ export default async function testCase(): Promise<void> {
     class: '1',
   }, { logger: new UpgradeLogger(), userDoc: experimentUserDoc});
   experimentUserDoc = await experimentUserService.getOriginalUserDoc(experimentUsers[0].id, new UpgradeLogger());
-  let experimentUser = await experimentUserService.findOne(experimentUserDoc.id);
+  let experimentUser = await experimentUserService.findOne(experimentUserDoc.id, new UpgradeLogger());
   let objectToCheck = {
     ...experimentUsers[0],
     group: {
@@ -69,7 +69,7 @@ export default async function testCase(): Promise<void> {
     class: '2',
   }, { logger: new UpgradeLogger(), userDoc: experimentUserDoc});
   experimentUserDoc = await experimentUserService.getOriginalUserDoc(experimentUsers[1].id, new UpgradeLogger());
-  experimentUser = await experimentUserService.findOne(experimentUserDoc.id);
+  experimentUser = await experimentUserService.findOne(experimentUserDoc.id, new UpgradeLogger());
   objectToCheck = {
     ...experimentUsers[1],
     group: {
@@ -100,7 +100,7 @@ export default async function testCase(): Promise<void> {
     class: '2',
   }, { logger: new UpgradeLogger(), userDoc: experimentUserDoc});
   experimentUserDoc = await experimentUserService.getOriginalUserDoc(experimentUsers[2].id, new UpgradeLogger());
-  experimentUser = await experimentUserService.findOne(experimentUserDoc.id);
+  experimentUser = await experimentUserService.findOne(experimentUserDoc.id, new UpgradeLogger());
   objectToCheck = {
     ...experimentUsers[2],
     group: {
@@ -131,7 +131,7 @@ export default async function testCase(): Promise<void> {
     class: '1',
   }, { logger: new UpgradeLogger(), userDoc: experimentUserDoc});
   experimentUserDoc = await experimentUserService.getOriginalUserDoc(experimentUsers[3].id, new UpgradeLogger());
-  experimentUser = await experimentUserService.findOne(experimentUserDoc.id);
+  experimentUser = await experimentUserService.findOne(experimentUserDoc.id, new UpgradeLogger());
   objectToCheck = {
     ...experimentUsers[3],
     group: {
@@ -151,8 +151,8 @@ export default async function testCase(): Promise<void> {
   delete experimentUser.updatedAt;
   expect(experimentUser).toEqual(objectToCheck);
   // ===============  create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -167,10 +167,10 @@ export default async function testCase(): Promise<void> {
 
   // change experiment status to Enrolling
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -208,7 +208,7 @@ export default async function testCase(): Promise<void> {
     class: '2',
   }, { logger: new UpgradeLogger(), userDoc: experimentUserDoc});
   experimentUserDoc = await experimentUserService.getOriginalUserDoc(experimentUsers[0].id, new UpgradeLogger());
-  experimentUser = await experimentUserService.findOne(experimentUserDoc.id);
+  experimentUser = await experimentUserService.findOne(experimentUserDoc.id, new UpgradeLogger());
   objectToCheck = {
     ...experimentUsers[0],
     group: {
@@ -249,10 +249,10 @@ export default async function testCase(): Promise<void> {
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName, experimentPoint);
 
   // change experiment status to complete
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario9.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario9.ts
@@ -18,7 +18,7 @@ export default async function testCase(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = groupAssignmentWithIndividualConsistencyExperimentSwitchAfterAssignment;
@@ -38,7 +38,7 @@ export default async function testCase(): Promise<void> {
     class: '1',
   }, { logger: new UpgradeLogger(), userDoc: experimentUserDoc});
   experimentUserDoc = await experimentUserService.getOriginalUserDoc(experimentUsers[0].id, new UpgradeLogger());
-  let experimentUser = await experimentUserService.findOne(experimentUserDoc.id);
+  let experimentUser = await experimentUserService.findOne(experimentUserDoc.id, new UpgradeLogger());
   let objectToCheck = {
     ...experimentUsers[0],
     group: {
@@ -69,7 +69,7 @@ export default async function testCase(): Promise<void> {
     class: '2',
   }, { logger: new UpgradeLogger(), userDoc: experimentUserDoc});
   experimentUserDoc = await experimentUserService.getOriginalUserDoc(experimentUsers[1].id, new UpgradeLogger());
-  experimentUser = await experimentUserService.findOne(experimentUserDoc.id);
+  experimentUser = await experimentUserService.findOne(experimentUserDoc.id, new UpgradeLogger());
   objectToCheck = {
     ...experimentUsers[1],
     group: {
@@ -100,7 +100,7 @@ export default async function testCase(): Promise<void> {
     class: '2',
   }, { logger: new UpgradeLogger(), userDoc: experimentUserDoc});
   experimentUserDoc = await experimentUserService.getOriginalUserDoc(experimentUsers[2].id, new UpgradeLogger());
-  experimentUser = await experimentUserService.findOne(experimentUserDoc.id);
+  experimentUser = await experimentUserService.findOne(experimentUserDoc.id, new UpgradeLogger());
   objectToCheck = {
     ...experimentUsers[2],
     group: {
@@ -131,7 +131,7 @@ export default async function testCase(): Promise<void> {
     class: '1',
   }, { logger: new UpgradeLogger(), userDoc: experimentUserDoc});
   experimentUserDoc = await experimentUserService.getOriginalUserDoc(experimentUsers[3].id, new UpgradeLogger());
-  experimentUser = await experimentUserService.findOne(experimentUserDoc.id);
+  experimentUser = await experimentUserService.findOne(experimentUserDoc.id, new UpgradeLogger());
   objectToCheck = {
     ...experimentUsers[3],
     group: {
@@ -151,8 +151,8 @@ export default async function testCase(): Promise<void> {
   delete experimentUser.updatedAt;
   expect(experimentUser).toEqual(objectToCheck);
   // ===============  create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -167,10 +167,10 @@ export default async function testCase(): Promise<void> {
 
   // change experiment status to Enrolling
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -209,7 +209,7 @@ export default async function testCase(): Promise<void> {
     class: '2',
   }, { logger: new UpgradeLogger(), userDoc: experimentUserDoc});
   experimentUserDoc = await experimentUserService.getOriginalUserDoc(experimentUsers[0].id, new UpgradeLogger());
-  experimentUser = await experimentUserService.findOne(experimentUserDoc.id);
+  experimentUser = await experimentUserService.findOne(experimentUserDoc.id, new UpgradeLogger());
   objectToCheck = {
     ...experimentUsers[0],
     group: {
@@ -256,10 +256,10 @@ export default async function testCase(): Promise<void> {
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName, experimentPoint);
 
   // change experiment status to complete
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/ExperimentAssignment/index.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentAssignment/index.ts
@@ -26,7 +26,7 @@ const initialChecks = async () => {
   const checkService = Container.get<CheckService>(CheckService);
 
   // check all the tables are empty
-  const users = await userService.find();
+  const users = await userService.find(new UpgradeLogger());
   expect(users.length).toEqual(0);
 
   const monitoredPoints = await checkService.getAllMarkedExperimentPoints();
@@ -48,7 +48,7 @@ const initialChecks = async () => {
   await userService.create(experimentUsers as any, new UpgradeLogger());
 
   // get all user here
-  const userList = await userService.find();
+  const userList = await userService.find(new UpgradeLogger());
   expect(userList.length).toBe(experimentUsers.length);
   experimentUsers.map((user) => {
     expect(userList).toContainEqual(user);

--- a/backend/packages/Upgrade/test/integration/ExperimentStats/DetailGroupExperiment.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentStats/DetailGroupExperiment.ts
@@ -22,13 +22,13 @@ export default async function testCase(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
   // experiment object
   const experimentObject = groupExperimentStats;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  const experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  const experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -60,7 +60,7 @@ export default async function testCase(): Promise<void> {
   let markedExperimentPoint = await markExperimentPoint(experimentUsers[0].id, experimentName1, experimentPoint1, condition1, new UpgradeLogger());
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[0].id, experimentName1, experimentPoint1);
 
-  let checkData = await analyticsService.getDetailEnrollment(experimentId);
+  let checkData = await analyticsService.getDetailEnrollment(experimentId, new UpgradeLogger());
   expect(checkData).toEqual(
     expect.objectContaining({
       id: experimentId,
@@ -118,9 +118,9 @@ export default async function testCase(): Promise<void> {
   );
 
   // change experiment state to enrolling
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
-  checkData = await analyticsService.getDetailEnrollment(experimentId);
+  checkData = await analyticsService.getDetailEnrollment(experimentId, new UpgradeLogger());
   expect(checkData).toEqual(
     expect.objectContaining({
       id: experimentId,
@@ -187,7 +187,7 @@ export default async function testCase(): Promise<void> {
   markedExperimentPoint = await markExperimentPoint(experimentUsers[1].id, experimentName2, experimentPoint2, condition2, new UpgradeLogger());
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[1].id, experimentName2, experimentPoint2);
 
-  checkData = await analyticsService.getDetailEnrollment(experimentId);
+  checkData = await analyticsService.getDetailEnrollment(experimentId, new UpgradeLogger());
   expect(checkData).toEqual(
     expect.objectContaining({
       users: 0,
@@ -205,7 +205,7 @@ export default async function testCase(): Promise<void> {
   markedExperimentPoint = await markExperimentPoint(experimentUsers[2].id, experimentName1, experimentPoint1, condition1, new UpgradeLogger());
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName1, experimentPoint1);
 
-  checkData = await analyticsService.getDetailEnrollment(experimentId);
+  checkData = await analyticsService.getDetailEnrollment(experimentId, new UpgradeLogger());
   expect(checkData).toEqual(
     expect.objectContaining({
       users: 1,
@@ -216,7 +216,7 @@ export default async function testCase(): Promise<void> {
   );
 
   // change experiment state to enrolling
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
 
   experimentConditionAssignments = await getAllExperimentCondition(experimentUsers[3].id, new UpgradeLogger());
   checkExperimentAssignedIsNotDefault(experimentConditionAssignments, experimentName1, experimentPoint1);
@@ -226,7 +226,7 @@ export default async function testCase(): Promise<void> {
   markedExperimentPoint = await markExperimentPoint(experimentUsers[3].id, experimentName1, experimentPoint1, condition1, new UpgradeLogger());
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[3].id, experimentName1, experimentPoint1);
 
-  checkData = await analyticsService.getDetailEnrollment(experimentId);
+  checkData = await analyticsService.getDetailEnrollment(experimentId, new UpgradeLogger());
   expect(checkData).toEqual(
     expect.objectContaining({
       users: 1,

--- a/backend/packages/Upgrade/test/integration/ExperimentStats/DetailIndividualExperiment.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentStats/DetailIndividualExperiment.ts
@@ -21,16 +21,16 @@ export default async function testCase(): Promise<void> {
   const previewService = Container.get<PreviewUserService>(PreviewUserService);
 
   // creating preview user
-  const previewUser = await previewService.create(previewUsers[0]);
+  const previewUser = await previewService.create(previewUsers[0], new UpgradeLogger());
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
   // experiment object
   const experimentObject = individualExperimentStats;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  const experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  const experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -62,7 +62,7 @@ export default async function testCase(): Promise<void> {
   let markedExperimentPoint = await markExperimentPoint(experimentUsers[0].id, experimentName1, experimentPoint1, condition1, new UpgradeLogger());
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[0].id, experimentName1, experimentPoint1);
 
-  let checkData = await analyticsService.getDetailEnrollment(experimentId);
+  let checkData = await analyticsService.getDetailEnrollment(experimentId, new UpgradeLogger());
   expect(checkData).toEqual(
     expect.objectContaining({
       id: experimentId,
@@ -120,9 +120,9 @@ export default async function testCase(): Promise<void> {
   );
 
   // change experiment state to enrolling
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
-  checkData = await analyticsService.getDetailEnrollment(experimentId);
+  checkData = await analyticsService.getDetailEnrollment(experimentId, new UpgradeLogger());
   expect(checkData).toEqual(
     expect.objectContaining({
       id: experimentId,
@@ -189,7 +189,7 @@ export default async function testCase(): Promise<void> {
   markedExperimentPoint = await markExperimentPoint(experimentUsers[1].id, experimentName2, experimentPoint2, condition2, new UpgradeLogger());
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[1].id, experimentName2, experimentPoint2);
 
-  checkData = await analyticsService.getDetailEnrollment(experimentId);
+  checkData = await analyticsService.getDetailEnrollment(experimentId, new UpgradeLogger());
   expect(checkData).toEqual(
     expect.objectContaining({
       users: 1,
@@ -204,7 +204,7 @@ export default async function testCase(): Promise<void> {
   // because the user was excluded from the experiment
   expect(experimentConditionAssignments).toHaveLength(0);
 
-  checkData = await analyticsService.getDetailEnrollment(experimentId);
+  checkData = await analyticsService.getDetailEnrollment(experimentId, new UpgradeLogger());
   expect(checkData).toEqual(
     expect.objectContaining({
       users: 1,
@@ -225,7 +225,7 @@ export default async function testCase(): Promise<void> {
   markedExperimentPoint = await markExperimentPoint(experimentUsers[2].id, experimentName1, experimentPoint1, condition1, new UpgradeLogger());
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName1, experimentPoint1);
 
-  checkData = await analyticsService.getDetailEnrollment(experimentId);
+  checkData = await analyticsService.getDetailEnrollment(experimentId, new UpgradeLogger());
   expect(checkData).toEqual(
     expect.objectContaining({
       users: 2,
@@ -236,13 +236,13 @@ export default async function testCase(): Promise<void> {
   );
 
   // change experiment state to enrolling
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
 
   // mark experiment point
   markedExperimentPoint = await markExperimentPoint(experimentUsers[3].id, experimentName1, experimentPoint1, condition1, new UpgradeLogger());
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[3].id, experimentName1, experimentPoint1);
 
-  checkData = await analyticsService.getDetailEnrollment(experimentId);
+  checkData = await analyticsService.getDetailEnrollment(experimentId, new UpgradeLogger());
   expect(checkData).toEqual(
     expect.objectContaining({
       users: 2,

--- a/backend/packages/Upgrade/test/integration/ExperimentStats/GroupEnrollment.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentStats/GroupEnrollment.ts
@@ -22,13 +22,13 @@ export default async function testCase(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
   // experiment object
   const experimentObject = groupExperimentStats;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  const experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  const experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -42,7 +42,7 @@ export default async function testCase(): Promise<void> {
   );
 
   const experimentId = experiments[0].id;
-  let stats = await analyticsService.getEnrollments([experimentId]);
+  let stats = await analyticsService.getEnrollments([experimentId], new UpgradeLogger());
   expect(stats).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -70,7 +70,7 @@ export default async function testCase(): Promise<void> {
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[0].id, experimentName1, experimentPoint1);
 
   // check stats
-  stats = await analyticsService.getEnrollments([experimentId]);
+  stats = await analyticsService.getEnrollments([experimentId], new UpgradeLogger());
   expect(stats).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -82,7 +82,7 @@ export default async function testCase(): Promise<void> {
   );
 
   // change experiment state to enrolling
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // user 2 logs in experiment
   // get all experiment condition for user 2
@@ -95,7 +95,7 @@ export default async function testCase(): Promise<void> {
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[1].id, experimentName1, experimentPoint1);
 
   // check stats
-  stats = await analyticsService.getEnrollments([experimentId]);
+  stats = await analyticsService.getEnrollments([experimentId], new UpgradeLogger());
   expect(stats).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -116,7 +116,7 @@ export default async function testCase(): Promise<void> {
   markedExperimentPoint = await markExperimentPoint(experimentUsers[2].id, experimentName2, experimentPoint2, condition2, new UpgradeLogger());
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName2, experimentPoint2);
 
-  stats = await analyticsService.getEnrollments([experimentId]);
+  stats = await analyticsService.getEnrollments([experimentId], new UpgradeLogger());
   expect(stats).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -137,7 +137,7 @@ export default async function testCase(): Promise<void> {
   markedExperimentPoint = await markExperimentPoint(experimentUsers[3].id, experimentName1, experimentPoint1, condition1, new UpgradeLogger());
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[3].id, experimentName1, experimentPoint1);
 
-  stats = await analyticsService.getEnrollments([experimentId]);
+  stats = await analyticsService.getEnrollments([experimentId], new UpgradeLogger());
   expect(stats).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -149,5 +149,5 @@ export default async function testCase(): Promise<void> {
   );
 
   // change experiment state to enrolling
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
 }

--- a/backend/packages/Upgrade/test/integration/ExperimentStats/IndividualEnrollment.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentStats/IndividualEnrollment.ts
@@ -25,16 +25,16 @@ export default async function testCase(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating preview user
-  const previewUser = await previewService.create(previewUsers[3]);
+  const previewUser = await previewService.create(previewUsers[3], new UpgradeLogger());
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
   // experiment object
   const experimentObject = individualExperimentStats;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  const experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  const experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -75,7 +75,7 @@ export default async function testCase(): Promise<void> {
   markedExperimentPoint = await markExperimentPoint(experimentUsers[0].id, experimentName1, experimentPoint1, condition1, new UpgradeLogger());
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[0].id, experimentName1, experimentPoint1);
 
-  let stats = await analyticsService.getEnrollments([experimentId]);
+  let stats = await analyticsService.getEnrollments([experimentId], new UpgradeLogger());
   expect(stats).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -87,7 +87,7 @@ export default async function testCase(): Promise<void> {
   );
 
   // change experiment state to enrolling
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // user 2 logs in experiment
   // get all experiment condition for user 2
@@ -95,7 +95,7 @@ export default async function testCase(): Promise<void> {
   checkExperimentAssignedIsNotDefault(experimentConditionAssignments, experimentName1, experimentPoint1);
   checkExperimentAssignedIsNotDefault(experimentConditionAssignments, experimentName2, experimentPoint2);
 
-  stats = await analyticsService.getEnrollments([experimentId]);
+  stats = await analyticsService.getEnrollments([experimentId], new UpgradeLogger());
   expect(stats).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -112,7 +112,7 @@ export default async function testCase(): Promise<void> {
   markedExperimentPoint = await markExperimentPoint(experimentUsers[0].id, experimentName1, experimentPoint1, condition1, new UpgradeLogger());
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[0].id, experimentName1, experimentPoint1);
 
-  stats = await analyticsService.getEnrollments([experimentId]);
+  stats = await analyticsService.getEnrollments([experimentId], new UpgradeLogger());
   expect(stats).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -127,7 +127,7 @@ export default async function testCase(): Promise<void> {
   markedExperimentPoint = await markExperimentPoint(experimentUsers[1].id, experimentName1, experimentPoint1, condition1, new UpgradeLogger());
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[1].id, experimentName1, experimentPoint1);
 
-  stats = await analyticsService.getEnrollments([experimentId]);
+  stats = await analyticsService.getEnrollments([experimentId], new UpgradeLogger());
   expect(stats.length).toEqual(1);
   expect(stats).toEqual(
     expect.arrayContaining([
@@ -147,7 +147,7 @@ export default async function testCase(): Promise<void> {
   checkMarkExperimentPointForUser(markedExperimentPoint, previewUser.id, experimentName2, experimentPoint2);
 
   // number of users should not increase
-  stats = await analyticsService.getEnrollments([experimentId]);
+  stats = await analyticsService.getEnrollments([experimentId], new UpgradeLogger());
   expect(stats.length).toEqual(1);
   expect(stats).toEqual(
     expect.arrayContaining([
@@ -167,7 +167,7 @@ export default async function testCase(): Promise<void> {
   markedExperimentPoint = await markExperimentPoint(experimentUsers[2].id, experimentName2, experimentPoint2, condition2, new UpgradeLogger());
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName2, experimentPoint2);
 
-  stats = await analyticsService.getEnrollments([experimentId]);
+  stats = await analyticsService.getEnrollments([experimentId], new UpgradeLogger());
   expect(stats).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/ExperimentStats/index.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentStats/index.ts
@@ -13,7 +13,7 @@ const initialChecks = async () => {
   const checkService = Container.get<CheckService>(CheckService);
 
   // check all the tables are empty
-  const users = await userService.find();
+  const users = await userService.find(new UpgradeLogger());
   expect(users.length).toEqual(0);
 
   const monitoredPoints = await checkService.getAllMarkedExperimentPoints();
@@ -35,7 +35,7 @@ const initialChecks = async () => {
   await userService.create(experimentUsers as any, new UpgradeLogger());
 
   // get all user here
-  const userList = await userService.find();
+  const userList = await userService.find(new UpgradeLogger());
   expect(userList.length).toBe(experimentUsers.length);
   experimentUsers.map((user) => {
     expect(userList).toContainEqual(user);

--- a/backend/packages/Upgrade/test/integration/ExperimentUser/NoExperimentUserOnAssignment.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentUser/NoExperimentUserOnAssignment.ts
@@ -16,14 +16,14 @@ export default async function testCase(): Promise<void> {
   const experimentUserService = Container.get<ExperimentUserService>(ExperimentUserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = individualAssignmentExperiment;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  const experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  const experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -36,12 +36,12 @@ export default async function testCase(): Promise<void> {
     ])
   );
 
-  let experimentUser = await experimentUserService.find();
+  let experimentUser = await experimentUserService.find(new UpgradeLogger());
   expect(experimentUser.length).toEqual(0);
 
   // get all experiment condition for user 1
   await expect(getAllExperimentCondition(experimentUsers[0].id, new UpgradeLogger())).rejects.toThrow();
 
-  experimentUser = await experimentUserService.find();
+  experimentUser = await experimentUserService.find(new UpgradeLogger());
   expect(experimentUser.length).toEqual(0);
 }

--- a/backend/packages/Upgrade/test/integration/ExperimentUser/index.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentUser/index.ts
@@ -10,7 +10,7 @@ const initialChecks = async () => {
   const checkService = Container.get<CheckService>(CheckService);
 
   // check all the tables are empty
-  const users = await userService.find();
+  const users = await userService.find(new UpgradeLogger());
   expect(users.length).toEqual(0);
 
   const monitoredPoints = await checkService.getAllMarkedExperimentPoints();
@@ -32,7 +32,7 @@ const initialChecks = async () => {
   await userService.create(experimentUsers as any, new UpgradeLogger());
 
   // get all user here
-  const userList = await userService.find();
+  const userList = await userService.find(new UpgradeLogger());
   expect(userList.length).toBe(experimentUsers.length);
   experimentUsers.map((user) => {
     expect(userList).toContainEqual(user);

--- a/backend/packages/Upgrade/test/integration/ExplicitExclude/GroupExclude.ts
+++ b/backend/packages/Upgrade/test/integration/ExplicitExclude/GroupExclude.ts
@@ -17,14 +17,14 @@ export default async function GroupExclude(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const userIn = await userService.upsertUser(systemUser as any);
+  const userIn = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = groupAssignmentWithGroupConsistencyExperiment;
 
   // create experiment
-  await experimentService.create(experimentObject as any, userIn);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, userIn, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -39,10 +39,10 @@ export default async function GroupExclude(): Promise<void> {
 
   // change experiment status to Enrolling
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, userIn);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, userIn, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/ExplicitExclude/IndividualExclude.ts
+++ b/backend/packages/Upgrade/test/integration/ExplicitExclude/IndividualExclude.ts
@@ -17,14 +17,14 @@ export default async function IndividualExclude(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const userIn = await userService.upsertUser(systemUser as any);
+  const userIn = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = individualAssignmentExperiment;
 
   // create experiment
-  await experimentService.create(individualAssignmentExperiment as any, userIn);
-  let experiments = await experimentService.find();
+  await experimentService.create(individualAssignmentExperiment as any, userIn, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -39,10 +39,10 @@ export default async function IndividualExclude(): Promise<void> {
 
   // change experiment status to Enrolling
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, userIn);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, userIn, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/ExplicitExclude/index.ts
+++ b/backend/packages/Upgrade/test/integration/ExplicitExclude/index.ts
@@ -11,7 +11,7 @@ const initialCheck = async () => {
   const checkService = Container.get<CheckService>(CheckService);
 
   // check all the tables are empty
-  const users = await userService.find();
+  const users = await userService.find(new UpgradeLogger());
   expect(users.length).toEqual(0);
 
   const monitoredPoints = await checkService.getAllMarkedExperimentPoints();
@@ -33,7 +33,7 @@ const initialCheck = async () => {
   await userService.create(experimentUsers as any, new UpgradeLogger());
 
   // get all user here
-  const userList = await userService.find();
+  const userList = await userService.find(new UpgradeLogger());
   expect(userList.length).toBe(experimentUsers.length);
   experimentUsers.map(user => {
     expect(userList).toContainEqual(user);

--- a/backend/packages/Upgrade/test/integration/PreviewExperiment/DeletePreviewAssignmentOnExperimentDelete.ts
+++ b/backend/packages/Upgrade/test/integration/PreviewExperiment/DeletePreviewAssignmentOnExperimentDelete.ts
@@ -6,6 +6,7 @@ import { systemUser } from '../mockData/user/index';
 import { previewIndividualAssignmentExperiment } from '../mockData/experiment';
 import { PreviewUserService } from '../../../src/api/services/PreviewUserService';
 import { previewUsers } from '../mockData/previewUsers/index';
+import { UpgradeLogger } from '../../../src/lib/logger/UpgradeLogger';
 
 export default async function testCase(): Promise<void> {
   const logger = new WinstonLogger(__filename);
@@ -14,14 +15,14 @@ export default async function testCase(): Promise<void> {
   const previewService = Container.get<PreviewUserService>(PreviewUserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = previewIndividualAssignmentExperiment;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  const experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  const experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -35,7 +36,7 @@ export default async function testCase(): Promise<void> {
   );
 
   // creating preview user
-  const previewUser = await previewService.create(previewUsers[0]);
+  const previewUser = await previewService.create(previewUsers[0], new UpgradeLogger());
 
   // add single assignments for
   const previewDocuments: any = {
@@ -52,9 +53,9 @@ export default async function testCase(): Promise<void> {
     ],
   };
 
-  await previewService.upsertExperimentConditionAssignment(previewDocuments);
+  await previewService.upsertExperimentConditionAssignment(previewDocuments, new UpgradeLogger());
 
-  let previewUsersData = await previewService.find();
+  let previewUsersData = await previewService.find(new UpgradeLogger());
   expect(previewUsersData[0].assignments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -68,8 +69,8 @@ export default async function testCase(): Promise<void> {
     ])
   );
 
-  await experimentService.delete(experiments[0].id, user);
-  previewUsersData = await previewService.find();
+  await experimentService.delete(experiments[0].id, user, new UpgradeLogger());
+  previewUsersData = await previewService.find(new UpgradeLogger());
 
   expect(previewUsersData[0].assignments).toBeUndefined();
 }

--- a/backend/packages/Upgrade/test/integration/PreviewExperiment/DeletePreviewAssignmentWithPreviewUserDelete.ts
+++ b/backend/packages/Upgrade/test/integration/PreviewExperiment/DeletePreviewAssignmentWithPreviewUserDelete.ts
@@ -6,6 +6,7 @@ import { systemUser } from '../mockData/user/index';
 import { previewIndividualAssignmentExperiment } from '../mockData/experiment';
 import { PreviewUserService } from '../../../src/api/services/PreviewUserService';
 import { previewUsers } from '../mockData/previewUsers/index';
+import { UpgradeLogger } from '../../../src/lib/logger/UpgradeLogger';
 
 export default async function testCase(): Promise<void> {
   const logger = new WinstonLogger(__filename);
@@ -14,14 +15,14 @@ export default async function testCase(): Promise<void> {
   const previewService = Container.get<PreviewUserService>(PreviewUserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = previewIndividualAssignmentExperiment;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  const experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  const experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -35,7 +36,7 @@ export default async function testCase(): Promise<void> {
   );
 
   // creating preview user
-  const previewUser = await previewService.create(previewUsers[0]);
+  const previewUser = await previewService.create(previewUsers[0], new UpgradeLogger());
 
   // add single assignments for
   const previewDocuments: any = {
@@ -52,9 +53,9 @@ export default async function testCase(): Promise<void> {
     ],
   };
 
-  await previewService.upsertExperimentConditionAssignment(previewDocuments);
+  await previewService.upsertExperimentConditionAssignment(previewDocuments, new UpgradeLogger());
 
-  let previewUsersData = await previewService.find();
+  let previewUsersData = await previewService.find(new UpgradeLogger());
   expect(previewUsersData[0].assignments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -68,8 +69,8 @@ export default async function testCase(): Promise<void> {
     ])
   );
 
-  await previewService.delete(previewUsersData[0].id);
-  previewUsersData = await previewService.find();
+  await previewService.delete(previewUsersData[0].id, new UpgradeLogger());
+  previewUsersData = await previewService.find(new UpgradeLogger());
 
   expect(previewUsersData.length).toEqual(0);
 }

--- a/backend/packages/Upgrade/test/integration/PreviewExperiment/DeletePreviewAssignmentsWithExperimentUpdate.ts
+++ b/backend/packages/Upgrade/test/integration/PreviewExperiment/DeletePreviewAssignmentsWithExperimentUpdate.ts
@@ -6,6 +6,7 @@ import { systemUser } from '../mockData/user/index';
 import { previewIndividualAssignmentExperiment } from '../mockData/experiment';
 import { PreviewUserService } from '../../../src/api/services/PreviewUserService';
 import { previewUsers } from '../mockData/previewUsers/index';
+import { UpgradeLogger } from '../../../src/lib/logger/UpgradeLogger';
 
 export default async function testCase(): Promise<void> {
   const logger = new WinstonLogger(__filename);
@@ -14,14 +15,14 @@ export default async function testCase(): Promise<void> {
   const previewService = Container.get<PreviewUserService>(PreviewUserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = previewIndividualAssignmentExperiment;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  const experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  const experiments = await experimentService.find(new UpgradeLogger());
 
   // sort conditions
   experiments[0].conditions.sort((a,b) => {
@@ -46,7 +47,7 @@ export default async function testCase(): Promise<void> {
   );
 
   // creating preview user
-  const previewUser = await previewService.create(previewUsers[0]);
+  const previewUser = await previewService.create(previewUsers[0], new UpgradeLogger());
 
   // add single assignments for
   const previewDocuments: any = {
@@ -63,9 +64,9 @@ export default async function testCase(): Promise<void> {
     ],
   };
 
-  await previewService.upsertExperimentConditionAssignment(previewDocuments);
+  await previewService.upsertExperimentConditionAssignment(previewDocuments, new UpgradeLogger());
 
-  const previewUsersData = await previewService.find();
+  const previewUsersData = await previewService.find(new UpgradeLogger());
   expect(previewUsersData[0].assignments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -98,7 +99,7 @@ export default async function testCase(): Promise<void> {
     const newCondition = {...condition, order: index + 1};
     newExperimentDoc.conditions[index] = newCondition;
   });
-  const updatedExperimentDoc = await experimentService.update(newExperimentDoc.id, newExperimentDoc as any, user);
+  const updatedExperimentDoc = await experimentService.update(newExperimentDoc.id, newExperimentDoc as any, user, new UpgradeLogger());
 
   // check the conditions
   expect(updatedExperimentDoc.conditions).toEqual(

--- a/backend/packages/Upgrade/test/integration/PreviewExperiment/NoPreviewUser.ts
+++ b/backend/packages/Upgrade/test/integration/PreviewExperiment/NoPreviewUser.ts
@@ -14,14 +14,14 @@ export default async function testCase(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = previewIndividualAssignmentExperiment;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  const experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  const experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/PreviewExperiment/PreviewAssignments.ts
+++ b/backend/packages/Upgrade/test/integration/PreviewExperiment/PreviewAssignments.ts
@@ -6,6 +6,7 @@ import { systemUser } from '../mockData/user/index';
 import { PreviewUserService } from '../../../src/api/services/PreviewUserService';
 import { previewUsers } from '../mockData/previewUsers/index';
 import { previewIndividualAssignmentExperiment } from '../mockData/experiment/index';
+import { UpgradeLogger } from '../../../src/lib/logger/UpgradeLogger';
 
 export default async function testCase(): Promise<void> {
   const logger = new WinstonLogger(__filename);
@@ -14,14 +15,14 @@ export default async function testCase(): Promise<void> {
   const previewService = Container.get<PreviewUserService>(PreviewUserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = previewIndividualAssignmentExperiment;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  const experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  const experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -35,7 +36,7 @@ export default async function testCase(): Promise<void> {
   );
 
   // creating preview user
-  const previewUser = await previewService.create(previewUsers[0]);
+  const previewUser = await previewService.create(previewUsers[0], new UpgradeLogger());
 
   // add single assignments for
   let previewDocuments: any = {
@@ -52,9 +53,9 @@ export default async function testCase(): Promise<void> {
     ],
   };
 
-  await previewService.upsertExperimentConditionAssignment(previewDocuments);
+  await previewService.upsertExperimentConditionAssignment(previewDocuments, new UpgradeLogger());
 
-  let previewUsersData = await previewService.find();
+  let previewUsersData = await previewService.find(new UpgradeLogger());
   expect(previewUsersData[0].assignments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -84,9 +85,9 @@ export default async function testCase(): Promise<void> {
     ],
   };
 
-  await previewService.upsertExperimentConditionAssignment(previewDocuments);
+  await previewService.upsertExperimentConditionAssignment(previewDocuments, new UpgradeLogger());
 
-  previewUsersData = await previewService.find();
+  previewUsersData = await previewService.find(new UpgradeLogger());
   expect(previewUsersData[0].assignments.length).toEqual(2);
   expect(previewUsersData[0].assignments).toEqual(
     expect.arrayContaining([
@@ -115,9 +116,9 @@ export default async function testCase(): Promise<void> {
     assignments: [{ ...previewUsersData[0].assignments[0] }],
   };
 
-  await previewService.upsertExperimentConditionAssignment(previewDocuments);
+  await previewService.upsertExperimentConditionAssignment(previewDocuments, new UpgradeLogger());
 
-  previewUsersData = await previewService.find();
+  previewUsersData = await previewService.find(new UpgradeLogger());
   expect(previewUsersData[0].assignments.length).toEqual(1);
   expect(previewUsersData[0].assignments).toEqual(
     expect.arrayContaining([

--- a/backend/packages/Upgrade/test/integration/PreviewExperiment/PreviewExperimentWithPreviewUser.ts
+++ b/backend/packages/Upgrade/test/integration/PreviewExperiment/PreviewExperimentWithPreviewUser.ts
@@ -17,17 +17,17 @@ export default async function testCase(): Promise<void> {
   const previewService = Container.get<PreviewUserService>(PreviewUserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // creating preview user
-  const previewUser = await previewService.create(previewUsers[0]);
+  const previewUser = await previewService.create(previewUsers[0], new UpgradeLogger());
 
   // experiment object
   const experimentObject = previewIndividualAssignmentExperiment;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  const experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  const experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/PreviewExperiment/index.ts
+++ b/backend/packages/Upgrade/test/integration/PreviewExperiment/index.ts
@@ -15,7 +15,7 @@ const initialChecks = async () => {
   const checkService = Container.get<CheckService>(CheckService);
 
   // check all the tables are empty
-  const users = await userService.find();
+  const users = await userService.find(new UpgradeLogger());
   expect(users.length).toEqual(0);
 
   const monitoredPoints = await checkService.getAllMarkedExperimentPoints();
@@ -37,7 +37,7 @@ const initialChecks = async () => {
   await userService.create(experimentUsers as any, new UpgradeLogger());
 
   // get all user here
-  const userList = await userService.find();
+  const userList = await userService.find(new UpgradeLogger());
   expect(userList.length).toBe(experimentUsers.length);
   experimentUsers.map(user => {
     expect(userList).toContainEqual(user);

--- a/backend/packages/Upgrade/test/integration/Support/getAssignments.ts
+++ b/backend/packages/Upgrade/test/integration/Support/getAssignments.ts
@@ -18,14 +18,14 @@ export default async function testCase(): Promise<void> {
   const userService = Container.get<UserService>(UserService);
 
   // creating new user
-  const user = await userService.upsertUser(systemUser as any);
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
 
   // experiment object
   const experimentObject = individualAssignmentExperiment;
 
   // create experiment
-  await experimentService.create(experimentObject as any, user);
-  let experiments = await experimentService.find();
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  let experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -55,10 +55,10 @@ export default async function testCase(): Promise<void> {
 
   // change experiment status to Enrolling
   const experimentId = experiments[0].id;
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLING, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -109,10 +109,10 @@ export default async function testCase(): Promise<void> {
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName, experimentPoint);
 
   // change experiment status to complete
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user);
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
 
   // fetch experiment
-  experiments = await experimentService.find();
+  experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/backend/packages/Upgrade/test/integration/Support/index.ts
+++ b/backend/packages/Upgrade/test/integration/Support/index.ts
@@ -10,7 +10,7 @@ const initialChecks = async () => {
   const checkService = Container.get<CheckService>(CheckService);
 
   // check all the tables are empty
-  const users = await userService.find();
+  const users = await userService.find(new UpgradeLogger());
   expect(users.length).toEqual(0);
 
   const monitoredPoints = await checkService.getAllMarkedExperimentPoints();
@@ -32,7 +32,7 @@ const initialChecks = async () => {
   await userService.create(experimentUsers as any, new UpgradeLogger());
 
   // get all user here
-  const userList = await userService.find();
+  const userList = await userService.find(new UpgradeLogger());
   expect(userList.length).toBe(experimentUsers.length);
   experimentUsers.map((user) => {
     expect(userList).toContainEqual(user);

--- a/backend/packages/Upgrade/test/integration/SystemUser/index.ts
+++ b/backend/packages/Upgrade/test/integration/SystemUser/index.ts
@@ -1,10 +1,11 @@
 import { UserService } from '../../../src/api/services/UserService';
 import Container from 'typedi';
 import { systemUserDoc } from '../../../src/init/seed/systemUser';
+import { UpgradeLogger } from '../../../src/lib/logger/UpgradeLogger';
 
 export const SystemUserCreated = async () => {
   const userService = Container.get<UserService>(UserService);
-  const users = await userService.find();
+  const users = await userService.find(new UpgradeLogger());
 
   expect(users).toEqual(expect.arrayContaining([expect.objectContaining(systemUserDoc)]));
 };

--- a/backend/packages/Upgrade/test/integration/UserNotDefined/index.ts
+++ b/backend/packages/Upgrade/test/integration/UserNotDefined/index.ts
@@ -7,20 +7,20 @@ import { experimentUsers } from '../mockData/experimentUsers/index';
 export const UserNotDefined = async () => {
   const experimentUserService = Container.get<ExperimentUserService>(ExperimentUserService);
   const experimentAssignmentService = Container.get<ExperimentAssignmentService>(ExperimentAssignmentService);
-
-  await expect(experimentAssignmentService.getAllExperimentConditions(experimentUsers[0].id, null, new UpgradeLogger(), null)).rejects.toThrow();
+  let experimentUserDoc = await experimentUserService.getOriginalUserDoc(experimentUsers[0].id, new UpgradeLogger());
+  await expect(experimentAssignmentService.getAllExperimentConditions(experimentUsers[0].id, null, { logger: new UpgradeLogger(), userDoc: experimentUserDoc}, null)).rejects.toThrow();
 
   await expect(experimentAssignmentService.blobDataLog(experimentUsers[0].id, null, new UpgradeLogger())).rejects.toThrow();
 
-  await expect(experimentAssignmentService.dataLog(experimentUsers[0].id, null, new UpgradeLogger())).rejects.toThrow();
+  await expect(experimentAssignmentService.dataLog(experimentUsers[0].id, null, { logger: new UpgradeLogger(), userDoc: experimentUserDoc})).rejects.toThrow();
 
-  await expect(experimentAssignmentService.clientFailedExperimentPoint(null, null, experimentUsers[0].id, null, new UpgradeLogger())).rejects.toThrow();
+  await expect(experimentAssignmentService.clientFailedExperimentPoint(null, null, experimentUsers[0].id, null, { logger: new UpgradeLogger(), userDoc: experimentUserDoc})).rejects.toThrow();
 
-  await expect(experimentAssignmentService.markExperimentPoint(experimentUsers[0].id, null, null, new UpgradeLogger(), null)).rejects.toThrow();
+  await expect(experimentAssignmentService.markExperimentPoint(experimentUsers[0].id, null, null, { logger: new UpgradeLogger(), userDoc: experimentUserDoc}, null)).rejects.toThrow();
 
-  await expect(experimentUserService.setAliasesForUser(experimentUsers[0].id, null, new UpgradeLogger())).rejects.toThrow();
+  await expect(experimentUserService.setAliasesForUser(experimentUsers[0].id, null, { logger: new UpgradeLogger(), userDoc: experimentUserDoc})).rejects.toThrow();
 
-  await expect(experimentUserService.updateGroupMembership(experimentUsers[0].id, null, new UpgradeLogger())).rejects.toThrow();
+  await expect(experimentUserService.updateGroupMembership(experimentUsers[0].id, null, { logger: new UpgradeLogger(), userDoc: experimentUserDoc})).rejects.toThrow();
 
-  await expect(experimentUserService.updateWorkingGroup(experimentUsers[0].id, null, new UpgradeLogger())).rejects.toThrow();
+  await expect(experimentUserService.updateWorkingGroup(experimentUsers[0].id, null, { logger: new UpgradeLogger(), userDoc: experimentUserDoc})).rejects.toThrow();
 };


### PR DESCRIPTION
PR-2: This includes logger format change for all controllers except ExperimentClientController which is covered in PR-1.

This will replace all the old logger instances throughout the codebase.