### PR TITLE
set response status code

### DIFF
--- a/backend/packages/Upgrade/src/api/middlewares/ErrorHandlerMiddleware.ts
+++ b/backend/packages/Upgrade/src/api/middlewares/ErrorHandlerMiddleware.ts
@@ -110,6 +110,8 @@ export class ErrorHandlerMiddleware implements ExpressErrorMiddlewareInterface {
       ? await this.errorService.create(experimentError, req.logger)
       : await Promise.resolve(error);
     if (!res.headersSent) {
+      res.statusCode = error.httpCode;
+      res.json(error);
       next(error);
     }
   }


### PR DESCRIPTION
Looking into this error, this question https://github.com/typestack/routing-controllers/issues/433 shows a solution where the json/status code should be set if the headers are not sent. I tested this locally by turning on authorization and verifying that I was receiving 4xx status codes instead of 500 when unauthenticated.