### PR TITLE
update docker image to 12.22.1

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.7.0-alpine
+FROM node:12.22.1-alpine
 
 ENV NEW_RELIC_NO_CONFIG_FILE=true
 ENV NR_NATIVE_METRICS_NO_BUILD=true

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.22.1-alpine
+FROM node:12.22.10-alpine
 
 ENV NEW_RELIC_NO_CONFIG_FILE=true
 ENV NR_NATIVE_METRICS_NO_BUILD=true


### PR DESCRIPTION
#260 #267

Updating node image 12.7 -> 12.22 in docker. This will ensure code will work for `api/query/analyze` endpoint.

Pushing this now because it is blocking ability to push QA code to production. Linking issue #267 for upgrading the docker image @ppratikcr7, node version 16 was not working smoothly for us in local yet (npm install / dependency version issues raise questions), still needs to be looked into further.

Tested via @kawcl's local-docker branch off of latest dev with recent replica of QA db.

@amurphy-cl 