### PR TITLE
Revert "Returning an empty object for experiment point/ID where user is getting 'default' condition."

### DIFF
--- a/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
@@ -494,8 +494,7 @@ export class ExperimentAssignmentService {
             },
           };
         });
-
-        return [...accumulator, ...partitions]
+        return assignment ? [...accumulator, ...partitions] : accumulator;
       }, []);
     } catch (err) {
       const error = err as ErrorWithType;

--- a/backend/packages/Upgrade/test/integration/ExperimentStats/DetailIndividualExperiment.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentStats/DetailIndividualExperiment.ts
@@ -202,7 +202,7 @@ export default async function testCase(): Promise<void> {
   // when preview user is assigned an experiment condition
   experimentConditionAssignments = await getAllExperimentCondition(previewUser.id, new UpgradeLogger());
   // because the user was excluded from the experiment
-  expect(experimentConditionAssignments).not.toHaveLength(0);
+  expect(experimentConditionAssignments).toHaveLength(0);
 
   checkData = await analyticsService.getDetailEnrollment(experimentId, new UpgradeLogger());
   expect(checkData).toEqual(

--- a/backend/packages/Upgrade/test/integration/utils/index.ts
+++ b/backend/packages/Upgrade/test/integration/utils/index.ts
@@ -18,7 +18,7 @@ export function checkExperimentAssignedIsNull(
   experimentName: string,
   experimentPoint: string
 ): void {
-  expect(experimentConditionAssignments).toEqual(
+  expect(experimentConditionAssignments).not.toEqual(
     expect.arrayContaining([
       expect.objectContaining({
         expId: experimentName,


### PR DESCRIPTION
Reverts CarnegieLearningWeb/UpGrade#221