### PR TITLE
adds global css to override tooltip/selection option truncation

### DIFF
--- a/frontend/projects/upgrade/src/styles.scss
+++ b/frontend/projects/upgrade/src/styles.scss
@@ -196,3 +196,17 @@
     opacity: 0 !important;
   }
 }
+
+// Material library doesn't expose any params to prevent content truncation for these widgets.
+// Therefore we override the css. If option appears in future, these can go away.
+
+// Added to globally prevent truncation of content dropdowns
+.mat-select-panel-wrap .mat-select-panel {
+  max-width: fit-content;
+}
+
+// Added to globally prevent truncation in tooltips
+.mat-tooltip {
+  word-break: break-all;
+  white-space: normal;
+}


### PR DESCRIPTION
This takes care of #308 #310

For both the [MatTooltip](https://material.angular.io/components/tooltip/api) and [MatSelect Options](https://material.angular.io/components/select/overview) widgets, truncation for long content is automatic. No param is exposed that allows you to change this, so this is a basic css override to accommodate long text values, but note, this would be _**global**_ change for all tooltips and dropdowns.

Tooltips will just wrap, which look pretty natural, no issues.
Dropdowns will extend horizontally without wrapping, see notes below:

<img width="783" alt="Screen Shot 2022-03-18 at 3 10 32 PM" src="https://user-images.githubusercontent.com/97542869/159071531-fa29607c-c6d1-4cd4-b549-3fcaeab2403a.png">
nt.com/97542869/159071524-46aa15aa-b820-46f8-8fe6-dd7a77286c9e.png">
<img width="929" alt="Screen Shot 2022-03-18 at 3 10 45 PM" src="https://user-images.githubusercontent.com/97542869/159071540-c8fc77ea-5f44-4b69-92d3-c0c2276310a5.png">
<img width="619" alt="Screen Shot 2022-03-18 at 3 09 59 PM" src="https://user-images.githubusercontent.com/97542869/159071542-742faab2-3b8e-4d54-a08b-727d64fc4d07.png">
<img width="1481" alt="Screen Shot 2022-03-18 at 3 09 35 PM" src="https://user-images.githubusercontent.com/97542869/159071665-156cb0d4-cd67-42ab-95e2-6f9b947080fd.png">

A quick look around the UI seemed pretty good, tooltips shouldn't cause any issues with long texts. These dropdown select option widths could get pretty wide depending on the length of the text, but it looks like this will work well.

If long horizontal text turns out to cause some real estate issues, there are some other ways: you could have a dropdown of 'normal' width that allows overflow of text, which would create a horizontal scrollbar, which is kind of gross:

<img width="510" alt="image" src="https://user-images.githubusercontent.com/97542869/159072427-54de960e-5dca-4433-9f05-ac51eba6223d.png">

Or some word-wrap, which I only messed around with a little bit, it could improved but still, kinda gross, and could grow pretty long vertically:

<img width="423" alt="image" src="https://user-images.githubusercontent.com/97542869/159073059-e6cd29dc-00f0-4322-9bf2-ffbab7536556.png">




