### PR TITLE
fix for off metric data due to excluded users data pulled in

### DIFF
--- a/backend/packages/Upgrade/src/api/repositories/LogRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/LogRepository.ts
@@ -7,6 +7,7 @@ import { OPERATION_TYPES, IMetricMetaData, REPEATED_MEASURE } from 'upgrade_type
 import { METRICS_JOIN_TEXT } from '../services/MetricService';
 import { Query } from '../models/Query';
 import { Metric } from '../models/Metric';
+import { MonitoredExperimentPoint } from '../models/MonitoredExperimentPoint';
 
 @EntityRepository(Log)
 export class LogRepository extends Repository<Log> {
@@ -293,6 +294,7 @@ export class LogRepository extends Repository<Log> {
     const experimentRepo = getRepository(Experiment);
     return experimentRepo
       .createQueryBuilder('experiment')
+      .innerJoin('experiment.partitions', 'partitions')
       .innerJoin('experiment.queries', 'queries')
       .innerJoin('queries.metric', 'metric')
       .innerJoin('metric.logs', 'logs')
@@ -300,6 +302,11 @@ export class LogRepository extends Repository<Log> {
         IndividualAssignment,
         'individualAssignment',
         'experiment.id = "individualAssignment"."experimentId" AND logs."userId" = "individualAssignment"."userId"'
+      )
+      .innerJoin(
+        MonitoredExperimentPoint,
+        'monitoredExperimentPoint',
+        'logs."userId" = "monitoredExperimentPoint"."userId" AND partitions.id = "monitoredExperimentPoint"."experimentId"'
       )
       .innerJoin(
         (qb) => {

--- a/backend/packages/Upgrade/test/integration/Experiment/dataLog/LogOperations.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/dataLog/LogOperations.ts
@@ -8,7 +8,7 @@ import { systemUser } from '../../mockData/user/index';
 import { ExperimentAssignmentService } from '../../../../src/api/services/ExperimentAssignmentService';
 import { experimentUsers } from '../../mockData/experimentUsers/index';
 import { EXPERIMENT_STATE, OPERATION_TYPES, REPEATED_MEASURE } from 'upgrade_types';
-import { getAllExperimentCondition } from '../../utils';
+import { checkMarkExperimentPointForUser, getAllExperimentCondition, markExperimentPoint } from '../../utils';
 import { checkExperimentAssignedIsNotDefault } from '../../utils/index';
 import { MetricService, METRICS_JOIN_TEXT } from '../../../../src/api/services/MetricService';
 import { SettingService } from '../../../../src/api/services/SettingService';
@@ -72,27 +72,48 @@ export default async function LogOperations(): Promise<void> {
       }),
     ])
   );
+  const condition = experimentObject.conditions[0].conditionCode;
 
   // get all experiment condition for user 1
   let experimentConditionAssignments = await getAllExperimentCondition(experimentUsers[0].id, new UpgradeLogger());
   checkExperimentAssignedIsNotDefault(experimentConditionAssignments, experimentName, experimentPoint);
+  
+  // mark experiment point for user 1
+  let markedExperimentPoint = await markExperimentPoint(experimentUsers[0].id, experimentName, experimentPoint, condition, new UpgradeLogger());
+  checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[0].id, experimentName, experimentPoint);
 
   // get all experiment condition for user 2
   experimentConditionAssignments = await getAllExperimentCondition(experimentUsers[1].id, new UpgradeLogger());
   checkExperimentAssignedIsNotDefault(experimentConditionAssignments, experimentName, experimentPoint);
+  
+  // mark experiment point for user 2
+  markedExperimentPoint = await markExperimentPoint(experimentUsers[1].id, experimentName, experimentPoint, condition, new UpgradeLogger());
+  checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[1].id, experimentName, experimentPoint);
 
   // get all experiment condition for user 3
   experimentConditionAssignments = await getAllExperimentCondition(experimentUsers[2].id, new UpgradeLogger());
   checkExperimentAssignedIsNotDefault(experimentConditionAssignments, experimentName, experimentPoint);
+  
+  // mark experiment point for user 3
+  markedExperimentPoint = await markExperimentPoint(experimentUsers[2].id, experimentName, experimentPoint, condition, new UpgradeLogger());
+  checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName, experimentPoint);
 
   // get all experiment condition for user 4
   experimentConditionAssignments = await getAllExperimentCondition(experimentUsers[3].id, new UpgradeLogger());
   checkExperimentAssignedIsNotDefault(experimentConditionAssignments, experimentName, experimentPoint);
+  
+  // mark experiment point for user 4
+  markedExperimentPoint = await markExperimentPoint(experimentUsers[3].id, experimentName, experimentPoint, condition, new UpgradeLogger());
+  checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[3].id, experimentName, experimentPoint);
 
   // get all experiment condition for user 5
   experimentConditionAssignments = await getAllExperimentCondition(experimentUsers[4].id, new UpgradeLogger());
   checkExperimentAssignedIsNotDefault(experimentConditionAssignments, experimentName, experimentPoint);
 
+  // mark experiment point for user 5
+  markedExperimentPoint = await markExperimentPoint(experimentUsers[4].id, experimentName, experimentPoint, condition, new UpgradeLogger());
+  checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[4].id, experimentName, experimentPoint);
+  
   // Save queries for various operations
   const querySum = makeQuery('totalProblemsCompleted', OPERATION_TYPES.SUM, experiments[0].id);
 

--- a/backend/packages/Upgrade/test/integration/Experiment/dataLog/RepeatedMeasure.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/dataLog/RepeatedMeasure.ts
@@ -11,7 +11,7 @@ import { systemUser } from '../../mockData/user/index';
 import { Metric } from '../../../../src/api/models/Metric';
 import { metrics } from '../../mockData/metric/index';
 import { EXPERIMENT_STATE, IMetricMetaData, OPERATION_TYPES, REPEATED_MEASURE } from 'upgrade_types';
-import { getAllExperimentCondition } from '../../utils';
+import { checkMarkExperimentPointForUser, getAllExperimentCondition, markExperimentPoint } from '../../utils';
 import { checkExperimentAssignedIsNotDefault } from '../../utils/index';
 import { experimentUsers } from '../../mockData/experimentUsers/index';
 import { Log } from '../../../../src/api/models/Log';
@@ -71,22 +71,40 @@ export default async function RepeatedMeasure(): Promise<void> {
       }),
     ])
   );
+  
+  const condition = experimentObject.conditions[0].conditionCode;
 
   // get all experiment condition for user 1
   let experimentConditionAssignments = await getAllExperimentCondition(experimentUsers[0].id, new UpgradeLogger());
   checkExperimentAssignedIsNotDefault(experimentConditionAssignments, experimentName, experimentPoint);
-
+  
+  // mark experiment point for user 1
+  let markedExperimentPoint = await markExperimentPoint(experimentUsers[0].id, experimentName, experimentPoint, condition, new UpgradeLogger());
+  checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[0].id, experimentName, experimentPoint);
+  
   // get all experiment condition for user 2
   experimentConditionAssignments = await getAllExperimentCondition(experimentUsers[1].id, new UpgradeLogger());
   checkExperimentAssignedIsNotDefault(experimentConditionAssignments, experimentName, experimentPoint);
-
+  
+  // mark experiment point for user 2
+  markedExperimentPoint = await markExperimentPoint(experimentUsers[1].id, experimentName, experimentPoint, condition, new UpgradeLogger());
+  checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[1].id, experimentName, experimentPoint);
+  
   // get all experiment condition for user 3
   experimentConditionAssignments = await getAllExperimentCondition(experimentUsers[2].id, new UpgradeLogger());
   checkExperimentAssignedIsNotDefault(experimentConditionAssignments, experimentName, experimentPoint);
+  
+  // mark experiment point for user 3
+  markedExperimentPoint = await markExperimentPoint(experimentUsers[2].id, experimentName, experimentPoint, condition, new UpgradeLogger());
+  checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName, experimentPoint);
 
   // get all experiment condition for user 4
   experimentConditionAssignments = await getAllExperimentCondition(experimentUsers[3].id, new UpgradeLogger());
   checkExperimentAssignedIsNotDefault(experimentConditionAssignments, experimentName, experimentPoint);
+  
+  // mark experiment point for user 4
+  markedExperimentPoint = await markExperimentPoint(experimentUsers[3].id, experimentName, experimentPoint, condition, new UpgradeLogger());
+  checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[3].id, experimentName, experimentPoint);
 
   const findMetric = await metricRepository.find();
   expect(findMetric.length).toEqual(32);


### PR DESCRIPTION
This PR contains fix for metric data pulled for excluded users as query didn't had join with monitored experiment point table to check metric data only for enrolled users. I have verified this on the prod_clone db shared by @jreddig and now we see metric data for only enrolled users using this fix. Test cases where also updated to mark the experiments so as to enroll users in the experiment and we get only enrolled user metric data.