### PR TITLE
local storage service spec and static methods change

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -4,10 +4,13 @@ A/B Testing Tool
 
 Frontend Unit Test Coverage
 
-![](https://img.shields.io/badge/Coverage-41%25-F2C572.svg?style=flat&logo=jest&label=Statements&prefix=$statements$) ![](https://img.shields.io/badge/Coverage-16%25-F2C572.svg?style=flat&logo=jest&label=Branches&prefix=$branches$) ![](https://img.shields.io/badge/Coverage-14%25-733B27.svg?style=flat&logo=jest&label=Functions&prefix=$functions$) ![](https://img.shields.io/badge/Coverage-38%25-F2C572.svg?style=flat&logo=jest&label=Lines&prefix=$lines$)
+![](https://img.shields.io/badge/Coverage-46%25-F2E96B.svg?style=flat&logo=jest&label=Statements&prefix=$statements$)
+![](https://img.shields.io/badge/Coverage-22%25-F2C572.svg?style=flat&logo=jest&label=Branches&prefix=$branches$)
+![](https://img.shields.io/badge/Coverage-25%25-F2C572.svg?style=flat&logo=jest&label=Functions&prefix=$functions$)
+![](https://img.shields.io/badge/Coverage-44%25-F2C572.svg?style=flat&logo=jest&label=Lines&prefix=$lines$)
 
 Overall (average of all 4) Goal: 80%
 
-![](https://img.shields.io/badge/Coverage-27%25-F2C572.svg?style=flat&logo=jest&label=Overall&prefix=$coverage$)
+![](https://img.shields.io/badge/Coverage-34%25-F2C572.svg?style=flat&logo=jest&label=Overall&prefix=$coverage$)
 
 ---

--- a/frontend/projects/upgrade/src/app/core/local-storage/local-storage.service.spec.ts
+++ b/frontend/projects/upgrade/src/app/core/local-storage/local-storage.service.spec.ts
@@ -1,52 +1,180 @@
-import { TestBed } from '@angular/core/testing';
-import { ExperimentLocalStorageKeys, ExperimentState, EXPERIMENT_SORT_AS, EXPERIMENT_SORT_KEY } from '../experiments/store/experiments.model';
-
+import { ExperimentState, EXPERIMENT_SEARCH_KEY, EXPERIMENT_SORT_AS, EXPERIMENT_SORT_KEY } from '../experiments/store/experiments.model';
 import { LocalStorageService } from './local-storage.service';
 
+
 describe('LocalStorageService', () => {
-  let service: LocalStorageService;
+    let service: LocalStorageService;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [LocalStorageService]
+    beforeEach(() => {
+        service = new LocalStorageService()
     });
-    service = TestBed.get(LocalStorageService);
-  });
 
-  afterEach(() => localStorage.clear());
+    afterEach(() => {
+        window.localStorage.__proto__.setItem = jest.fn().mockRestore();
+        window.localStorage.__proto__.getItem = jest.fn().mockRestore();
+        window.localStorage.__proto__.removeItem = jest.fn().mockRestore();
+    })
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
-  });
+    describe('#loadInitialState', () => {
+        const expectedStateWithFetchedValues: ExperimentState = {
+            ids: [],
+            entities: {},
+            isLoadingExperiment: false,
+            skipExperiment: 0,
+            totalExperiments: null,
+            searchKey: EXPERIMENT_SEARCH_KEY.ALL,
+            searchString: 'test',
+            sortKey: EXPERIMENT_SORT_KEY.STATUS,
+            sortAs: EXPERIMENT_SORT_AS.ASCENDING,
+            stats: {},
+            graphInfo: null,
+            graphRange: null,
+            isGraphInfoLoading: false,
+            allPartitions: null,
+            allExperimentNames: null,
+            contextMetaData: {}
+        }
+        const expectedStateWithDefaults: ExperimentState = {
+            ids: [],
+            entities: {},
+            isLoadingExperiment: false,
+            skipExperiment: 0,
+            totalExperiments: null,
+            searchKey: null,
+            searchString: null,
+            sortKey: EXPERIMENT_SORT_KEY.NAME,
+            sortAs: EXPERIMENT_SORT_AS.ASCENDING,
+            stats: {},
+            graphInfo: null,
+            graphRange: null,
+            isGraphInfoLoading: false,
+            allPartitions: null,
+            allExperimentNames: null,
+            contextMetaData: {}
+        }
 
-  it('should get, set, and remove the item', () => {
-    service.setItem('TEST', 'item');
-    expect(service.getItem('TEST')).toBe('item');
-    LocalStorageService.removeItem('TEST');
-    expect(service.getItem('TEST')).toBe(null);
-  });
+        const testCases = [
+            {
+                whenCondition: 'when data in local storage, THEN experiment should use those values',
+                expectedValue: expectedStateWithFetchedValues,
+                fetchedSortKey: EXPERIMENT_SORT_KEY.STATUS,
+                fetchedSortAs: EXPERIMENT_SORT_AS.ASCENDING,
+                fetchedSearchKey: EXPERIMENT_SEARCH_KEY.ALL,
+                fetchedSearchString: 'test'
+            },
+            {
+                whenCondition: 'nothing in local storage, THEN use defaults',
+                expectedValue: expectedStateWithDefaults,
+                fetchedSortKey: null,
+                fetchedSortAs: null,
+                fetchedSearchKey: null,
+                fetchedSearchString: null
+            }
+        ];
 
-  it('should load initial state', () => {
-    const experimentState: ExperimentState = {
-      ids: [],
-      entities: {},
-      isLoadingExperiment: false,
-      skipExperiment: 0,
-      totalExperiments: null,
-      searchKey: null,
-      searchString: null,
-      sortKey: EXPERIMENT_SORT_KEY.STATUS,
-      sortAs: EXPERIMENT_SORT_AS.DESCENDING,
-      stats: {},
-      graphInfo: null,
-      graphRange: null,
-      isGraphInfoLoading: false,
-      allPartitions: null,
-      allExperimentNames: null,
-      contextMetaData: {}
-    }
-    service.setItem(ExperimentLocalStorageKeys.EXPERIMENT_SORT_KEY, EXPERIMENT_SORT_KEY.STATUS);
-    service.setItem(ExperimentLocalStorageKeys.EXPERIMENT_SORT_TYPE, EXPERIMENT_SORT_AS.DESCENDING);
-    expect(LocalStorageService.loadInitialState()).toEqual({ experiments: experimentState });
-  });
+        testCases.forEach(({ 
+            whenCondition,
+            expectedValue,
+            fetchedSearchKey,
+            fetchedSearchString,
+            fetchedSortAs,
+            fetchedSortKey
+        }) => {
+            it(`WHEN ${whenCondition}:`, () => {
+                service.getItem = jest.fn()
+                    .mockReturnValueOnce(fetchedSortKey)
+                    .mockReturnValueOnce(fetchedSortAs)
+                    .mockReturnValueOnce(fetchedSearchKey)
+                    .mockReturnValueOnce(fetchedSearchString)
+
+                const { experiments } = service.loadInitialState();
+
+                expect(experiments).toEqual(expectedValue);
+            })
+        })
+    })
+
+    describe('#setItem', () => {
+        const testCases = [
+            {
+                key: 'testString',
+                value: 'testString'
+            },
+            {
+                key: 'testObject',
+                value: {
+                    thing: 'test'
+                }
+            },
+            {
+                key: 'testNull',
+                value: null
+            },
+            {
+                key: 'testUndefined',
+                value: undefined
+            },
+        ]
+
+        testCases.forEach(({ key, value }) => {
+            it('should call setItem on localstorage object', () => {
+                const expectedKey = `UPGRADE-${key}`;
+                const expectedValue = JSON.stringify(value);
+                window.localStorage.__proto__.setItem = jest.fn();
+
+                service.setItem(key, value);
+    
+                expect(localStorage.setItem).toHaveBeenCalledWith(expectedKey, expectedValue)
+            })
+        })
+    })
+
+    describe('#getItem', () => {
+        const testCases = [
+            {
+
+                key: 'testString',
+                value: 'testString',
+                storedValue: JSON.stringify('testString')
+            },
+            {
+                key: 'testObject',
+                value: {
+                    thing: 'test'
+                },
+                storedValue: JSON.stringify({
+                    thing: 'test'
+                })
+            },
+            {
+                key: 'testNull',
+                value: null,
+                storedValue: null
+            },
+        ]
+
+        testCases.forEach(({ key, value, storedValue }) => {
+            it(`should call getItem on localstorage object and JSON.parse on ${storedValue}`, () => {
+                const expectedLookupKey = `UPGRADE-${key}`;
+                window.localStorage.__proto__.getItem = jest.fn().mockReturnValue(storedValue)
+
+                const actualValue = service.getItem(key);
+    
+                expect(localStorage.getItem).toHaveBeenCalledWith(expectedLookupKey);
+                expect(actualValue).toEqual(value);
+            })
+        })
+    })
+
+    describe('#removeItem', () => {
+        it('should call local storage remove item method with prefixed key', () => {
+            const key = 'test';
+            const expectedLookupKey = `UPGRADE-${key}`;
+            window.localStorage.__proto__.removeItem = jest.fn();
+
+            service.removeItem(key);
+
+            expect(localStorage.removeItem).toHaveBeenCalledWith(expectedLookupKey);
+        })
+    })
 });

--- a/frontend/projects/upgrade/src/app/core/local-storage/local-storage.service.ts
+++ b/frontend/projects/upgrade/src/app/core/local-storage/local-storage.service.ts
@@ -14,7 +14,7 @@ const APP_PREFIX = 'UPGRADE-';
 export class LocalStorageService {
   constructor() {}
 
-  static loadInitialState() {
+  loadInitialState() {
     const experimentSortKey = this.getItem(ExperimentLocalStorageKeys.EXPERIMENT_SORT_KEY);
     const experimentSortType = this.getItem(ExperimentLocalStorageKeys.EXPERIMENT_SORT_TYPE);
     const experimentSearchKey = this.getItem(ExperimentLocalStorageKeys.EXPERIMENT_SEARCH_KEY);
@@ -54,19 +54,7 @@ export class LocalStorageService {
     return JSON.parse(localStorage.getItem(`${APP_PREFIX}${key}`));
   }
 
-  static getItem(key: string) {
-    return JSON.parse(localStorage.getItem(`${APP_PREFIX}${key}`));
-  }
-
-  static removeItem(key: string) {
+  removeItem(key: string) {
     localStorage.removeItem(`${APP_PREFIX}${key}`);
-  }
-
-  clear() {
-    Object.keys(sessionStorage).forEach(key => {
-      if (key.includes(APP_PREFIX)) {
-        sessionStorage.removeItem(key);
-      }
-    });
   }
 }

--- a/frontend/projects/upgrade/src/app/core/meta-reducers/clear-state.reducer.ts
+++ b/frontend/projects/upgrade/src/app/core/meta-reducers/clear-state.reducer.ts
@@ -12,13 +12,14 @@ export function clearState(reducer) {
         toCheckAuth: null,
         toFilterMetric: null
       };
+      const localStorageService = new LocalStorageService()
 
       state = {
         settings: settingState, // Used to persist theme,
       };
 
       Object.values(ExperimentLocalStorageKeys).forEach(key => {
-        LocalStorageService.removeItem(key);
+        localStorageService.removeItem(key);
       })
     }
     return reducer(state, action);

--- a/frontend/projects/upgrade/src/app/core/meta-reducers/init-state-from-local-storage.reducer.ts
+++ b/frontend/projects/upgrade/src/app/core/meta-reducers/init-state-from-local-storage.reducer.ts
@@ -8,8 +8,9 @@ export function initStateFromLocalStorage(
 ): ActionReducer<AppState> {
   return function(state, action) {
     const newState = reducer(state, action);
+    const localStorageService = new LocalStorageService();
     if ([INIT.toString(), UPDATE.toString()].includes(action.type)) {
-      return { ...newState, ...LocalStorageService.loadInitialState() };
+      return { ...newState, ...localStorageService.loadInitialState() };
     }
     return newState;
   };


### PR DESCRIPTION
While writing unit-tests for this service I found some dead code and inconsistent implementation of static vs nonstatic methods that were making the unit-tests funky to write, especially the duplicate `getItem` implementation (one static, one non-static, which was causing some typescript confusion, or maybe just mine). As far as I can tell it's trivial to instantiate this object, no real good reason to have static methods as far as I could tell, so I converted the static methods to non-static to avoid the confusion and updated the couple spots in the app code.

I tested in local, the local-storage methods work appropriately to remember the values uses in browser when searching/filtering experiments. Let me know if these changes are okay.