### PR TITLE
Updating slower query for enrollment count and removing group count on homepage

### DIFF
--- a/backend/packages/Upgrade/test/integration/ExperimentStats/DetailGroupExperiment.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentStats/DetailGroupExperiment.ts
@@ -65,51 +65,60 @@ export default async function testCase(): Promise<void> {
     expect.objectContaining({
       id: experimentId,
       users: 0,
-      groups: 0,
+      // TODO: uncomment when we have the groups count
+      // groups: 0,
       usersExcluded: 0,
       groupsExcluded: 0,
       conditions: expect.arrayContaining([
         expect.objectContaining({
           id: experiments[0].conditions[0].id,
           users: 0,
-          groups: 0,
+          // TODO: uncomment when we have the groups count
+          // groups: 0,
           partitions: expect.arrayContaining([
             expect.objectContaining({
               id: experiments[0].partitions[0].id,
               users: 0,
-              groups: 0,
+              // TODO: uncomment when we have the groups count
+              // groups: 0,
             }),
             expect.objectContaining({
               id: experiments[0].partitions[1].id,
               users: 0,
-              groups: 0,
+              // TODO: uncomment when we have the groups count
+              // groups: 0,
             }),
             expect.objectContaining({
               id: experiments[0].partitions[2].id,
               users: 0,
-              groups: 0,
+              // TODO: uncomment when we have the groups count
+              // groups: 0,
             }),
           ]),
         }),
         expect.objectContaining({
           id: experiments[0].conditions[1].id,
           users: 0,
-          groups: 0,
+          // TODO: uncomment when we have the groups count
+          // groups: 0,
           partitions: expect.arrayContaining([
             expect.objectContaining({
               id: experiments[0].partitions[0].id,
               users: 0,
-              groups: 0,
+              // TODO: uncomment when we have the groups count
+              // groups: 0,
             }),
             expect.objectContaining({
               id: experiments[0].partitions[1].id,
               users: 0,
-              groups: 0,
+              // TODO: uncomment when we have the groups count
+              // groups: 0,
             }),
             expect.objectContaining({
               id: experiments[0].partitions[2].id,
               users: 0,
-              groups: 0,
+              // TODO: uncomment when we have the groups count
+              // groups: 0,
             }),
           ]),
         }),
@@ -125,51 +134,60 @@ export default async function testCase(): Promise<void> {
     expect.objectContaining({
       id: experimentId,
       users: 0,
-      groups: 0,
+      // TODO: uncomment when we have the groups count
+      // groups: 0,
       usersExcluded: 1,
       groupsExcluded: 1,
       conditions: expect.arrayContaining([
         expect.objectContaining({
           id: experiments[0].conditions[0].id,
           users: 0,
-          groups: 0,
+          // TODO: uncomment when we have the groups count
+          // groups: 0,
           partitions: expect.arrayContaining([
             expect.objectContaining({
               id: experiments[0].partitions[0].id,
               users: 0,
-              groups: 0,
+              // TODO: uncomment when we have the groups count
+              // groups: 0,
             }),
             expect.objectContaining({
               id: experiments[0].partitions[1].id,
               users: 0,
-              groups: 0,
+              // TODO: uncomment when we have the groups count
+              // groups: 0,
             }),
             expect.objectContaining({
               id: experiments[0].partitions[2].id,
               users: 0,
-              groups: 0,
+              // TODO: uncomment when we have the groups count
+              // groups: 0,
             }),
           ]),
         }),
         expect.objectContaining({
           id: experiments[0].conditions[1].id,
           users: 0,
-          groups: 0,
+          // TODO: uncomment when we have the groups count
+          // groups: 0,
           partitions: expect.arrayContaining([
             expect.objectContaining({
               id: experiments[0].partitions[0].id,
               users: 0,
-              groups: 0,
+              // TODO: uncomment when we have the groups count
+              // groups: 0,
             }),
             expect.objectContaining({
               id: experiments[0].partitions[1].id,
               users: 0,
-              groups: 0,
+              // TODO: uncomment when we have the groups count
+              // groups: 0,
             }),
             expect.objectContaining({
               id: experiments[0].partitions[2].id,
               users: 0,
-              groups: 0,
+              // TODO: uncomment when we have the groups count
+              // groups: 0,
             }),
           ]),
         }),
@@ -191,7 +209,8 @@ export default async function testCase(): Promise<void> {
   expect(checkData).toEqual(
     expect.objectContaining({
       users: 0,
-      groups: 0,
+      // TODO: uncomment when we have the groups count
+      // groups: 0,
       usersExcluded: 2,
       groupsExcluded: 1,
     })
@@ -209,7 +228,8 @@ export default async function testCase(): Promise<void> {
   expect(checkData).toEqual(
     expect.objectContaining({
       users: 1,
-      groups: 1,
+      // TODO: uncomment when we have the groups count
+      // groups: 1,
       usersExcluded: 2,
       groupsExcluded: 1,
     })
@@ -230,7 +250,8 @@ export default async function testCase(): Promise<void> {
   expect(checkData).toEqual(
     expect.objectContaining({
       users: 1,
-      groups: 1,
+      // TODO: uncomment when we have the groups count
+      // groups: 1,
       usersExcluded: 3,
       groupsExcluded: 1,
     })

--- a/backend/packages/Upgrade/test/integration/ExperimentStats/DetailIndividualExperiment.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentStats/DetailIndividualExperiment.ts
@@ -67,51 +67,60 @@ export default async function testCase(): Promise<void> {
     expect.objectContaining({
       id: experimentId,
       users: 0,
-      groups: 0,
+      // TODO: uncomment when we have the groups count
+      // groups: 0,
       usersExcluded: 0,
       groupsExcluded: 0,
       conditions: expect.arrayContaining([
         expect.objectContaining({
           id: experiments[0].conditions[0].id,
           users: 0,
-          groups: 0,
+          // TODO: uncomment when we have the groups count
+          // groups: 0,
           partitions: expect.arrayContaining([
             expect.objectContaining({
               id: experiments[0].partitions[0].id,
               users: 0,
-              groups: 0,
+              // TODO: uncomment when we have the groups count
+              // groups: 0,
             }),
             expect.objectContaining({
               id: experiments[0].partitions[1].id,
               users: 0,
-              groups: 0,
+              // TODO: uncomment when we have the groups count
+              // groups: 0,
             }),
             expect.objectContaining({
               id: experiments[0].partitions[2].id,
               users: 0,
-              groups: 0,
+              // TODO: uncomment when we have the groups count
+              // groups: 0,
             }),
           ]),
         }),
         expect.objectContaining({
           id: experiments[0].conditions[1].id,
           users: 0,
-          groups: 0,
+          // TODO: uncomment when we have the groups count
+          // groups: 0,
           partitions: expect.arrayContaining([
             expect.objectContaining({
               id: experiments[0].partitions[0].id,
               users: 0,
-              groups: 0,
+              // TODO: uncomment when we have the groups count
+              // groups: 0,
             }),
             expect.objectContaining({
               id: experiments[0].partitions[1].id,
               users: 0,
-              groups: 0,
+              // TODO: uncomment when we have the groups count
+              // groups: 0,
             }),
             expect.objectContaining({
               id: experiments[0].partitions[2].id,
               users: 0,
-              groups: 0,
+              // TODO: uncomment when we have the groups count
+              // groups: 0,
             }),
           ]),
         }),
@@ -127,51 +136,60 @@ export default async function testCase(): Promise<void> {
     expect.objectContaining({
       id: experimentId,
       users: 0,
-      groups: 0,
+      // TODO: uncomment when we have the groups count
+      // groups: 0,
       usersExcluded: 1,
       groupsExcluded: 0,
       conditions: expect.arrayContaining([
         expect.objectContaining({
           id: experiments[0].conditions[0].id,
           users: 0,
-          groups: 0,
+          // TODO: uncomment when we have the groups count
+          // groups: 0,
           partitions: expect.arrayContaining([
             expect.objectContaining({
               id: experiments[0].partitions[0].id,
               users: 0,
-              groups: 0,
+              // TODO: uncomment when we have the groups count
+              // groups: 0,
             }),
             expect.objectContaining({
               id: experiments[0].partitions[1].id,
               users: 0,
-              groups: 0,
+              // TODO: uncomment when we have the groups count
+              // groups: 0,
             }),
             expect.objectContaining({
               id: experiments[0].partitions[2].id,
               users: 0,
-              groups: 0,
+              // TODO: uncomment when we have the groups count
+              // groups: 0,
             }),
           ]),
         }),
         expect.objectContaining({
           id: experiments[0].conditions[1].id,
           users: 0,
-          groups: 0,
+          // TODO: uncomment when we have the groups count
+          // groups: 0,
           partitions: expect.arrayContaining([
             expect.objectContaining({
               id: experiments[0].partitions[0].id,
               users: 0,
-              groups: 0,
+              // TODO: uncomment when we have the groups count
+              // groups: 0,
             }),
             expect.objectContaining({
               id: experiments[0].partitions[1].id,
               users: 0,
-              groups: 0,
+              // TODO: uncomment when we have the groups count
+              // groups: 0,
             }),
             expect.objectContaining({
               id: experiments[0].partitions[2].id,
               users: 0,
-              groups: 0,
+              // TODO: uncomment when we have the groups count
+              // groups: 0,
             }),
           ]),
         }),
@@ -193,7 +211,8 @@ export default async function testCase(): Promise<void> {
   expect(checkData).toEqual(
     expect.objectContaining({
       users: 1,
-      groups: 0,
+      // TODO: uncomment when we have the groups count
+      // groups: 0,
       usersExcluded: 1,
       groupsExcluded: 0,
     })
@@ -208,7 +227,8 @@ export default async function testCase(): Promise<void> {
   expect(checkData).toEqual(
     expect.objectContaining({
       users: 1,
-      groups: 0,
+      // TODO: uncomment when we have the groups count
+      // groups: 0,
       usersExcluded: 1,
       groupsExcluded: 0,
     })
@@ -229,7 +249,8 @@ export default async function testCase(): Promise<void> {
   expect(checkData).toEqual(
     expect.objectContaining({
       users: 2,
-      groups: 0,
+      // TODO: uncomment when we have the groups count
+      // groups: 0,
       usersExcluded: 1,
       groupsExcluded: 0,
     })
@@ -246,7 +267,8 @@ export default async function testCase(): Promise<void> {
   expect(checkData).toEqual(
     expect.objectContaining({
       users: 2,
-      groups: 0,
+      // TODO: uncomment when we have the groups count
+      // groups: 0,
       usersExcluded: 2,
       groupsExcluded: 0,
     })

--- a/backend/packages/Upgrade/test/integration/ExperimentStats/GroupEnrollment.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentStats/GroupEnrollment.ts
@@ -47,7 +47,8 @@ export default async function testCase(): Promise<void> {
     expect.arrayContaining([
       expect.objectContaining({
         users: 0,
-        groups: 0,
+        // TODO: uncomment when we have the groups count
+        // groups: 0,
         id: experimentId,
       }),
     ])
@@ -75,7 +76,8 @@ export default async function testCase(): Promise<void> {
     expect.arrayContaining([
       expect.objectContaining({
         users: 0,
-        groups: 0,
+        // TODO: uncomment when we have the groups count
+        // groups: 0,
         id: experimentId,
       }),
     ])
@@ -100,7 +102,8 @@ export default async function testCase(): Promise<void> {
     expect.arrayContaining([
       expect.objectContaining({
         users: 0,
-        groups: 0,
+        // TODO: uncomment when we have the groups count
+        // groups: 0,
         id: experimentId,
       }),
     ])
@@ -120,8 +123,9 @@ export default async function testCase(): Promise<void> {
   expect(stats).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
-        users: 1,
-        groups: 1,
+        users: "1",
+        // TODO: uncomment when we have the groups count
+        // groups: 1,
         id: experimentId,
       }),
     ])
@@ -141,8 +145,9 @@ export default async function testCase(): Promise<void> {
   expect(stats).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
-        users: 2,
-        groups: 1,
+        users: "2",
+        // TODO: uncomment when we have the groups count
+        // groups: 1,
         id: experimentId,
       }),
     ])

--- a/backend/packages/Upgrade/test/integration/ExperimentStats/IndividualEnrollment.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentStats/IndividualEnrollment.ts
@@ -78,7 +78,8 @@ export default async function testCase(): Promise<void> {
     expect.arrayContaining([
       expect.objectContaining({
         users: 0,
-        groups: 0,
+        // TODO: uncomment when we have the groups count
+        // groups: 0,
         id: experimentId,
       }),
     ])
@@ -98,7 +99,8 @@ export default async function testCase(): Promise<void> {
     expect.arrayContaining([
       expect.objectContaining({
         users: 0,
-        groups: 0,
+        // TODO: uncomment when we have the groups count
+        // groups: 0,
         id: experimentId,
       }),
     ])
@@ -115,7 +117,8 @@ export default async function testCase(): Promise<void> {
     expect.arrayContaining([
       expect.objectContaining({
         users: 0,
-        groups: 0,
+        // TODO: uncomment when we have the groups count
+        // groups: 0,
         id: experimentId,
       }),
     ])
@@ -130,8 +133,9 @@ export default async function testCase(): Promise<void> {
   expect(stats).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
-        users: 1,
-        groups: 0,
+        users: "1",
+        // TODO: uncomment when we have the groups count
+        // groups: 0,
         id: experimentId,
       }),
     ])
@@ -150,8 +154,9 @@ export default async function testCase(): Promise<void> {
   expect(stats).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
-        users: 1,
-        groups: 0,
+        users: "2",
+        // TODO: uncomment when we have the groups count
+        // groups: 0,
         id: experimentId,
       }),
     ])
@@ -169,8 +174,9 @@ export default async function testCase(): Promise<void> {
   expect(stats).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
-        users: 2,
-        groups: 0,
+        users: "3",
+        // TODO: uncomment when we have the groups count
+        // groups: 0,
         id: experimentId,
       }),
     ])

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-list/experiment-list.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-list/experiment-list.component.html
@@ -245,7 +245,8 @@
               *ngIf="experiment.stat?.users"
               [innerHTML]="'home.experiments-table.students.text' | translate: { noOfStudents: experiment.stat?.users }"
             ></span>
-            <span
+            <!-- TODO: Removing the below group counts from the homepage until we have a better way to display the group counts -->
+            <!-- <span
               class="enrollment-info"
               *ngIf="experiment.stat?.groups"
             >
@@ -258,7 +259,7 @@
               <ng-template #groupTypePlural>
                 <span>{{ 'global.group-type-plural.text' | translate: { groupType: experiment.group } }}</span>
               </ng-template>
-            </span>
+            </span> -->
             <span
               class="enrollment-info"
               *ngIf="!experiment.stat?.groups && !experiment.stat?.users"


### PR DESCRIPTION
Now the enrollment counts on homepage loads in around 5-8 seconds for the latest prod db shared, as shown in below video:

https://user-images.githubusercontent.com/33730817/165968358-b6add094-ba8f-4e44-bc4d-bf3df6406139.mov

