### PR TITLE
add http cancel interceptor on user navigating away from page

### DIFF
--- a/frontend/projects/upgrade/src/app/core/core.module.ts
+++ b/frontend/projects/upgrade/src/app/core/core.module.ts
@@ -27,6 +27,7 @@ import { UsersModule } from './users/users.module';
 import { FeatureFlagsModule } from './feature-flags/feature-flags.module';
 import { HttpAuthInterceptor } from './http-interceptors/http-auth.interceptor';
 import { AnalysisModule } from './analysis/analysis.module';
+import { HttpCancelInterceptor } from './http-interceptors/http-cancel.interceptor';
 
 export {
   TitleService,
@@ -80,6 +81,7 @@ export function HttpLoaderFactory(http: HttpClient) {
   providers: [
     { provide: HTTP_INTERCEPTORS, useClass: HttpErrorInterceptor, multi: true },
     { provide: HTTP_INTERCEPTORS, useClass: HttpAuthInterceptor, multi: true },
+    { provide: HTTP_INTERCEPTORS, useClass: HttpCancelInterceptor, multi: true },
     { provide: ErrorHandler, useClass: AppErrorHandler },
     { provide: RouterStateSerializer, useClass: CustomSerializer }
   ],

--- a/frontend/projects/upgrade/src/app/core/http-interceptors/http-cancel.interceptor.spec.ts
+++ b/frontend/projects/upgrade/src/app/core/http-interceptors/http-cancel.interceptor.spec.ts
@@ -1,0 +1,91 @@
+import { HttpRequest } from "@angular/common/http";
+import { fakeAsync, tick } from "@angular/core/testing";
+import { ActivationEnd, ActivationStart } from "@angular/router";
+import { BehaviorSubject, Subject } from "rxjs";
+import { finalize } from "rxjs/operators";
+import { HttpCancelInterceptor } from "./http-cancel.interceptor";
+
+class MockRouter {
+    events = new Subject();
+}
+
+describe('HttpCancelInterceptor', () => {
+    let mockRouter: any;
+    let service: HttpCancelInterceptor;
+    let mockSnapshot = {
+        data: {
+            title: 'test'
+        },
+        routeConfig: {
+            data: {
+                label: 'test'
+            }
+        }
+    } as any;
+
+    beforeEach(() => {
+        mockRouter = new MockRouter();
+        service = new HttpCancelInterceptor(mockRouter);
+    })
+
+    describe('#constructor', () => {
+        it('should call cancelPaymentRequests when router event type ActivationEnd is emitted', () => {
+            const cancelSpy = jest.spyOn(service, 'cancelPendingRequests')
+            
+            mockRouter.events.next(new ActivationEnd(mockSnapshot));
+
+            expect(cancelSpy).toHaveBeenCalled();
+        })
+
+        it('should NOT call cancelPaymentRequests when router other event types are emitted', () => {
+            service.cancelPendingRequests = jest.fn();
+            
+            mockRouter.events.next(new ActivationStart(mockSnapshot));
+
+            expect(service.cancelPendingRequests).not.toHaveBeenCalled();
+        })
+    })
+
+
+    describe('#intercept', () => {
+        it('should complete the observable if onCancelPendingRequests is called', fakeAsync(() => {
+            const next: any = {
+                handle: () => new BehaviorSubject(null)
+              };
+              
+            const mockRequest = new HttpRequest('GET', '/test');
+            let completed = false;
+
+            const interceptedRequestObservable = service.intercept(mockRequest, next);
+
+            interceptedRequestObservable.pipe(finalize(() => {
+                completed = true;
+            })).subscribe();
+
+            service.cancelPendingRequests();
+
+            tick(0);
+
+            expect(completed).toBeTruthy();
+        }))
+
+        it('should NOT complete the observable if onCancelPendingRequests is NOT called', fakeAsync(() => {
+            const next: any = {
+                handle: () => new BehaviorSubject(null)
+              };
+              
+            const mockRequest = new HttpRequest('GET', '/test');
+            let completed = false;
+
+            const interceptedRequestObservable = service.intercept(mockRequest, next);
+
+            interceptedRequestObservable.pipe(finalize(() => {
+                completed = true;
+            })).subscribe();
+
+            tick(0);
+
+            expect(completed).toBeFalsy();
+        }))
+    })
+})

--- a/frontend/projects/upgrade/src/app/core/http-interceptors/http-cancel.interceptor.ts
+++ b/frontend/projects/upgrade/src/app/core/http-interceptors/http-cancel.interceptor.ts
@@ -1,0 +1,52 @@
+// managehttp.interceptor.ts
+import { Injectable } from '@angular/core';
+import {
+    HttpRequest,
+    HttpHandler,
+    HttpEvent,
+    HttpInterceptor
+} from '@angular/common/http';
+import { Observable, Subject } from 'rxjs';
+import { Router, ActivationEnd } from '@angular/router';
+import { takeUntil } from 'rxjs/operators';
+
+/**
+ * This interceptor will add a rxjs takeuntil 'listener' to any outgoing http request.
+ * 
+ * The effect will be to cancel the requestion on navigation.
+ * 
+ * The rxjs observable pipe will work like this:
+ * 
+ * WHEN an Http request goes out, this intercept function will fire,
+ * IF 'ActivationEnd' event ever emitted from router (meaning user has successfully navigated away from page):
+ * THEN make 'pendingHTTPRequests$' observable emit an event (no value even matters)
+ * 
+ * The 'takeUntil' rxjs operator will 'complete' the HTTPRequest observable when this observable emits any event.
+ * This will cancel the request.
+ */
+
+@Injectable()
+export class HttpCancelInterceptor implements HttpInterceptor {
+
+    private pendingHTTPRequests$ = new Subject<void>();
+
+    constructor(private router: Router) {
+        this.router.events.subscribe(event => {
+            if (event instanceof ActivationEnd) {
+                this.cancelPendingRequests();
+            }
+        });
+    }
+
+    intercept<T>(req: HttpRequest<T>, next: HttpHandler): Observable<HttpEvent<T>> {
+        return next.handle(req).pipe(takeUntil(this.onCancelPendingRequests()))
+    }
+
+    cancelPendingRequests() {
+        this.pendingHTTPRequests$.next();
+    }
+
+    onCancelPendingRequests() {
+        return this.pendingHTTPRequests$.asObservable();
+    }
+}


### PR DESCRIPTION
Currently if user navigates away from a page that has a pending API call, the call still completes in the background even though the payload is no longer needed. If we are having latency issues or slower queries, this could compound issues with performance (as it does currently with the enrollment query in production).

This is a simple interceptor for HTTP requests that will listen for router event that signals that a user has navigated away from page. It will cancel any requests that are pending so we aren't wasting resources.

Attached is short video showing current behavior in QA region (requests always attempting to complete), vs this change in local (pending requests will get cancelled if they are still running when user navigates away.)

Note: In dev console, I use the feature to throttle requests to make them extra slow (simulates 3G connection).

Uploading cancelcompare.mov…


