### PR TITLE
iscontextchanged logic bug

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/new-experiment/new-experiment.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/new-experiment/new-experiment.component.ts
@@ -59,7 +59,7 @@ export class NewExperimentComponent implements OnInit {
           this.currentContext = this.experimentInfo.context[0];
         }
 
-        this.isContextChanged = this.currentContext ? (this.currentContext !== this.newExperimentData.context[0]) : false;
+        this.isContextChanged = this.currentContext !== this.newExperimentData.context[0];
 
         this.currentContext  = this.newExperimentData.context[0];
 


### PR DESCRIPTION
When looking for reason for #363, i found reason was actually this:

`this.isContextChanged = this.currentContext ? (this.currentContext !== this.newExperimentData.context[0]) : false;`

`this.currentContext` is `undefined` initially, so `isContextChanged` will always evaluate to false initially, even though the user has indeed caused the context to change from `undefined` to whatever they have chosen.

The design page listens for changes to `this.isContextChanged` to initialize populating the dropdown items from the context metadata, and this was coming as false on the first pass.

    ngOnChanges(changes: SimpleChanges) {
    if (changes.animationCompleteStepperIndex && changes.animationCompleteStepperIndex.currentValue === 1 && this.conditionCode) {
      this.conditionCode.nativeElement.focus();
    }

    if (this.isContextChanged) {
      this.isContextChanged = false;
      this.partition.clear();
      this.condition.clear();
      this.partition.push(this.addPartitions());
      this.condition.push(this.addConditions());
      this.partitionDataSource.next(this.partition.controls);
      this.conditionDataSource.next(this.condition.controls);
    }
    }

I'm pretty sure this is the only spot that uses `isContextChanged`, this seems to be the intended logic.