### PR TITLE
send 404 for user not defined

### DIFF
--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
@@ -563,12 +563,15 @@ export class ExperimentClientController {
       });
     }).catch((error) => {
       request.logger.error(error);     
-      throw new Error(
+      error = new Error(
         JSON.stringify({
           type: SERVER_ERROR.EXPERIMENT_USER_NOT_DEFINED,
           message: error.message,
         })
       );
+      (error as any).type = SERVER_ERROR.EXPERIMENT_USER_NOT_DEFINED;
+      (error as any).httpCode = 404
+      throw error;
     });
   }
 

--- a/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
@@ -121,6 +121,7 @@ export class ExperimentAssignmentService {
     if (!userDoc) {
       const error = new Error(`User not defined in markExperimentPoint: ${userId}`);
       (error as any).type = SERVER_ERROR.EXPERIMENT_USER_NOT_DEFINED;
+      (error as any).httpCode = 404
       logger.error(error);
       throw error;
     }
@@ -258,12 +259,15 @@ export class ExperimentAssignmentService {
     // throw error if user not defined
     if (!experimentUser) {
       logger.error({ message: `User not defined in getAllExperimentConditions: ${userId}` });
-      throw new Error(
+      let error = new Error(
         JSON.stringify({
           type: SERVER_ERROR.EXPERIMENT_USER_NOT_DEFINED,
           message: `User not defined in getAllExperimentConditions: ${userId}`,
         })
       );
+      (error as any).type = SERVER_ERROR.EXPERIMENT_USER_NOT_DEFINED;
+      (error as any).httpCode = 404
+      throw error;
     }
 
     // query all experiment and sub experiment
@@ -715,12 +719,15 @@ export class ExperimentAssignmentService {
     // throw error if user not defined
     if (!userDoc) {
       logger.error({ message: `User not found in dataLog, userId => ${userId}`, details: jsonLog });
-      throw new Error(
+      let error = new Error(
         JSON.stringify({
           type: SERVER_ERROR.EXPERIMENT_USER_NOT_DEFINED,
           message: `User not defined dataLog: ${userId}`,
         })
       );
+      (error as any).type = SERVER_ERROR.EXPERIMENT_USER_NOT_DEFINED;
+      (error as any).httpCode = 404
+      throw error;
     }
 
     // extract the array value
@@ -746,12 +753,15 @@ export class ExperimentAssignmentService {
     // throw error if user not defined
     if (!userDoc) {
       logger.error({ message: `User not found in clientFailedExperimentPoint, userId => ${userId}` });
-      throw new Error(
+      let error = new Error(
         JSON.stringify({
           type: SERVER_ERROR.EXPERIMENT_USER_NOT_DEFINED,
           message: `User not defined clientFailedExperimentPoint: ${userId}`,
         })
       );
+      (error as any).type = SERVER_ERROR.EXPERIMENT_USER_NOT_DEFINED;
+      (error as any).httpCode = 404
+      throw error;
     }
 
     error.type = SERVER_ERROR.REPORTED_ERROR;

--- a/backend/packages/Upgrade/src/api/services/ExperimentUserService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentUserService.ts
@@ -67,12 +67,15 @@ export class ExperimentUserService {
     // throw error if user not defined
     if (!userExist) {
       logger.error({ message: 'User not defined setAliasesForUser' + userId, details: aliases });
-      throw new Error(
+      
+      let error = new Error(
         JSON.stringify({
           type: SERVER_ERROR.EXPERIMENT_USER_NOT_DEFINED,
           message: `User not defined setAliasesForUser: ${userId}`,
-        })
-      );
+        }));
+      (error as any).type = SERVER_ERROR.EXPERIMENT_USER_NOT_DEFINED;
+      (error as any).httpCode = 404
+      throw error;
     }
     const promiseArray = [];
     aliases.map((aliasId) => {
@@ -166,12 +169,14 @@ export class ExperimentUserService {
     logger.info({ message: 'Update working group for user: ' + userId, details: workingGroup });
     if (!userExist) {
       logger.error({ message: 'User not defined updateWorkingGroup', details: userId });
-      throw new Error(
+      let error =  new Error(
         JSON.stringify({
           type: SERVER_ERROR.EXPERIMENT_USER_NOT_DEFINED,
           message: `User not defined updateWorkingGroup: ${userId}`,
-        })
-      );
+        }));
+      (error as any).type = SERVER_ERROR.EXPERIMENT_USER_NOT_DEFINED;
+      (error as any).httpCode = 404
+      throw error;
     }
     // TODO check if workingGroup is the subset of group membership
     const newDocument = { ...userExist, workingGroup };
@@ -191,12 +196,14 @@ export class ExperimentUserService {
     logger.info({ message: `Set Group Membership for userId: ${userId} with Group membership details as below:`, details: groupMembership });
     if (!userExist) {
       logger.error({ message: 'User not defined updateGroupMembership', details: userId });
-      throw new Error(
+      let error = new Error(
         JSON.stringify({
           type: SERVER_ERROR.EXPERIMENT_USER_NOT_DEFINED,
           message: `User not defined updateGroupMembership: ${userId}`,
-        })
-      );
+        }));
+      (error as any).type = SERVER_ERROR.EXPERIMENT_USER_NOT_DEFINED;
+      (error as any).httpCode = 404
+      throw error;
     }
 
     // update assignments

--- a/backend/packages/Upgrade/test/unit/middlewares/ErrorHandlerMiddleware.test.ts
+++ b/backend/packages/Upgrade/test/unit/middlewares/ErrorHandlerMiddleware.test.ts
@@ -77,7 +77,7 @@ describe('ErrorHandler Middleware tests', () => {
         let error = {
             type:SERVER_ERROR.EXPERIMENT_USER_NOT_DEFINED,
             message:"Experiment user not defined",
-            httpCode: 500
+            httpCode: 404
         };
 
         await errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
@@ -89,7 +89,7 @@ describe('ErrorHandler Middleware tests', () => {
         let error = {
             type:SERVER_ERROR.EXPERIMENT_USER_GROUP_NOT_DEFINED,
             message:"Experiment user group not defined",
-            httpCode: 500
+            httpCode: 404
         };
 
         await errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);


### PR DESCRIPTION
Send 404 instead of 500 for EXPERIMENT_USER_NOT_DEFINED. 

Another option would be to use `UserNotFoundError`, but the `(error as any)` format was already present elsewhere to set the error type, so I used it for consistency