### PR TITLE
checkout branch main

### DIFF
--- a/.github/workflows/merge-dev-to-main.yml
+++ b/.github/workflows/merge-dev-to-main.yml
@@ -9,6 +9,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          ref: main
       - name: Merge dev into main
         run: |
           git config --global user.name 'GitHub Actions'


### PR DESCRIPTION
It appears that the merge-dev-to-main action is checking out dev and pulling any changes from dev. I believe this change will check out main and then pull from dev.

Logs from a recent run of merge-dev-to-main: https://github.com/CarnegieLearningWeb/UpGrade/runs/7079103430?check_suite_focus=true
```
Switched to a new branch 'dev'
branch 'dev' set up to track 'origin/dev'.
git merge origin/dev
git push
```