### PR TITLE
Issue- 411 Fixed default rows in Participants Stepper

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-participants/experiment-participants.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-participants/experiment-participants.component.ts
@@ -70,6 +70,7 @@ export class ExperimentParticipantsComponent implements OnInit {
       this.members2.clear();
       this.members1DataSource.next(this.members1.controls);
       this.members2DataSource.next(this.members2.controls);
+      this.addMember1();
     }
   }
 
@@ -128,7 +129,9 @@ export class ExperimentParticipantsComponent implements OnInit {
         });
       }
 
-      this.members1.removeAt(0);
+      if (this.members1.length !== 1) {
+        this.members1.removeAt(0);
+      }
       this.members2.removeAt(0);
     }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49234788/177086539-ada7a89e-dec0-428b-aecc-951f7cbc2ac3.png)

Default rows are now showing while creating and editing if no member is selected.