### PR TITLE
Feature/consistent modal button styles

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/components/flag-overview/flag-overview.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/components/flag-overview/flag-overview.component.html
@@ -49,7 +49,7 @@
 
   <div class="button-container">
     <button
-      class="modal-btn"
+      class="shared-modal--modal-btn"
       mat-raised-button
       (click)="emitEvent(NewFlagDialogEvents.CLOSE_DIALOG)"
     >
@@ -57,7 +57,7 @@
     </button>
     <button
       mat-raised-button
-      class="modal-btn default-button"
+      class="shared-modal--modal-btn default-button"
       (click)="emitEvent(NewFlagDialogEvents.SEND_FORM_DATA)"
     >
       {{ 'global.next.text' | translate }}

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/components/flag-variations/flag-variations.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/components/flag-variations/flag-variations.component.html
@@ -158,14 +158,14 @@
     <button
       matStepperPrevious
       mat-raised-button
-      class="modal-btn default-button btn-back"
+      class="shared-modal--modal-btn default-button btn-back"
     >
       {{ 'global.back.text' | translate }}
     </button>
     <div>
       <button
         mat-raised-button
-        class="modal-btn"
+        class="shared-modal--modal-btn"
         (click)="emitEvent(NewFlagDialogEvents.CLOSE_DIALOG)"
       >
         {{ 'global.cancel.text' | translate }}
@@ -173,7 +173,7 @@
       <button
         matStepperNext
         mat-raised-button
-        class="modal-btn default-button"
+        class="shared-modal--modal-btn default-button"
         [ngClass]="{'default-button--disabled': !flagVariationsForm.valid }"
         [disabled]="!flagVariationsForm.valid"
         (click)="emitEvent(NewFlagDialogEvents.SEND_FORM_DATA)"

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/components/modal/delete-flag/delete-flag.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/components/modal/delete-flag/delete-flag.component.html
@@ -13,14 +13,14 @@
 </div>
 <div mat-dialog-actions class="delete-flag-dialog-actions">
   <button
-    class="modal-btn"
+    class="shared-modal--modal-btn"
     mat-flat-button
     (click)="onCancelClick()"
   >
     {{ 'global.cancel.text' | translate }}
   </button>
   <button
-    class="modal-btn default-button delete-btn"
+    class="shared-modal--modal-btn default-button delete-btn"
     mat-flat-button
     [ngClass]="{ 'default-button--disabled': flagName !== data.flagName }"
     [disabled]="flagName !== data.flagName"

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.html
@@ -1,355 +1,358 @@
-<div class="modal-step-container"> 
-<section class="modal-form-container">
-  <form class="experiment-design" [formGroup]="experimentDesignForm">
-    <!-- Partition Table -->
-    <span class="title">{{ 'home.new-experiment.design.decision-point.text' | translate }}</span>
-    <ng-container>
-      <mat-table
-        class="partition-table"
-        [dataSource]="partitionDataSource"
-        formArrayName="partitions"
-        #partitionTable
-      >
-        <!-- Site Column -->
-        <ng-container matColumnDef="site">
-          <mat-header-cell class="ft-14-700" *matHeaderCellDef>
-            {{ 'home.new-experiment.design.partition-point.text' | translate }}
-          </mat-header-cell>
-          <mat-cell
-            *matCellDef="let element; let groupIndex = index"
-            [formGroupName]="groupIndex"
-          >
-            <mat-form-field floatLabel="never">
-              <span
-                [matTooltip]="experimentDesignForm.getRawValue('site')?.partitions[groupIndex]?.site"
-                matTooltipPosition="above"
-                >
-                <input
-                  matInput
-                  [placeholder]="
-                    'home.new-experiment.design.partition-point.placeholder.text'
-                      | translate
-                  "
-                  formControlName="site"
-                  [matAutocomplete]="autoCompleteExperimentPoints"
-                />
-                <mat-autocomplete #autoCompleteExperimentPoints="matAutocomplete" panelWidth="fit-content">
-                  <mat-option *ngFor="let site of filteredExpPoints$[groupIndex] | async" [value]="site">
-                    {{ site }}
-                  </mat-option>
-                </mat-autocomplete>
-              </span>
-            </mat-form-field>
-          </mat-cell>
-        </ng-container>
-
-        <!-- Target Column -->
-        <ng-container matColumnDef="target">
-          <mat-header-cell class="ft-14-700" *matHeaderCellDef>
-            {{ 'home.new-experiment.design.partition-id.text' | translate }}
-          </mat-header-cell>
-          <mat-cell
-            *matCellDef="let element; let groupIndex = index"
-            [formGroupName]="groupIndex"
-          >
-            <mat-form-field floatLabel="never">
-              <span
-                [matTooltip]="experimentDesignForm.getRawValue('target')?.partitions[groupIndex]?.target"
-                matTooltipPosition="above">
-                <input
-                  matInput
-                  [placeholder]="
-                    'home.new-experiment.design.partition-id.placeholder.text'
-                      | translate
-                  "
-                  formControlName="target"
-                  [matAutocomplete]="autoCompleteExperimentIds"
-                />
-                <mat-autocomplete #autoCompleteExperimentIds="matAutocomplete" panelWidth="fit-content">
-                  <mat-option *ngFor="let target of filteredExpIds$[groupIndex] | async" [value]="target">
-                    {{ target }}
-                  </mat-option>
-                </mat-autocomplete>
-              </span>
-            </mat-form-field>
-          </mat-cell>
-        </ng-container>
-
-        <!-- Required Column -->
-        <!-- <ng-container matColumnDef="requiredId">
-          <mat-header-cell class="ft-14-700" *matHeaderCellDef>
-            {{ 'home.new-experiment.design.required.text' | translate }}
-          </mat-header-cell>
-          <mat-cell
-            *matCellDef="let element; let groupIndex = index"
-            [formGroupName]="groupIndex"
-            style="margin-left: 25px;"
-          >
-            <mat-checkbox
-                    class="ft-8-100"
-                    color="primary"
-                    [disabled]="true"
-                    >
-            </mat-checkbox>
-          </mat-cell>
-        </ng-container> -->
-
-        <ng-container matColumnDef="removePartition">
-          <mat-header-cell class="ft-14-700" *matHeaderCellDef></mat-header-cell>
-          <mat-cell
-            *matCellDef="let element; let groupIndex = index"
-            [formGroupName]="groupIndex"
-            style="justify-content: flex-end;"
-          >
-          <button mat-icon-button
-            [disabled]="experimentInfo && (experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE)"
-            (click)="removeConditionOrPartition('partition', groupIndex)">
-            <mat-icon
-              class="remove-icon"
+<div class="shared-modal--step-container"> 
+  <section class="shared-modal--form-container">
+    <form class="experiment-design" [formGroup]="experimentDesignForm">
+      <!-- Partition Table -->
+      <span class="title">{{ 'home.new-experiment.design.decision-point.text' | translate }}</span>
+      <ng-container>
+        <mat-table
+          class="partition-table"
+          [dataSource]="partitionDataSource"
+          formArrayName="partitions"
+          #partitionTable
+        >
+          <!-- Site Column -->
+          <ng-container matColumnDef="site">
+            <mat-header-cell class="ft-14-700" *matHeaderCellDef>
+              {{ 'home.new-experiment.design.partition-point.text' | translate }}
+            </mat-header-cell>
+            <mat-cell
+              *matCellDef="let element; let groupIndex = index"
+              [formGroupName]="groupIndex"
             >
-              delete_outline
-            </mat-icon>
-          </button>
-          </mat-cell>
-        </ng-container>
+              <mat-form-field floatLabel="never">
+                <span
+                  [matTooltip]="experimentDesignForm.getRawValue('site')?.partitions[groupIndex]?.site"
+                  matTooltipPosition="above"
+                  >
+                  <input
+                    matInput
+                    [placeholder]="
+                      'home.new-experiment.design.partition-point.placeholder.text'
+                        | translate
+                    "
+                    formControlName="site"
+                    [matAutocomplete]="autoCompleteExperimentPoints"
+                  />
+                  <mat-autocomplete #autoCompleteExperimentPoints="matAutocomplete" panelWidth="fit-content">
+                    <mat-option *ngFor="let site of filteredExpPoints$[groupIndex] | async" [value]="site">
+                      {{ site }}
+                    </mat-option>
+                  </mat-autocomplete>
+                </span>
+              </mat-form-field>
+            </mat-cell>
+          </ng-container>
 
-        <mat-header-row
-          *matHeaderRowDef="partitionDisplayedColumns; sticky: true"
-        ></mat-header-row>
-        <mat-row *matRowDef="let row; columns: partitionDisplayedColumns"></mat-row>
-      </mat-table>
-      <button
-        type="button"
-        class="ft-12-700 add-partition"
-        *ngIf="!experimentInfo"
-        (click)="addConditionOrPartition('partition')"
-      >
-        +
-        {{ 'home.new-experiment.design.add-experiment-partition.text' | translate }}
-      </button>
-      <button
-        type="button"
-        class="ft-12-700 add-partition"
-        *ngIf="experimentInfo"
-        [ngClass]="{ 'add-partition--disabled': this.experimentInfo && (this.experimentInfo.state == ExperimentState.ENROLLING || this.experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE) }"
-        [disabled]="(experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE)"
-        (click)="addConditionOrPartition('partition')"
-      >
-        +
-        {{ 'home.new-experiment.design.add-experiment-partition.text' | translate }}
-      </button>
-    </ng-container>
-    <span
-      class="ft-14-600 validation-message"
-      *ngFor="let error of partitionPointErrors"
-    >{{ error }}</span>
-    <span
+          <!-- Target Column -->
+          <ng-container matColumnDef="target">
+            <mat-header-cell class="ft-14-700" *matHeaderCellDef>
+              {{ 'home.new-experiment.design.partition-id.text' | translate }}
+            </mat-header-cell>
+            <mat-cell
+              *matCellDef="let element; let groupIndex = index"
+              [formGroupName]="groupIndex"
+            >
+              <mat-form-field floatLabel="never">
+                <span
+                  [matTooltip]="experimentDesignForm.getRawValue('target')?.partitions[groupIndex]?.target"
+                  matTooltipPosition="above">
+                  <input
+                    matInput
+                    [placeholder]="
+                      'home.new-experiment.design.partition-id.placeholder.text'
+                        | translate
+                    "
+                    formControlName="target"
+                    [matAutocomplete]="autoCompleteExperimentIds"
+                  />
+                  <mat-autocomplete #autoCompleteExperimentIds="matAutocomplete" panelWidth="fit-content">
+                    <mat-option *ngFor="let target of filteredExpIds$[groupIndex] | async" [value]="target">
+                      {{ target }}
+                    </mat-option>
+                  </mat-autocomplete>
+                </span>
+              </mat-form-field>
+            </mat-cell>
+          </ng-container>
+
+          <!-- Required Column -->
+          <!-- <ng-container matColumnDef="requiredId">
+            <mat-header-cell class="ft-14-700" *matHeaderCellDef>
+              {{ 'home.new-experiment.design.required.text' | translate }}
+            </mat-header-cell>
+            <mat-cell
+              *matCellDef="let element; let groupIndex = index"
+              [formGroupName]="groupIndex"
+              style="margin-left: 25px;"
+            >
+              <mat-checkbox
+                      class="ft-8-100"
+                      color="primary"
+                      [disabled]="true"
+                      >
+              </mat-checkbox>
+            </mat-cell>
+          </ng-container> -->
+
+          <ng-container matColumnDef="removePartition">
+            <mat-header-cell class="ft-14-700" *matHeaderCellDef></mat-header-cell>
+            <mat-cell
+              *matCellDef="let element; let groupIndex = index"
+              [formGroupName]="groupIndex"
+              style="justify-content: flex-end;"
+            >
+            <button mat-icon-button
+              [disabled]="experimentInfo && (experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE)"
+              (click)="removeConditionOrPartition('partition', groupIndex)">
+              <mat-icon
+                class="remove-icon"
+              >
+                delete_outline
+              </mat-icon>
+            </button>
+            </mat-cell>
+          </ng-container>
+
+          <mat-header-row
+            *matHeaderRowDef="partitionDisplayedColumns; sticky: true"
+          ></mat-header-row>
+          <mat-row *matRowDef="let row; columns: partitionDisplayedColumns"></mat-row>
+        </mat-table>
+        <button
+          type="button"
+          class="ft-12-700 add-partition"
+          *ngIf="!experimentInfo"
+          (click)="addConditionOrPartition('partition')"
+        >
+          +
+          {{ 'home.new-experiment.design.add-experiment-partition.text' | translate }}
+        </button>
+        <button
+          type="button"
+          class="ft-12-700 add-partition"
+          *ngIf="experimentInfo"
+          [ngClass]="{ 'add-partition--disabled': this.experimentInfo && (this.experimentInfo.state == ExperimentState.ENROLLING || this.experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE) }"
+          [disabled]="(experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE)"
+          (click)="addConditionOrPartition('partition')"
+        >
+          +
+          {{ 'home.new-experiment.design.add-experiment-partition.text' | translate }}
+        </button>
+      </ng-container>
+      <span
         class="ft-14-600 validation-message"
-        *ngIf="partitionCountError"
-        [innerHTML]="partitionCountError"
-    ></span>
-    <!-- If experiment point and id are not from predefined value -->
-    <span
-      class="ft-14-600 validation-message"
-      *ngFor="let error of expPointAndIdErrors"
-    >{{ error }}</span>
-    <br>
-    <br>
-    <!-- Condition table -->
-    <span class="title">{{ 'home.new-experiment.design.condition.text' | translate }}</span>
-    <!-- apply equal condition weights -->
-    <div class="header-group">
-      <mat-checkbox
-      class="ft-8-100"
-      color="primary"
-      [checked]="equalWeightFlag"
-      (change)="changeEqualWeightFlag($event)">
-      {{ 'home.new-experiment.design.equal-assignment-weights.text' | translate }}
-      </mat-checkbox>
-    </div>
-    <ng-container>
-      <mat-table
-        class="condition-table"
-        [dataSource]="conditionDataSource"
-        formArrayName="conditions"
-        #conditionTable
-      >
-        <!-- CONDITION NAME Column -->
-        <ng-container matColumnDef="conditionCode">
-          <mat-header-cell class="ft-14-700" *matHeaderCellDef>
-            {{ 'home.new-experiment.design.name.text' | translate }}
-          </mat-header-cell>
-          <mat-cell
-            *matCellDef="let element; let groupIndex = index"
-            [formGroupName]="groupIndex"
-          >
-            <mat-form-field floatLabel="never">
-              <span 
-                [matTooltip]="experimentDesignForm.getRawValue('conditionCode')?.conditions[groupIndex]?.conditionCode"
-                matTooltipPosition="above"
-                >
+        *ngFor="let error of partitionPointErrors"
+      >{{ error }}</span>
+      <span
+          class="ft-14-600 validation-message"
+          *ngIf="partitionCountError"
+          [innerHTML]="partitionCountError"
+      ></span>
+      <!-- If experiment point and id are not from predefined value -->
+      <span
+        class="ft-14-600 validation-message"
+        *ngFor="let error of expPointAndIdErrors"
+      >{{ error }}</span>
+      <br>
+      <br>
+      <!-- Condition table -->
+      <span class="title">{{ 'home.new-experiment.design.condition.text' | translate }}</span>
+      <!-- apply equal condition weights -->
+      <div class="header-group">
+        <mat-checkbox
+        class="ft-8-100"
+        color="primary"
+        [checked]="equalWeightFlag"
+        (change)="changeEqualWeightFlag($event)">
+        {{ 'home.new-experiment.design.equal-assignment-weights.text' | translate }}
+        </mat-checkbox>
+      </div>
+      <ng-container>
+        <mat-table
+          class="condition-table"
+          [dataSource]="conditionDataSource"
+          formArrayName="conditions"
+          #conditionTable
+        >
+          <!-- CONDITION NAME Column -->
+          <ng-container matColumnDef="conditionCode">
+            <mat-header-cell class="ft-14-700" *matHeaderCellDef>
+              {{ 'home.new-experiment.design.name.text' | translate }}
+            </mat-header-cell>
+            <mat-cell
+              *matCellDef="let element; let groupIndex = index"
+              [formGroupName]="groupIndex"
+            >
+              <mat-form-field floatLabel="never">
+                <span 
+                  [matTooltip]="experimentDesignForm.getRawValue('conditionCode')?.conditions[groupIndex]?.conditionCode"
+                  matTooltipPosition="above"
+                  >
+                  <input
+                    matInput
+                    [placeholder]="
+                      'home.new-experiment.design.condition.placeholder.text'
+                        | translate
+                    "
+                    formControlName="conditionCode"
+                    [matAutocomplete]="autoCompleteConditionCodes"
+                  />
+                  <mat-autocomplete #autoCompleteConditionCodes="matAutocomplete" panelWidth="fit-content">
+                    <mat-option *ngFor="let conditionCode of filteredConditionCodes$[groupIndex] | async" [value]="conditionCode">
+                      {{ conditionCode }}
+                    </mat-option>
+                  </mat-autocomplete>
+                </span>
+              </mat-form-field>
+            </mat-cell>
+          </ng-container>
+
+          <!-- ASSIGNMENT WEIGHT Column -->
+          <ng-container matColumnDef="assignmentWeight">
+            <mat-header-cell class="ft-14-700" *matHeaderCellDef>
+              {{ 'home-global.assignment-weight.text' | translate }}
+            </mat-header-cell>
+            <mat-cell
+              *matCellDef="let element; let groupIndex = index"
+              [formGroupName]="groupIndex"
+              style="margin-left: 5px;"
+            >
+              <mat-form-field floatLabel="never">
+                <input
+                  type="string"
+                  matInput
+                  [placeholder]="
+                    'home.new-experiment.design.assignment-weight.placeholder.text'
+                      | translate
+                  "
+                  formControlName="assignmentWeight"
+                />
+              </mat-form-field>
+            </mat-cell>
+          </ng-container>
+
+          <!-- DESCRIPTION Column -->
+          <ng-container matColumnDef="description">
+            <mat-header-cell class="ft-14-700" *matHeaderCellDef>
+              {{ 'home.new-experiment.design.description.text' | translate }}
+            </mat-header-cell>
+            <mat-cell
+              *matCellDef="let element; let groupIndex = index"
+              [formGroupName]="groupIndex"
+            >
+              <mat-form-field floatLabel="never">
                 <input
                   matInput
                   [placeholder]="
-                    'home.new-experiment.design.condition.placeholder.text'
+                    'home.new-experiment.design.description.placeholder.text'
                       | translate
                   "
-                  formControlName="conditionCode"
-                  [matAutocomplete]="autoCompleteConditionCodes"
+                  formControlName="description"
                 />
-                <mat-autocomplete #autoCompleteConditionCodes="matAutocomplete" panelWidth="fit-content">
-                  <mat-option *ngFor="let conditionCode of filteredConditionCodes$[groupIndex] | async" [value]="conditionCode">
-                    {{ conditionCode }}
-                  </mat-option>
-                </mat-autocomplete>
-              </span>
-            </mat-form-field>
-          </mat-cell>
-        </ng-container>
+              </mat-form-field>
+            </mat-cell>
+          </ng-container>
 
-        <!-- ASSIGNMENT WEIGHT Column -->
-        <ng-container matColumnDef="assignmentWeight">
-          <mat-header-cell class="ft-14-700" *matHeaderCellDef>
-            {{ 'home-global.assignment-weight.text' | translate }}
-          </mat-header-cell>
-          <mat-cell
-            *matCellDef="let element; let groupIndex = index"
-            [formGroupName]="groupIndex"
-            style="margin-left: 5px;"
-          >
-            <mat-form-field floatLabel="never">
-              <input
-                type="string"
-                matInput
-                [placeholder]="
-                  'home.new-experiment.design.assignment-weight.placeholder.text'
-                    | translate
-                "
-                formControlName="assignmentWeight"
-              />
-            </mat-form-field>
-          </mat-cell>
-        </ng-container>
-
-        <!-- DESCRIPTION Column -->
-        <ng-container matColumnDef="description">
-          <mat-header-cell class="ft-14-700" *matHeaderCellDef>
-            {{ 'home.new-experiment.design.description.text' | translate }}
-          </mat-header-cell>
-          <mat-cell
-            *matCellDef="let element; let groupIndex = index"
-            [formGroupName]="groupIndex"
-          >
-            <mat-form-field floatLabel="never">
-              <input
-                matInput
-                [placeholder]="
-                  'home.new-experiment.design.description.placeholder.text'
-                    | translate
-                "
-                formControlName="description"
-              />
-            </mat-form-field>
-          </mat-cell>
-        </ng-container>
-
-        <ng-container matColumnDef="removeCondition">
-          <mat-header-cell class="ft-14-700" *matHeaderCellDef></mat-header-cell>
-          <mat-cell
-            *matCellDef="let element; let groupIndex = index"
-            [formGroupName]="groupIndex"
-            style="justify-content: flex-end;"
-          >
-          <button mat-icon-button
-            [disabled]="experimentInfo && (experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE)"
-            (click)="removeConditionOrPartition('condition', groupIndex)">
-            <mat-icon
-              class="remove-icon"
+          <ng-container matColumnDef="removeCondition">
+            <mat-header-cell class="ft-14-700" *matHeaderCellDef></mat-header-cell>
+            <mat-cell
+              *matCellDef="let element; let groupIndex = index"
+              [formGroupName]="groupIndex"
+              style="justify-content: flex-end;"
             >
-              delete_outline
-            </mat-icon>
-          </button>
-          </mat-cell>
-        </ng-container>
-        <mat-header-row *matHeaderRowDef="conditionDisplayedColumns; sticky: true"></mat-header-row>
-        <mat-row
-          *matRowDef="let row; columns: conditionDisplayedColumns"
-        ></mat-row>
-      </mat-table>
-      <button
-      type="button"
-      class="ft-12-700 add-condition"
-      *ngIf="!experimentInfo"
-      (click)="addConditionOrPartition('condition')"
-    >
-      + {{ 'home.new-experiment.design.add-condition.text' | translate }}
-    </button>
-      <button
+            <button mat-icon-button
+              [disabled]="experimentInfo && (experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE)"
+              (click)="removeConditionOrPartition('condition', groupIndex)">
+              <mat-icon
+                class="remove-icon"
+              >
+                delete_outline
+              </mat-icon>
+            </button>
+            </mat-cell>
+          </ng-container>
+          <mat-header-row *matHeaderRowDef="conditionDisplayedColumns; sticky: true"></mat-header-row>
+          <mat-row
+            *matRowDef="let row; columns: conditionDisplayedColumns"
+          ></mat-row>
+        </mat-table>
+        <button
         type="button"
         class="ft-12-700 add-condition"
-        *ngIf="experimentInfo"
-        [ngClass]="{ 'add-condition--disabled': (experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE) }"
-        [disabled]="(experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE)"
+        *ngIf="!experimentInfo"
         (click)="addConditionOrPartition('condition')"
       >
         + {{ 'home.new-experiment.design.add-condition.text' | translate }}
       </button>
-      <span
+        <button
+          type="button"
+          class="ft-12-700 add-condition"
+          *ngIf="experimentInfo"
+          [ngClass]="{ 'add-condition--disabled': (experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE) }"
+          [disabled]="(experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE)"
+          (click)="addConditionOrPartition('condition')"
+        >
+          + {{ 'home.new-experiment.design.add-condition.text' | translate }}
+        </button>
+        <span
+          class="ft-14-600 validation-message"
+          *ngIf="experimentDesignForm.errors?.assignmentWeightsSumError"
+          [innerHTML]="'home.new-experiment.design.assignment-weight-validation.text' | translate"
+        ></span>
+        <span
         class="ft-14-600 validation-message"
-        *ngIf="experimentDesignForm.errors?.assignmentWeightsSumError"
-        [innerHTML]="'home.new-experiment.design.assignment-weight-validation.text' | translate"
-      ></span>
-      <span
-      class="ft-14-600 validation-message"
-      *ngFor="let error of conditionCodeErrors"
-      >{{ error }} </span>
-      <span
-        class="ft-14-600 validation-message"
-        *ngIf="conditionCountError"
-        [innerHTML]="conditionCountError"
-      ></span>
-    </ng-container>
-    <br>
-    <br>
-    
-  </form>
-</section>
-<section class="modal-buttons-container">
-  <button
-    matStepperPrevious
-    mat-raised-button
-    class="modal-btn btn-back default-button"
-  >
-    {{ 'global.back.text' | translate }}
-  </button>
-  <div>
-    <button
-      type="button"
-      mat-raised-button
-      class="modal-btn"
-      (click)="emitEvent(NewExperimentDialogEvents.CLOSE_DIALOG)"
-    >
-      {{ 'global.cancel.text' | translate }}
-    </button> 
-    <button
-      type="button"
-      mat-raised-button
-      class="modal-btn default-button"
-      (click)="emitEvent(NewExperimentDialogEvents.SEND_FORM_DATA)"
-    >
-      {{ 'global.next.text' | translate }}
-    </button>
-    <button
-      type="button"
-      *ngIf="experimentInfo"
-      mat-raised-button
-      class="modal-btn default-button"
-      [ngClass]="{ 'default-button--disabled': (experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE) }"
-      [disabled]="(experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE)"
-      (click)="emitEvent(NewExperimentDialogEvents.SAVE_DATA)"
-    >
-      {{ 'global.update.text' | translate }}
-    </button>
-  </div>
-</section>
+        *ngFor="let error of conditionCodeErrors"
+        >{{ error }} </span>
+        <span
+          class="ft-14-600 validation-message"
+          *ngIf="conditionCountError"
+          [innerHTML]="conditionCountError"
+        ></span>
+      </ng-container>
+      <br>
+      <br>
+      
+    </form>
+  </section>
+
+  <section class="shared-modal--buttons-container">
+    <span class="shared-modal--buttons-left">
+      <button
+        matStepperPrevious
+        mat-raised-button
+        class="shared-modal--modal-btn btn-back default-button"
+      >
+        {{ 'global.back.text' | translate }}
+      </button>
+    </span>
+    <span class="shared-modal--buttons-right">
+      <button
+        type="button"
+        mat-raised-button
+        class="shared-modal--modal-btn"
+        (click)="emitEvent(NewExperimentDialogEvents.CLOSE_DIALOG)"
+      >
+        {{ 'global.cancel.text' | translate }}
+      </button>
+      <button
+        type="button"
+        mat-raised-button
+        class="shared-modal--modal-btn default-button"
+        (click)="emitEvent(NewExperimentDialogEvents.SEND_FORM_DATA)"
+      >
+        {{ 'global.next.text' | translate }}
+      </button>
+      <button
+        type="button"
+        *ngIf="experimentInfo"
+        mat-raised-button
+        class="shared-modal--modal-btn default-button"
+        [ngClass]="{ 'default-button--disabled': (experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE) }"
+        [disabled]="(experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE)"
+        (click)="emitEvent(NewExperimentDialogEvents.SAVE_DATA)"
+      >
+        {{ 'global.update.text' | translate }}
+      </button>
+    </span>
+  </section>
 </div> 

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.html
@@ -1,350 +1,355 @@
-<form class="experiment-design" [formGroup]="experimentDesignForm">
-  <!-- Partition Table -->
-  <span class="title">{{ 'home.new-experiment.design.decision-point.text' | translate }}</span>
-  <ng-container>
-    <mat-table
-      class="partition-table"
-      [dataSource]="partitionDataSource"
-      formArrayName="partitions"
-      #partitionTable
-    >
-      <!-- Site Column -->
-      <ng-container matColumnDef="site">
-        <mat-header-cell class="ft-14-700" *matHeaderCellDef>
-          {{ 'home.new-experiment.design.partition-point.text' | translate }}
-        </mat-header-cell>
-        <mat-cell
-          *matCellDef="let element; let groupIndex = index"
-          [formGroupName]="groupIndex"
-        >
-          <mat-form-field floatLabel="never">
-            <span
-              [matTooltip]="experimentDesignForm.getRawValue('site')?.partitions[groupIndex]?.site"
-              matTooltipPosition="above"
-              >
-              <input
-                matInput
-                [placeholder]="
-                  'home.new-experiment.design.partition-point.placeholder.text'
-                    | translate
-                "
-                formControlName="site"
-                [matAutocomplete]="autoCompleteExperimentPoints"
-              />
-              <mat-autocomplete #autoCompleteExperimentPoints="matAutocomplete" panelWidth="fit-content">
-                <mat-option *ngFor="let site of filteredExpPoints$[groupIndex] | async" [value]="site">
-                  {{ site }}
-                </mat-option>
-              </mat-autocomplete>
-            </span>
-          </mat-form-field>
-        </mat-cell>
-      </ng-container>
-
-      <!-- Target Column -->
-      <ng-container matColumnDef="target">
-        <mat-header-cell class="ft-14-700" *matHeaderCellDef>
-          {{ 'home.new-experiment.design.partition-id.text' | translate }}
-        </mat-header-cell>
-        <mat-cell
-          *matCellDef="let element; let groupIndex = index"
-          [formGroupName]="groupIndex"
-        >
-          <mat-form-field floatLabel="never">
-            <span
-              [matTooltip]="experimentDesignForm.getRawValue('target')?.partitions[groupIndex]?.target"
-              matTooltipPosition="above">
-              <input
-                matInput
-                [placeholder]="
-                  'home.new-experiment.design.partition-id.placeholder.text'
-                    | translate
-                "
-                formControlName="target"
-                [matAutocomplete]="autoCompleteExperimentIds"
-              />
-              <mat-autocomplete #autoCompleteExperimentIds="matAutocomplete" panelWidth="fit-content">
-                <mat-option *ngFor="let target of filteredExpIds$[groupIndex] | async" [value]="target">
-                  {{ target }}
-                </mat-option>
-              </mat-autocomplete>
-            </span>
-          </mat-form-field>
-        </mat-cell>
-      </ng-container>
-
-      <!-- Required Column -->
-      <!-- <ng-container matColumnDef="requiredId">
-        <mat-header-cell class="ft-14-700" *matHeaderCellDef>
-          {{ 'home.new-experiment.design.required.text' | translate }}
-        </mat-header-cell>
-        <mat-cell
-          *matCellDef="let element; let groupIndex = index"
-          [formGroupName]="groupIndex"
-          style="margin-left: 25px;"
-        >
-          <mat-checkbox
-                  class="ft-8-100"
-                  color="primary"
-                  [disabled]="true"
-                  >
-          </mat-checkbox>
-        </mat-cell>
-      </ng-container> -->
-
-      <ng-container matColumnDef="removePartition">
-        <mat-header-cell class="ft-14-700" *matHeaderCellDef></mat-header-cell>
-        <mat-cell
-          *matCellDef="let element; let groupIndex = index"
-          [formGroupName]="groupIndex"
-          style="justify-content: flex-end;"
-        >
-        <button mat-icon-button
-          [disabled]="experimentInfo && (experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE)"
-          (click)="removeConditionOrPartition('partition', groupIndex)">
-          <mat-icon
-            class="remove-icon"
+<div class="modal-step-container"> 
+<section class="modal-form-container">
+  <form class="experiment-design" [formGroup]="experimentDesignForm">
+    <!-- Partition Table -->
+    <span class="title">{{ 'home.new-experiment.design.decision-point.text' | translate }}</span>
+    <ng-container>
+      <mat-table
+        class="partition-table"
+        [dataSource]="partitionDataSource"
+        formArrayName="partitions"
+        #partitionTable
+      >
+        <!-- Site Column -->
+        <ng-container matColumnDef="site">
+          <mat-header-cell class="ft-14-700" *matHeaderCellDef>
+            {{ 'home.new-experiment.design.partition-point.text' | translate }}
+          </mat-header-cell>
+          <mat-cell
+            *matCellDef="let element; let groupIndex = index"
+            [formGroupName]="groupIndex"
           >
-            delete_outline
-          </mat-icon>
-        </button>
-        </mat-cell>
-      </ng-container>
+            <mat-form-field floatLabel="never">
+              <span
+                [matTooltip]="experimentDesignForm.getRawValue('site')?.partitions[groupIndex]?.site"
+                matTooltipPosition="above"
+                >
+                <input
+                  matInput
+                  [placeholder]="
+                    'home.new-experiment.design.partition-point.placeholder.text'
+                      | translate
+                  "
+                  formControlName="site"
+                  [matAutocomplete]="autoCompleteExperimentPoints"
+                />
+                <mat-autocomplete #autoCompleteExperimentPoints="matAutocomplete" panelWidth="fit-content">
+                  <mat-option *ngFor="let site of filteredExpPoints$[groupIndex] | async" [value]="site">
+                    {{ site }}
+                  </mat-option>
+                </mat-autocomplete>
+              </span>
+            </mat-form-field>
+          </mat-cell>
+        </ng-container>
 
-      <mat-header-row
-        *matHeaderRowDef="partitionDisplayedColumns; sticky: true"
-      ></mat-header-row>
-      <mat-row *matRowDef="let row; columns: partitionDisplayedColumns"></mat-row>
-    </mat-table>
-    <button
-      type="button"
-      class="ft-12-700 add-partition"
-      *ngIf="!experimentInfo"
-      (click)="addConditionOrPartition('partition')"
-    >
-      +
-      {{ 'home.new-experiment.design.add-experiment-partition.text' | translate }}
-    </button>
-    <button
-      type="button"
-      class="ft-12-700 add-partition"
-      *ngIf="experimentInfo"
-      [ngClass]="{ 'add-partition--disabled': this.experimentInfo && (this.experimentInfo.state == ExperimentState.ENROLLING || this.experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE) }"
-      [disabled]="(experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE)"
-      (click)="addConditionOrPartition('partition')"
-    >
-      +
-      {{ 'home.new-experiment.design.add-experiment-partition.text' | translate }}
-    </button>
-  </ng-container>
-  <span
-    class="ft-14-600 validation-message"
-    *ngFor="let error of partitionPointErrors"
-  >{{ error }}</span>
-  <span
+        <!-- Target Column -->
+        <ng-container matColumnDef="target">
+          <mat-header-cell class="ft-14-700" *matHeaderCellDef>
+            {{ 'home.new-experiment.design.partition-id.text' | translate }}
+          </mat-header-cell>
+          <mat-cell
+            *matCellDef="let element; let groupIndex = index"
+            [formGroupName]="groupIndex"
+          >
+            <mat-form-field floatLabel="never">
+              <span
+                [matTooltip]="experimentDesignForm.getRawValue('target')?.partitions[groupIndex]?.target"
+                matTooltipPosition="above">
+                <input
+                  matInput
+                  [placeholder]="
+                    'home.new-experiment.design.partition-id.placeholder.text'
+                      | translate
+                  "
+                  formControlName="target"
+                  [matAutocomplete]="autoCompleteExperimentIds"
+                />
+                <mat-autocomplete #autoCompleteExperimentIds="matAutocomplete" panelWidth="fit-content">
+                  <mat-option *ngFor="let target of filteredExpIds$[groupIndex] | async" [value]="target">
+                    {{ target }}
+                  </mat-option>
+                </mat-autocomplete>
+              </span>
+            </mat-form-field>
+          </mat-cell>
+        </ng-container>
+
+        <!-- Required Column -->
+        <!-- <ng-container matColumnDef="requiredId">
+          <mat-header-cell class="ft-14-700" *matHeaderCellDef>
+            {{ 'home.new-experiment.design.required.text' | translate }}
+          </mat-header-cell>
+          <mat-cell
+            *matCellDef="let element; let groupIndex = index"
+            [formGroupName]="groupIndex"
+            style="margin-left: 25px;"
+          >
+            <mat-checkbox
+                    class="ft-8-100"
+                    color="primary"
+                    [disabled]="true"
+                    >
+            </mat-checkbox>
+          </mat-cell>
+        </ng-container> -->
+
+        <ng-container matColumnDef="removePartition">
+          <mat-header-cell class="ft-14-700" *matHeaderCellDef></mat-header-cell>
+          <mat-cell
+            *matCellDef="let element; let groupIndex = index"
+            [formGroupName]="groupIndex"
+            style="justify-content: flex-end;"
+          >
+          <button mat-icon-button
+            [disabled]="experimentInfo && (experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE)"
+            (click)="removeConditionOrPartition('partition', groupIndex)">
+            <mat-icon
+              class="remove-icon"
+            >
+              delete_outline
+            </mat-icon>
+          </button>
+          </mat-cell>
+        </ng-container>
+
+        <mat-header-row
+          *matHeaderRowDef="partitionDisplayedColumns; sticky: true"
+        ></mat-header-row>
+        <mat-row *matRowDef="let row; columns: partitionDisplayedColumns"></mat-row>
+      </mat-table>
+      <button
+        type="button"
+        class="ft-12-700 add-partition"
+        *ngIf="!experimentInfo"
+        (click)="addConditionOrPartition('partition')"
+      >
+        +
+        {{ 'home.new-experiment.design.add-experiment-partition.text' | translate }}
+      </button>
+      <button
+        type="button"
+        class="ft-12-700 add-partition"
+        *ngIf="experimentInfo"
+        [ngClass]="{ 'add-partition--disabled': this.experimentInfo && (this.experimentInfo.state == ExperimentState.ENROLLING || this.experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE) }"
+        [disabled]="(experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE)"
+        (click)="addConditionOrPartition('partition')"
+      >
+        +
+        {{ 'home.new-experiment.design.add-experiment-partition.text' | translate }}
+      </button>
+    </ng-container>
+    <span
       class="ft-14-600 validation-message"
-      *ngIf="partitionCountError"
-      [innerHTML]="partitionCountError"
-  ></span>
-  <!-- If experiment point and id are not from predefined value -->
-  <span
-    class="ft-14-600 validation-message"
-    *ngFor="let error of expPointAndIdErrors"
-  >{{ error }}</span>
-  <br>
-  <br>
-  <!-- Condition table -->
-  <span class="title">{{ 'home.new-experiment.design.condition.text' | translate }}</span>
-  <!-- apply equal condition weights -->
-  <div class="header-group">
-    <mat-checkbox
-    class="ft-8-100"
-    color="primary"
-    [checked]="equalWeightFlag"
-    (change)="changeEqualWeightFlag($event)">
-    {{ 'home.new-experiment.design.equal-assignment-weights.text' | translate }}
-    </mat-checkbox>
-  </div>
-  <ng-container>
-    <mat-table
-      class="condition-table"
-      [dataSource]="conditionDataSource"
-      formArrayName="conditions"
-      #conditionTable
-    >
-      <!-- CONDITION NAME Column -->
-      <ng-container matColumnDef="conditionCode">
-        <mat-header-cell class="ft-14-700" *matHeaderCellDef>
-          {{ 'home.new-experiment.design.name.text' | translate }}
-        </mat-header-cell>
-        <mat-cell
-          *matCellDef="let element; let groupIndex = index"
-          [formGroupName]="groupIndex"
-        >
-          <mat-form-field floatLabel="never">
-            <span 
-              [matTooltip]="experimentDesignForm.getRawValue('conditionCode')?.conditions[groupIndex]?.conditionCode"
-              matTooltipPosition="above"
-              >
+      *ngFor="let error of partitionPointErrors"
+    >{{ error }}</span>
+    <span
+        class="ft-14-600 validation-message"
+        *ngIf="partitionCountError"
+        [innerHTML]="partitionCountError"
+    ></span>
+    <!-- If experiment point and id are not from predefined value -->
+    <span
+      class="ft-14-600 validation-message"
+      *ngFor="let error of expPointAndIdErrors"
+    >{{ error }}</span>
+    <br>
+    <br>
+    <!-- Condition table -->
+    <span class="title">{{ 'home.new-experiment.design.condition.text' | translate }}</span>
+    <!-- apply equal condition weights -->
+    <div class="header-group">
+      <mat-checkbox
+      class="ft-8-100"
+      color="primary"
+      [checked]="equalWeightFlag"
+      (change)="changeEqualWeightFlag($event)">
+      {{ 'home.new-experiment.design.equal-assignment-weights.text' | translate }}
+      </mat-checkbox>
+    </div>
+    <ng-container>
+      <mat-table
+        class="condition-table"
+        [dataSource]="conditionDataSource"
+        formArrayName="conditions"
+        #conditionTable
+      >
+        <!-- CONDITION NAME Column -->
+        <ng-container matColumnDef="conditionCode">
+          <mat-header-cell class="ft-14-700" *matHeaderCellDef>
+            {{ 'home.new-experiment.design.name.text' | translate }}
+          </mat-header-cell>
+          <mat-cell
+            *matCellDef="let element; let groupIndex = index"
+            [formGroupName]="groupIndex"
+          >
+            <mat-form-field floatLabel="never">
+              <span 
+                [matTooltip]="experimentDesignForm.getRawValue('conditionCode')?.conditions[groupIndex]?.conditionCode"
+                matTooltipPosition="above"
+                >
+                <input
+                  matInput
+                  [placeholder]="
+                    'home.new-experiment.design.condition.placeholder.text'
+                      | translate
+                  "
+                  formControlName="conditionCode"
+                  [matAutocomplete]="autoCompleteConditionCodes"
+                />
+                <mat-autocomplete #autoCompleteConditionCodes="matAutocomplete" panelWidth="fit-content">
+                  <mat-option *ngFor="let conditionCode of filteredConditionCodes$[groupIndex] | async" [value]="conditionCode">
+                    {{ conditionCode }}
+                  </mat-option>
+                </mat-autocomplete>
+              </span>
+            </mat-form-field>
+          </mat-cell>
+        </ng-container>
+
+        <!-- ASSIGNMENT WEIGHT Column -->
+        <ng-container matColumnDef="assignmentWeight">
+          <mat-header-cell class="ft-14-700" *matHeaderCellDef>
+            {{ 'home-global.assignment-weight.text' | translate }}
+          </mat-header-cell>
+          <mat-cell
+            *matCellDef="let element; let groupIndex = index"
+            [formGroupName]="groupIndex"
+            style="margin-left: 5px;"
+          >
+            <mat-form-field floatLabel="never">
+              <input
+                type="string"
+                matInput
+                [placeholder]="
+                  'home.new-experiment.design.assignment-weight.placeholder.text'
+                    | translate
+                "
+                formControlName="assignmentWeight"
+              />
+            </mat-form-field>
+          </mat-cell>
+        </ng-container>
+
+        <!-- DESCRIPTION Column -->
+        <ng-container matColumnDef="description">
+          <mat-header-cell class="ft-14-700" *matHeaderCellDef>
+            {{ 'home.new-experiment.design.description.text' | translate }}
+          </mat-header-cell>
+          <mat-cell
+            *matCellDef="let element; let groupIndex = index"
+            [formGroupName]="groupIndex"
+          >
+            <mat-form-field floatLabel="never">
               <input
                 matInput
                 [placeholder]="
-                  'home.new-experiment.design.condition.placeholder.text'
+                  'home.new-experiment.design.description.placeholder.text'
                     | translate
                 "
-                formControlName="conditionCode"
-                [matAutocomplete]="autoCompleteConditionCodes"
+                formControlName="description"
               />
-              <mat-autocomplete #autoCompleteConditionCodes="matAutocomplete" panelWidth="fit-content">
-                <mat-option *ngFor="let conditionCode of filteredConditionCodes$[groupIndex] | async" [value]="conditionCode">
-                  {{ conditionCode }}
-                </mat-option>
-              </mat-autocomplete>
-            </span>
-          </mat-form-field>
-        </mat-cell>
-      </ng-container>
+            </mat-form-field>
+          </mat-cell>
+        </ng-container>
 
-      <!-- ASSIGNMENT WEIGHT Column -->
-      <ng-container matColumnDef="assignmentWeight">
-        <mat-header-cell class="ft-14-700" *matHeaderCellDef>
-          {{ 'home-global.assignment-weight.text' | translate }}
-        </mat-header-cell>
-        <mat-cell
-          *matCellDef="let element; let groupIndex = index"
-          [formGroupName]="groupIndex"
-          style="margin-left: 5px;"
-        >
-          <mat-form-field floatLabel="never">
-            <input
-              type="string"
-              matInput
-              [placeholder]="
-                'home.new-experiment.design.assignment-weight.placeholder.text'
-                  | translate
-              "
-              formControlName="assignmentWeight"
-            />
-          </mat-form-field>
-        </mat-cell>
-      </ng-container>
-
-      <!-- DESCRIPTION Column -->
-      <ng-container matColumnDef="description">
-        <mat-header-cell class="ft-14-700" *matHeaderCellDef>
-          {{ 'home.new-experiment.design.description.text' | translate }}
-        </mat-header-cell>
-        <mat-cell
-          *matCellDef="let element; let groupIndex = index"
-          [formGroupName]="groupIndex"
-        >
-          <mat-form-field floatLabel="never">
-            <input
-              matInput
-              [placeholder]="
-                'home.new-experiment.design.description.placeholder.text'
-                  | translate
-              "
-              formControlName="description"
-            />
-          </mat-form-field>
-        </mat-cell>
-      </ng-container>
-
-      <ng-container matColumnDef="removeCondition">
-        <mat-header-cell class="ft-14-700" *matHeaderCellDef></mat-header-cell>
-        <mat-cell
-          *matCellDef="let element; let groupIndex = index"
-          [formGroupName]="groupIndex"
-          style="justify-content: flex-end;"
-        >
-        <button mat-icon-button
-          [disabled]="experimentInfo && (experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE)"
-          (click)="removeConditionOrPartition('condition', groupIndex)">
-          <mat-icon
-            class="remove-icon"
+        <ng-container matColumnDef="removeCondition">
+          <mat-header-cell class="ft-14-700" *matHeaderCellDef></mat-header-cell>
+          <mat-cell
+            *matCellDef="let element; let groupIndex = index"
+            [formGroupName]="groupIndex"
+            style="justify-content: flex-end;"
           >
-            delete_outline
-          </mat-icon>
-        </button>
-        </mat-cell>
-      </ng-container>
-      <mat-header-row *matHeaderRowDef="conditionDisplayedColumns; sticky: true"></mat-header-row>
-      <mat-row
-        *matRowDef="let row; columns: conditionDisplayedColumns"
-      ></mat-row>
-    </mat-table>
-    <button
-    type="button"
-    class="ft-12-700 add-condition"
-    *ngIf="!experimentInfo"
-    (click)="addConditionOrPartition('condition')"
-  >
-    + {{ 'home.new-experiment.design.add-condition.text' | translate }}
-  </button>
-    <button
+          <button mat-icon-button
+            [disabled]="experimentInfo && (experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE)"
+            (click)="removeConditionOrPartition('condition', groupIndex)">
+            <mat-icon
+              class="remove-icon"
+            >
+              delete_outline
+            </mat-icon>
+          </button>
+          </mat-cell>
+        </ng-container>
+        <mat-header-row *matHeaderRowDef="conditionDisplayedColumns; sticky: true"></mat-header-row>
+        <mat-row
+          *matRowDef="let row; columns: conditionDisplayedColumns"
+        ></mat-row>
+      </mat-table>
+      <button
       type="button"
       class="ft-12-700 add-condition"
-      *ngIf="experimentInfo"
-      [ngClass]="{ 'add-condition--disabled': (experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE) }"
-      [disabled]="(experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE)"
+      *ngIf="!experimentInfo"
       (click)="addConditionOrPartition('condition')"
     >
       + {{ 'home.new-experiment.design.add-condition.text' | translate }}
     </button>
-    <span
-      class="ft-14-600 validation-message"
-      *ngIf="experimentDesignForm.errors?.assignmentWeightsSumError"
-      [innerHTML]="'home.new-experiment.design.assignment-weight-validation.text' | translate"
-    ></span>
-    <span
-    class="ft-14-600 validation-message"
-    *ngFor="let error of conditionCodeErrors"
-    >{{ error }} </span>
-    <span
-      class="ft-14-600 validation-message"
-      *ngIf="conditionCountError"
-      [innerHTML]="conditionCountError"
-    ></span>
-  </ng-container>
-  <br>
-  <br>
-  <div class="button-container">
-    <button
-      matStepperPrevious
-      mat-raised-button
-      class="modal-btn btn-back default-button"
-    >
-      {{ 'global.back.text' | translate }}
-    </button>
-    <div>
       <button
         type="button"
-        mat-raised-button
-        class="modal-btn"
-        (click)="emitEvent(NewExperimentDialogEvents.CLOSE_DIALOG)"
-      >
-        {{ 'global.cancel.text' | translate }}
-      </button> 
-      <button
-        type="button"
-        mat-raised-button
-        class="modal-btn default-button"
-        (click)="emitEvent(NewExperimentDialogEvents.SEND_FORM_DATA)"
-      >
-        {{ 'global.next.text' | translate }}
-      </button>
-      <button
-        type="button"
+        class="ft-12-700 add-condition"
         *ngIf="experimentInfo"
-        mat-raised-button
-        class="modal-btn default-button"
-        [ngClass]="{ 'default-button--disabled': (experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE) }"
+        [ngClass]="{ 'add-condition--disabled': (experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE) }"
         [disabled]="(experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE)"
-        (click)="emitEvent(NewExperimentDialogEvents.SAVE_DATA)"
+        (click)="addConditionOrPartition('condition')"
       >
-        {{ 'global.update.text' | translate }}
+        + {{ 'home.new-experiment.design.add-condition.text' | translate }}
       </button>
-    </div>
+      <span
+        class="ft-14-600 validation-message"
+        *ngIf="experimentDesignForm.errors?.assignmentWeightsSumError"
+        [innerHTML]="'home.new-experiment.design.assignment-weight-validation.text' | translate"
+      ></span>
+      <span
+      class="ft-14-600 validation-message"
+      *ngFor="let error of conditionCodeErrors"
+      >{{ error }} </span>
+      <span
+        class="ft-14-600 validation-message"
+        *ngIf="conditionCountError"
+        [innerHTML]="conditionCountError"
+      ></span>
+    </ng-container>
+    <br>
+    <br>
+    
+  </form>
+</section>
+<section class="modal-buttons-container">
+  <button
+    matStepperPrevious
+    mat-raised-button
+    class="modal-btn btn-back default-button"
+  >
+    {{ 'global.back.text' | translate }}
+  </button>
+  <div>
+    <button
+      type="button"
+      mat-raised-button
+      class="modal-btn"
+      (click)="emitEvent(NewExperimentDialogEvents.CLOSE_DIALOG)"
+    >
+      {{ 'global.cancel.text' | translate }}
+    </button> 
+    <button
+      type="button"
+      mat-raised-button
+      class="modal-btn default-button"
+      (click)="emitEvent(NewExperimentDialogEvents.SEND_FORM_DATA)"
+    >
+      {{ 'global.next.text' | translate }}
+    </button>
+    <button
+      type="button"
+      *ngIf="experimentInfo"
+      mat-raised-button
+      class="modal-btn default-button"
+      [ngClass]="{ 'default-button--disabled': (experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE) }"
+      [disabled]="(experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE)"
+      (click)="emitEvent(NewExperimentDialogEvents.SAVE_DATA)"
+    >
+      {{ 'global.update.text' | translate }}
+    </button>
   </div>
-</form>
+</section>
+</div> 

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.scss
@@ -1,10 +1,3 @@
-.modal-step-container {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  height: 575px;
-}
-
 .experiment-design {
   .condition-table,
   .partition-table {
@@ -111,14 +104,4 @@
   display: grid;
   margin-left: 10px;
   justify-content: left;
-}
-
-.modal-buttons-container {
-  display: flex;
-  justify-content: space-between;
-  margin-top: 15px;
-
-  .btn-back {
-    margin-left: 0 !important;
-  }
 }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.scss
@@ -1,3 +1,10 @@
+.modal-step-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 575px;
+}
+
 .experiment-design {
   .condition-table,
   .partition-table {
@@ -84,16 +91,6 @@
     margin-top: 30px;
   }
 
-  .button-container {
-    display: flex;
-    justify-content: space-between;
-    margin-top: 15px;
-
-    .btn-back {
-      margin-left: 0 !important;
-    }
-  }
-
   .title {
     font-size: 20px;
     font-weight: bold;
@@ -114,4 +111,14 @@
   display: grid;
   margin-left: 10px;
   justify-content: left;
+}
+
+.modal-buttons-container {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 15px;
+
+  .btn-back {
+    margin-left: 0 !important;
+  }
 }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.html
@@ -1,114 +1,117 @@
-<form class="experiment-overview" [formGroup]="overviewForm">
-  <mat-form-field class="ft-14-600 name">
-    <input
-      matInput
-      class="ft-14-400"
-      [placeholder]="
-        'home.new-experiment.overview.name.placeHolder' | translate
-      "
-      formControlName="experimentName"
-      cdkFocusInitial
-    />
-  </mat-form-field>
+<div class="modal-step-container">
+  <section class="modal-form-container">
+    <form class="experiment-overview" [formGroup]="overviewForm">
+      <mat-form-field class="ft-14-600 name">
+        <input
+          matInput
+          class="ft-14-400"
+          [placeholder]="
+            'home.new-experiment.overview.name.placeHolder' | translate
+          "
+          formControlName="experimentName"
+          cdkFocusInitial
+        />
+      </mat-form-field>
 
-  <mat-form-field class="ft-14-600 description">
-    <input
-      matInput
-      class="ft-14-400"
-      [placeholder]="
-        'home.new-experiment.overview.description.placeHolder' | translate
-      "
-      formControlName="description"
-    />
-  </mat-form-field>
+      <mat-form-field class="ft-14-600 description">
+        <input
+          matInput
+          class="ft-14-400"
+          [placeholder]="
+            'home.new-experiment.overview.description.placeHolder' | translate
+          "
+          formControlName="description"
+        />
+      </mat-form-field>
 
-  <mat-form-field class="ft-14-600 chips">
-    <mat-label>{{ 'Context' }}</mat-label>
-    <mat-select class="ft-14-400" formControlName="context">
-      <mat-option *ngFor="let context of allContexts" [value]="context">
-        {{ context }}
-      </mat-option>
-    </mat-select>
-    <mat-error
-      *ngIf="overviewForm.controls.context.hasError('required')"
-    >
-      {{ 'home.new-experiment.overview.context.error.text' | translate }}
-    </mat-error>
-  </mat-form-field>
-
-  <div class="property-container">
-    <mat-form-field class="ft-14-600 unit-of-assignment">
-      <mat-label>{{ 'home-global.unit-of-assignment.text' | translate }}</mat-label>
-      <mat-select class="ft-14-400" formControlName="unitOfAssignment">
-        <mat-option
-          *ngFor="let unitOfAssignment of unitOfAssignments"
-          [value]="unitOfAssignment.value"
+      <mat-form-field class="ft-14-600 chips">
+        <mat-label>{{ 'Context' }}</mat-label>
+        <mat-select class="ft-14-400" formControlName="context">
+          <mat-option *ngFor="let context of allContexts" [value]="context">
+            {{ context }}
+          </mat-option>
+        </mat-select>
+        <mat-error
+          *ngIf="overviewForm.controls.context.hasError('required')"
         >
-          {{ unitOfAssignment.value | titlecase }}
-        </mat-option>
-      </mat-select>
-      <mat-error
-        *ngIf="overviewForm.controls.unitOfAssignment.hasError('required')"
-      >
-        {{ 'home.new-experiment.overview.unit-of-assignment.error.text' | translate }}
-      </mat-error>
-    </mat-form-field>
+          {{ 'home.new-experiment.overview.context.error.text' | translate }}
+        </mat-error>
+      </mat-form-field>
 
-    <mat-form-field class="ft-14-600 group-type" *ngIf="unitOfAssignmentValue">
-      <mat-label>{{ 'home.new-experiment.overview.group-type.placeHolder' | translate }}</mat-label>
-      <mat-select class="ft-14-400" formControlName="groupType">
-        <mat-option *ngFor="let group of groupTypes" [value]="group.value">{{ group.value }}</mat-option>
-      </mat-select>
-      <mat-error *ngIf="overviewForm.controls.groupType.hasError('required')">
-        {{ 'home.new-experiment.overview.group-type.error.text' | translate }}
-      </mat-error>
-    </mat-form-field>
-  </div>
+      <div class="property-container">
+        <mat-form-field class="ft-14-600 unit-of-assignment">
+          <mat-label>{{ 'home-global.unit-of-assignment.text' | translate }}</mat-label>
+          <mat-select class="ft-14-400" formControlName="unitOfAssignment">
+            <mat-option
+              *ngFor="let unitOfAssignment of unitOfAssignments"
+              [value]="unitOfAssignment.value"
+            >
+              {{ unitOfAssignment.value | titlecase }}
+            </mat-option>
+          </mat-select>
+          <mat-error
+            *ngIf="overviewForm.controls.unitOfAssignment.hasError('required')"
+          >
+            {{ 'home.new-experiment.overview.unit-of-assignment.error.text' | translate }}
+          </mat-error>
+        </mat-form-field>
 
-  <mat-form-field class="ft-14-600 consistency-rule">
-    <mat-label>{{ 'home-global.consistency-rule.text' | translate }}</mat-label>
-    <mat-select class="ft-14-400" formControlName="consistencyRule">
-      <mat-option
-        *ngFor="let consistencyRule of consistencyRules"
-        [value]="consistencyRule.value"
-      >
-        {{ consistencyRule.value | titlecase }}
-      </mat-option>
-    </mat-select>
-    <mat-error
-      *ngIf="overviewForm.controls.consistencyRule.hasError('required')"
-    >
-      {{ 'home.new-experiment.overview.consistency-rule.error.text' | translate }}
-    </mat-error>
-  </mat-form-field>
+        <mat-form-field class="ft-14-600 group-type" *ngIf="unitOfAssignmentValue">
+          <mat-label>{{ 'home.new-experiment.overview.group-type.placeHolder' | translate }}</mat-label>
+          <mat-select class="ft-14-400" formControlName="groupType">
+            <mat-option *ngFor="let group of groupTypes" [value]="group.value">{{ group.value }}</mat-option>
+          </mat-select>
+          <mat-error *ngIf="overviewForm.controls.groupType.hasError('required')">
+            {{ 'home.new-experiment.overview.group-type.error.text' | translate }}
+          </mat-error>
+        </mat-form-field>
+      </div>
 
-  <mat-form-field class="ft-14-600 tags">
-    <mat-chip-list #tagsList aria-label="Tags" formControlName="tags">
-      <mat-chip
-        *ngFor="let experimentTag of tags.value"
-        [selectable]="isChipSelectable"
-        [removable]="isChipRemovable"
-        (removed)="removeChip(experimentTag, 'tags')"
-      >
-        {{ experimentTag }}
-        <mat-icon matChipRemove *ngIf="isChipRemovable">cancel</mat-icon>
-      </mat-chip>
-      <input
-        [placeholder]="
-          'home.new-experiment.overview.tags.placeHolder' | translate
-        "
-        [matChipInputFor]="tagsList"
-        [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
-        [matChipInputAddOnBlur]="addChipOnBlur"
-        (matChipInputTokenEnd)="addChip($event, 'tags')"
-      />
-    </mat-chip-list>
-  </mat-form-field>
-  <mat-checkbox class="ft-14-700" color="primary" formControlName="logging">
-    {{ 'home.view-experiment.logging.text' | translate }}
-  </mat-checkbox>
+      <mat-form-field class="ft-14-600 consistency-rule">
+        <mat-label>{{ 'home-global.consistency-rule.text' | translate }}</mat-label>
+        <mat-select class="ft-14-400" formControlName="consistencyRule">
+          <mat-option
+            *ngFor="let consistencyRule of consistencyRules"
+            [value]="consistencyRule.value"
+          >
+            {{ consistencyRule.value | titlecase }}
+          </mat-option>
+        </mat-select>
+        <mat-error
+          *ngIf="overviewForm.controls.consistencyRule.hasError('required')"
+        >
+          {{ 'home.new-experiment.overview.consistency-rule.error.text' | translate }}
+        </mat-error>
+      </mat-form-field>
 
-  <div class="button-container">
+      <mat-form-field class="ft-14-600 tags">
+        <mat-chip-list #tagsList aria-label="Tags" formControlName="tags">
+          <mat-chip
+            *ngFor="let experimentTag of tags.value"
+            [selectable]="isChipSelectable"
+            [removable]="isChipRemovable"
+            (removed)="removeChip(experimentTag, 'tags')"
+          >
+            {{ experimentTag }}
+            <mat-icon matChipRemove *ngIf="isChipRemovable">cancel</mat-icon>
+          </mat-chip>
+          <input
+            [placeholder]="
+              'home.new-experiment.overview.tags.placeHolder' | translate
+            "
+            [matChipInputFor]="tagsList"
+            [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
+            [matChipInputAddOnBlur]="addChipOnBlur"
+            (matChipInputTokenEnd)="addChip($event, 'tags')"
+          />
+        </mat-chip-list>
+      </mat-form-field>
+      <mat-checkbox class="ft-14-700" color="primary" formControlName="logging">
+        {{ 'home.view-experiment.logging.text' | translate }}
+      </mat-checkbox>
+    </form>
+  </section>
+  <section class="modal-buttons-container">
     <button
       type="button"
       mat-raised-button
@@ -133,8 +136,8 @@
       [ngClass]="{ 'default-button--disabled': experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE }"
         [disabled]="experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE"
       (click)="emitEvent(NewExperimentDialogEvents.SAVE_DATA)"
-    >
+      >
       {{ 'global.update.text' | translate }}
     </button>
-  </div>
-</form>
+  </section>
+</div>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.html
@@ -1,5 +1,5 @@
-<div class="modal-step-container">
-  <section class="modal-form-container">
+<div class="shared-modal--step-container">
+  <section class="shared-modal--form-container">
     <form class="experiment-overview" [formGroup]="overviewForm">
       <mat-form-field class="ft-14-600 name">
         <input
@@ -111,33 +111,42 @@
       </mat-checkbox>
     </form>
   </section>
-  <section class="modal-buttons-container">
-    <button
-      type="button"
-      mat-raised-button
-      class="modal-btn"
-      (click)="emitEvent(NewExperimentDialogEvents.CLOSE_DIALOG)"
-    >
-      {{ 'global.cancel.text' | translate }}
-    </button>
-    <button
-      type="button"
-      mat-raised-button
-      class="modal-btn default-button"
-      (click)="emitEvent(NewExperimentDialogEvents.SEND_FORM_DATA)"
-    >
-      {{ 'global.next.text' | translate }}
-    </button>
-    <button
-      type="button"
-      *ngIf="experimentInfo && enableSave"
-      mat-raised-button
-      class="modal-btn default-button"
-      [ngClass]="{ 'default-button--disabled': experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE }"
-        [disabled]="experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE"
-      (click)="emitEvent(NewExperimentDialogEvents.SAVE_DATA)"
+
+  <section class="shared-modal--buttons-container">
+    <span class="shared-modal--buttons-left">
+      <!-- 
+        empty left-side spacer for flex-box;
+        first modal step has no left side / back btn
+      -->
+    </span>
+    <span class="shared-modal--buttons-right">
+      <button
+        type="button"
+        mat-raised-button
+        class="shared-modal--modal-btn"
+        (click)="emitEvent(NewExperimentDialogEvents.CLOSE_DIALOG)"
       >
-      {{ 'global.update.text' | translate }}
-    </button>
+        {{ 'global.cancel.text' | translate }}
+      </button>
+      <button
+        type="button"
+        mat-raised-button
+        class="shared-modal--modal-btn default-button"
+        (click)="emitEvent(NewExperimentDialogEvents.SEND_FORM_DATA)"
+      >
+        {{ 'global.next.text' | translate }}
+      </button>
+      <button
+        type="button"
+        *ngIf="experimentInfo && enableSave"
+        mat-raised-button
+        class="shared-modal--modal-btn default-button"
+        [ngClass]="{ 'default-button--disabled': experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE }"
+          [disabled]="experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE"
+        (click)="emitEvent(NewExperimentDialogEvents.SAVE_DATA)"
+        >
+        {{ 'global.update.text' | translate }}
+      </button>
+    </span>
   </section>
 </div>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.scss
@@ -1,3 +1,10 @@
+.modal-step-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 575px;
+}
+
 .experiment-overview {
   display: flex;
   flex-direction: column;
@@ -41,12 +48,6 @@
     width: 100%;
   }
 
-  .button-container {
-    display: flex;
-    justify-content: flex-end;
-    margin-top: 30px;
-  }
-
   ::ng-deep .mat-chip-list-wrapper {
     max-height: 60px;
     overflow: auto;
@@ -55,4 +56,10 @@
   ::ng-deep .mat-form-field-label {
     color: var(--grey-6);
   }
+}
+
+.modal-buttons-container {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 30px;
 }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.scss
@@ -1,10 +1,3 @@
-.modal-step-container {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  height: 575px;
-}
-
 .experiment-overview {
   display: flex;
   flex-direction: column;
@@ -56,10 +49,4 @@
   ::ng-deep .mat-form-field-label {
     color: var(--grey-6);
   }
-}
-
-.modal-buttons-container {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 30px;
 }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-participants/experiment-participants.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-participants/experiment-participants.component.html
@@ -1,259 +1,266 @@
-<form class="experiment-participants" [formGroup]="participantsForm">
-  <!-- Table -->
-  <div class="property-container">
-    <mat-form-field class="ft-14-600 inclusion-criteria">
-      <mat-label>{{ 'home-global.inclusion-criteria.text' | translate }}</mat-label>
-      <mat-select class="ft-14-400" formControlName="inclusionCriteria">
-        <mat-option
-          *ngFor="let criteria of inclusionCriteria"
-          [value]="criteria.value"
-        >
-          {{ criteria.value | titlecase }}
-        </mat-option>
-      </mat-select>
-    </mat-form-field>
-    <br>
-    <span class="title"> {{ 'segments.include.text' | translate }} </span>
-    <mat-table
-      class="member-table"
-      [dataSource]="members1DataSource"
-      formArrayName="members1"
-      #membersTable
-    >
-      <!-- Members Type Column -->
-      <ng-container matColumnDef="type">
-        <mat-header-cell class="ft-14-700" *matHeaderCellDef>
-          {{ 'segments.global-members-type.text' | translate }}
-        </mat-header-cell>
-        <mat-cell
-          *matCellDef="let element; let groupIndex = index"
-          [formGroupName]="groupIndex"
-        >
-        <mat-form-field floatLabel="never" class="form-control">
-          <mat-label>{{ 'segments.members-placeholder-type.text' | translate }}</mat-label>
-          <mat-select formControlName="type">
-            <mat-optgroup
-              *ngFor="let type of subSegmentTypes"
-              [class.hideLabel]="type.heading == ''"
-              [disabled]="type.disabled"
-              [label]="type.heading"
-            >
-              <mat-option *ngFor="let val of type.value" [value]="val">
-                {{ val }}
-              </mat-option>
-            </mat-optgroup>
-          </mat-select>
-        </mat-form-field>
-        </mat-cell>
-      </ng-container>
-      <!-- Members Id Column -->
-      <ng-container matColumnDef="id">
-        <mat-header-cell class="ft-14-700" *matHeaderCellDef>
-          {{ 'segments.global-members-id/name.text' | translate }}
-        </mat-header-cell>
-        <mat-cell
-          *matCellDef="let element; let groupIndex = index"
-          [formGroupName]="groupIndex"
-        >
-        <ng-container *ngIf="participantsForm.getRawValue('type')?.members1[groupIndex]?.type === 'Segment'; else noSelect">
-          <mat-form-field floatLabel="never" class="form-control">
-            <mat-select formControlName="id">
-              <mat-option *ngFor="let subSegmentId of subSegmentIds" [value]="subSegmentId">
-                {{ subSegmentId }}
-              </mat-option>
-            </mat-select>
-          </mat-form-field>
-        </ng-container>
-        <ng-template #noSelect>
-          <mat-form-field floatLabel="never" class="form-control">
-            <input
-              matInput
-              [placeholder]="'segments.global-members-id/name.text' | translate"
-              formControlName="id"
-            />
-          </mat-form-field>
-        </ng-template>
-        </mat-cell>
-      </ng-container>
-      <!-- Members Remove Column -->
-      <ng-container matColumnDef="removeMember">
-        <mat-header-cell class="ft-14-700" *matHeaderCellDef></mat-header-cell>
-        <mat-cell
-          style="justify-content: flex-end;"
-          *matCellDef="let element; let groupIndex = index"
-          [formGroupName]="groupIndex"
-        >
-          <mat-icon
-            class="remove-icon"
-            (click)="removeMember1(groupIndex)"
-          >
-            delete_outline
-          </mat-icon>
-        </mat-cell>
-      </ng-container>
-      <mat-header-row *matHeaderRowDef="membersDisplayedColumns; sticky: true"></mat-header-row>
-      <mat-row *matRowDef="let row; columns: membersDisplayedColumns"></mat-row>
-    </mat-table>
-    <span
-      class="ft-14-600 validation-message"
-      *ngIf="membersCountError"
-      [innerHTML]="membersCountError"
-    ></span>
-    <button
-      type="button"
-      class="ft-12-700 add-member"
-      (click)="addMember1()"
-    >
-      + {{ 'segments.members-add-members.text' | translate }}
-    </button>
-    <br>
-  </div>
-</form>
-<br>
-<br>
-<form class="experiment-participants" [formGroup]="participantsForm2">
-  <div class="property-container">
-    <ng-container *ngIf="inclusionCriterisAsIncludeSpecific">
-    <span class="title"> {{ 'segments.except.text' | translate }} </span>
-    <mat-table
-      class="member-table"
-      [dataSource]="members2DataSource"
-      formArrayName="members2"
-      #membersExceptTable
-    >
-      <!-- Members NUMBER Column -->
-      <ng-container matColumnDef="memberNumber">
-        <mat-header-cell class="ft-14-700" *matHeaderCellDef>
-          {{ 'global.number.text' | translate }}
-        </mat-header-cell>
-        <mat-cell *matCellDef="let element; let groupIndex = index">
-          <span>{{ groupIndex + 1 }}</span>
-        </mat-cell>
-      </ng-container>
+<div class="modal-step-container">
 
-      <!-- Members Type Column -->
-      <ng-container matColumnDef="type">
-        <mat-header-cell class="ft-14-700" *matHeaderCellDef>
-          {{ 'segments.global-members-type.text' | translate }}
-        </mat-header-cell>
-        <mat-cell
-          *matCellDef="let element; let groupIndex = index"
-          [formGroupName]="groupIndex"
-        >
-        <mat-form-field floatLabel="never" class="form-control">
-          <mat-label>{{ 'segments.members-placeholder-type.text' | translate }}</mat-label>
-          <mat-select formControlName="type">
-            <mat-optgroup
-              *ngFor="let type of subSegmentTypes"
-              [class.hideLabel]="type.heading == ''"
-              [disabled]="type.disabled"
-              [label]="type.heading"
+  <section class="modal-form-container">
+    <form class="experiment-participants" [formGroup]="participantsForm">
+      <!-- Table -->
+      <div class="property-container">
+        <mat-form-field class="ft-14-600 inclusion-criteria">
+          <mat-label>{{ 'home-global.inclusion-criteria.text' | translate }}</mat-label>
+          <mat-select class="ft-14-400" formControlName="inclusionCriteria">
+            <mat-option
+              *ngFor="let criteria of inclusionCriteria"
+              [value]="criteria.value"
             >
-              <mat-option *ngFor="let val of type.value" [value]="val">
-                {{ val }}
-              </mat-option>
-            </mat-optgroup>
+              {{ criteria.value | titlecase }}
+            </mat-option>
           </mat-select>
         </mat-form-field>
-        </mat-cell>
-      </ng-container>
-      <!-- Members Id Column -->
-      <ng-container matColumnDef="id">
-        <mat-header-cell class="ft-14-700" *matHeaderCellDef>
-          {{ 'segments.global-members-id/name.text' | translate }}
-        </mat-header-cell>
-        <mat-cell
-          *matCellDef="let element; let groupIndex = index"
-          [formGroupName]="groupIndex"
+        <br>
+        <span class="title"> {{ 'segments.include.text' | translate }} </span>
+        <mat-table
+          class="member-table"
+          [dataSource]="members1DataSource"
+          formArrayName="members1"
+          #membersTable
         >
-        <ng-container *ngIf="participantsForm2.getRawValue('type')?.members2[groupIndex]?.type === 'Segment'; else noSelect">
-          <mat-form-field floatLabel="never" class="form-control">
-            <mat-select formControlName="id">
-              <mat-option *ngFor="let subSegmentId of subSegmentIds" [value]="subSegmentId">
-                {{ subSegmentId }}
-              </mat-option>
-            </mat-select>
-          </mat-form-field>
-        </ng-container>
-        <ng-template #noSelect>
-          <mat-form-field floatLabel="never" class="form-control">
-            <input
-              matInput
-              [placeholder]="'segments.global-members-id/name.text' | translate"
-              formControlName="id"
-            />
-          </mat-form-field>
-        </ng-template>
-        </mat-cell>
-      </ng-container>
-      <!-- Members Remove Column -->
-      <ng-container matColumnDef="removeMember">
-        <mat-header-cell class="ft-14-700" *matHeaderCellDef></mat-header-cell>
-        <mat-cell
-          style="justify-content: flex-end;"
-          *matCellDef="let element; let groupIndex = index"
-          [formGroupName]="groupIndex"
-        >
-          <mat-icon
-            class="remove-icon"
-            (click)="removeMember2(groupIndex)"
-          >
-            delete_outline
-          </mat-icon>
-        </mat-cell>
-      </ng-container>
-      <mat-header-row *matHeaderRowDef="membersDisplayedColumns; sticky: true"></mat-header-row>
-      <mat-row *matRowDef="let row; columns: membersDisplayedColumns"></mat-row>
-    </mat-table>
-    <span
-      class="ft-14-600 validation-message"
-      *ngIf="membersCountError"
-      [innerHTML]="membersCountError"
-    ></span>
-    <button
-      type="button"
-      class="ft-12-700 add-member"
-      (click)="addMember2()"
-    >
-      + {{ 'segments.members-add-members.text' | translate }}
-    </button>
-    </ng-container>
-    <br>
-    <div class="button-container">
-      <button
-        matStepperPrevious
-        mat-raised-button
-        class="modal-btn btn-back default-button"
-      >
-        {{ 'global.back.text' | translate }}
-      </button>
-      <div>
+          <!-- Members Type Column -->
+          <ng-container matColumnDef="type">
+            <mat-header-cell class="ft-14-700" *matHeaderCellDef>
+              {{ 'segments.global-members-type.text' | translate }}
+            </mat-header-cell>
+            <mat-cell
+              *matCellDef="let element; let groupIndex = index"
+              [formGroupName]="groupIndex"
+            >
+            <mat-form-field floatLabel="never" class="form-control">
+              <mat-label>{{ 'segments.members-placeholder-type.text' | translate }}</mat-label>
+              <mat-select formControlName="type">
+                <mat-optgroup
+                  *ngFor="let type of subSegmentTypes"
+                  [class.hideLabel]="type.heading == ''"
+                  [disabled]="type.disabled"
+                  [label]="type.heading"
+                >
+                  <mat-option *ngFor="let val of type.value" [value]="val">
+                    {{ val }}
+                  </mat-option>
+                </mat-optgroup>
+              </mat-select>
+            </mat-form-field>
+            </mat-cell>
+          </ng-container>
+          <!-- Members Id Column -->
+          <ng-container matColumnDef="id">
+            <mat-header-cell class="ft-14-700" *matHeaderCellDef>
+              {{ 'segments.global-members-id/name.text' | translate }}
+            </mat-header-cell>
+            <mat-cell
+              *matCellDef="let element; let groupIndex = index"
+              [formGroupName]="groupIndex"
+            >
+            <ng-container *ngIf="participantsForm.getRawValue('type')?.members1[groupIndex]?.type === 'Segment'; else noSelect">
+              <mat-form-field floatLabel="never" class="form-control">
+                <mat-select formControlName="id">
+                  <mat-option *ngFor="let subSegmentId of subSegmentIds" [value]="subSegmentId">
+                    {{ subSegmentId }}
+                  </mat-option>
+                </mat-select>
+              </mat-form-field>
+            </ng-container>
+            <ng-template #noSelect>
+              <mat-form-field floatLabel="never" class="form-control">
+                <input
+                  matInput
+                  [placeholder]="'segments.global-members-id/name.text' | translate"
+                  formControlName="id"
+                />
+              </mat-form-field>
+            </ng-template>
+            </mat-cell>
+          </ng-container>
+          <!-- Members Remove Column -->
+          <ng-container matColumnDef="removeMember">
+            <mat-header-cell class="ft-14-700" *matHeaderCellDef></mat-header-cell>
+            <mat-cell
+              style="justify-content: flex-end;"
+              *matCellDef="let element; let groupIndex = index"
+              [formGroupName]="groupIndex"
+            >
+              <mat-icon
+                class="remove-icon"
+                (click)="removeMember1(groupIndex)"
+              >
+                delete_outline
+              </mat-icon>
+            </mat-cell>
+          </ng-container>
+          <mat-header-row *matHeaderRowDef="membersDisplayedColumns; sticky: true"></mat-header-row>
+          <mat-row *matRowDef="let row; columns: membersDisplayedColumns"></mat-row>
+        </mat-table>
+        <span
+          class="ft-14-600 validation-message"
+          *ngIf="membersCountError"
+          [innerHTML]="membersCountError"
+        ></span>
         <button
           type="button"
-          mat-raised-button
-          class="modal-btn"
-          (click)="emitEvent(NewExperimentDialogEvents.CLOSE_DIALOG)"
+          class="ft-12-700 add-member"
+          (click)="addMember1()"
         >
-          {{ 'global.cancel.text' | translate }}
+          + {{ 'segments.members-add-members.text' | translate }}
         </button>
-        <button
-          type="button"
-          mat-raised-button
-          class="modal-btn default-button"
-          (click)="emitEvent(NewExperimentDialogEvents.SEND_FORM_DATA)"
-        >
-          {{ 'global.next.text' | translate }}
-        </button>
-        <button
-          type="button"
-          *ngIf="experimentInfo && enableSave"
-          mat-raised-button
-          class="modal-btn default-button"
-          (click)="emitEvent(NewExperimentDialogEvents.SAVE_DATA)"
-        >
-          {{ 'global.update.text' | translate }}
-        </button>
+        <br>
       </div>
+    </form>
+    <br>
+    <br>
+    <form class="experiment-participants" [formGroup]="participantsForm2">
+      <div class="property-container">
+        <ng-container *ngIf="inclusionCriterisAsIncludeSpecific">
+        <span class="title"> {{ 'segments.except.text' | translate }} </span>
+        <mat-table
+          class="member-table"
+          [dataSource]="members2DataSource"
+          formArrayName="members2"
+          #membersExceptTable
+        >
+          <!-- Members NUMBER Column -->
+          <ng-container matColumnDef="memberNumber">
+            <mat-header-cell class="ft-14-700" *matHeaderCellDef>
+              {{ 'global.number.text' | translate }}
+            </mat-header-cell>
+            <mat-cell *matCellDef="let element; let groupIndex = index">
+              <span>{{ groupIndex + 1 }}</span>
+            </mat-cell>
+          </ng-container>
+
+          <!-- Members Type Column -->
+          <ng-container matColumnDef="type">
+            <mat-header-cell class="ft-14-700" *matHeaderCellDef>
+              {{ 'segments.global-members-type.text' | translate }}
+            </mat-header-cell>
+            <mat-cell
+              *matCellDef="let element; let groupIndex = index"
+              [formGroupName]="groupIndex"
+            >
+            <mat-form-field floatLabel="never" class="form-control">
+              <mat-label>{{ 'segments.members-placeholder-type.text' | translate }}</mat-label>
+              <mat-select formControlName="type">
+                <mat-optgroup
+                  *ngFor="let type of subSegmentTypes"
+                  [class.hideLabel]="type.heading == ''"
+                  [disabled]="type.disabled"
+                  [label]="type.heading"
+                >
+                  <mat-option *ngFor="let val of type.value" [value]="val">
+                    {{ val }}
+                  </mat-option>
+                </mat-optgroup>
+              </mat-select>
+            </mat-form-field>
+            </mat-cell>
+          </ng-container>
+          <!-- Members Id Column -->
+          <ng-container matColumnDef="id">
+            <mat-header-cell class="ft-14-700" *matHeaderCellDef>
+              {{ 'segments.global-members-id/name.text' | translate }}
+            </mat-header-cell>
+            <mat-cell
+              *matCellDef="let element; let groupIndex = index"
+              [formGroupName]="groupIndex"
+            >
+            <ng-container *ngIf="participantsForm2.getRawValue('type')?.members2[groupIndex]?.type === 'Segment'; else noSelect">
+              <mat-form-field floatLabel="never" class="form-control">
+                <mat-select formControlName="id">
+                  <mat-option *ngFor="let subSegmentId of subSegmentIds" [value]="subSegmentId">
+                    {{ subSegmentId }}
+                  </mat-option>
+                </mat-select>
+              </mat-form-field>
+            </ng-container>
+            <ng-template #noSelect>
+              <mat-form-field floatLabel="never" class="form-control">
+                <input
+                  matInput
+                  [placeholder]="'segments.global-members-id/name.text' | translate"
+                  formControlName="id"
+                />
+              </mat-form-field>
+            </ng-template>
+            </mat-cell>
+          </ng-container>
+          <!-- Members Remove Column -->
+          <ng-container matColumnDef="removeMember">
+            <mat-header-cell class="ft-14-700" *matHeaderCellDef></mat-header-cell>
+            <mat-cell
+              style="justify-content: flex-end;"
+              *matCellDef="let element; let groupIndex = index"
+              [formGroupName]="groupIndex"
+            >
+              <mat-icon
+                class="remove-icon"
+                (click)="removeMember2(groupIndex)"
+              >
+                delete_outline
+              </mat-icon>
+            </mat-cell>
+          </ng-container>
+          <mat-header-row *matHeaderRowDef="membersDisplayedColumns; sticky: true"></mat-header-row>
+          <mat-row *matRowDef="let row; columns: membersDisplayedColumns"></mat-row>
+        </mat-table>
+        <span
+          class="ft-14-600 validation-message"
+          *ngIf="membersCountError"
+          [innerHTML]="membersCountError"
+        ></span>
+        <button
+          type="button"
+          class="ft-12-700 add-member"
+          (click)="addMember2()"
+        >
+          + {{ 'segments.members-add-members.text' | translate }}
+        </button>
+        </ng-container>
+        <!-- <br> -->
+
+      </div>
+    </form>
+  </section>
+
+  <section class="modal-buttons-container">
+    <button
+      matStepperPrevious
+      mat-raised-button
+      class="modal-btn btn-back default-button"
+    >
+      {{ 'global.back.text' | translate }}
+    </button>
+    <div>
+      <button
+        type="button"
+        mat-raised-button
+        class="modal-btn"
+        (click)="emitEvent(NewExperimentDialogEvents.CLOSE_DIALOG)"
+      >
+        {{ 'global.cancel.text' | translate }}
+      </button>
+      <button
+        type="button"
+        mat-raised-button
+        class="modal-btn default-button"
+        (click)="emitEvent(NewExperimentDialogEvents.SEND_FORM_DATA)"
+      >
+        {{ 'global.next.text' | translate }}
+      </button>
+      <button
+        type="button"
+        *ngIf="experimentInfo && enableSave"
+        mat-raised-button
+        class="modal-btn default-button"
+        (click)="emitEvent(NewExperimentDialogEvents.SAVE_DATA)"
+      >
+        {{ 'global.update.text' | translate }}
+      </button>
     </div>
-  </div>
-</form>
+  </section>
+</div>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-participants/experiment-participants.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-participants/experiment-participants.component.html
@@ -1,6 +1,5 @@
-<div class="modal-step-container">
-
-  <section class="modal-form-container">
+<div class="shared-modal--step-container">
+  <section class="shared-modal--form-container">
     <form class="experiment-participants" [formGroup]="participantsForm">
       <!-- Table -->
       <div class="property-container">
@@ -227,19 +226,21 @@
     </form>
   </section>
 
-  <section class="modal-buttons-container">
-    <button
-      matStepperPrevious
-      mat-raised-button
-      class="modal-btn btn-back default-button"
-    >
-      {{ 'global.back.text' | translate }}
-    </button>
-    <div>
+  <section class="shared-modal--buttons-container">
+    <span class="shared-modal--buttons-left">
+      <button
+        matStepperPrevious
+        mat-raised-button
+        class="shared-modal--modal-btn btn-back default-button"
+      >
+        {{ 'global.back.text' | translate }}
+      </button>
+    </span>
+    <span class="shared-modal--buttons-right">
       <button
         type="button"
         mat-raised-button
-        class="modal-btn"
+        class="shared-modal--modal-btn"
         (click)="emitEvent(NewExperimentDialogEvents.CLOSE_DIALOG)"
       >
         {{ 'global.cancel.text' | translate }}
@@ -247,7 +248,7 @@
       <button
         type="button"
         mat-raised-button
-        class="modal-btn default-button"
+        class="shared-modal--modal-btn default-button"
         (click)="emitEvent(NewExperimentDialogEvents.SEND_FORM_DATA)"
       >
         {{ 'global.next.text' | translate }}
@@ -256,11 +257,11 @@
         type="button"
         *ngIf="experimentInfo && enableSave"
         mat-raised-button
-        class="modal-btn default-button"
+        class="shared-modal--modal-btn default-button"
         (click)="emitEvent(NewExperimentDialogEvents.SAVE_DATA)"
       >
         {{ 'global.update.text' | translate }}
       </button>
-    </div>
+    </span>
   </section>
 </div>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-participants/experiment-participants.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-participants/experiment-participants.component.scss
@@ -2,13 +2,6 @@
   display: none;
 }
 
-.modal-step-container {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  height: 575px;
-}
-
 .experiment-participants {
   display: flex;
   flex-direction: column;
@@ -98,16 +91,5 @@
 
   ::ng-deep .mat-form-field-label {
     color: var(--grey-6);
-  }
-}
-
-.modal-buttons-container {
-  display: flex;
-  justify-content: space-between;
-  flex-direction: row;
-  margin-top: 15px;
-
-  .btn-back {
-    margin-left: 0 !important;
   }
 }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-participants/experiment-participants.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-participants/experiment-participants.component.scss
@@ -2,6 +2,13 @@
   display: none;
 }
 
+.modal-step-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 575px;
+}
+
 .experiment-participants {
   display: flex;
   flex-direction: column;
@@ -88,17 +95,19 @@
     margin-top: 30px;
   }
 
-  .button-container {
-    display: flex;
-    justify-content: space-between;
-    margin-top: 15px;
-
-    .btn-back {
-      margin-left: 0 !important;
-    }
-  }
 
   ::ng-deep .mat-form-field-label {
     color: var(--grey-6);
+  }
+}
+
+.modal-buttons-container {
+  display: flex;
+  justify-content: space-between;
+  flex-direction: row;
+  margin-top: 15px;
+
+  .btn-back {
+    margin-left: 0 !important;
   }
 }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-post-condition/experiment-post-condition.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-post-condition/experiment-post-condition.component.html
@@ -1,57 +1,61 @@
-<form
-  [formGroup]="postExperimentRuleForm"
-  class="post-experiment-rule-form"
->
-  <mat-form-field class="ft-14-600">
-    <mat-label>{{ 'home-global.post-experiment-rule.text' | translate }}</mat-label>
-    <mat-select class="ft-14-600" formControlName="postExperimentRule">
-      <mat-option
-        *ngFor="let rule of postExperimentRules"
-        [value]="rule.value"
-      >
-        {{ rule.value | titlecase }}
-      </mat-option>
-    </mat-select>
-  </mat-form-field>
-
-  <mat-form-field class="ft-14-600">
-    <mat-label>{{ 'global.condition.text' | translate }}</mat-label>
-    <mat-select class="ft-14-600" formControlName="revertTo">
-      <mat-option
-        *ngFor="let condition of experimentConditions"
-        [value]="condition.id"
-      >
-        {{ condition.value }}
-      </mat-option>
-    </mat-select>
-  </mat-form-field>
-</form>
-
-<div class="button-container">
-  <button
-    matStepperPrevious
-    mat-raised-button
-    class="modal-btn btn-back default-button"
-  >
-    {{ 'global.back.text' | translate }}
-  </button>
-  <div>
-    <button
-      mat-raised-button
-      class="modal-btn"
-      (click)="emitEvent(NewExperimentDialogEvents.CLOSE_DIALOG)"
+<div class="modal-step-container">
+  <section class="modal-form-container">
+    <form
+      [formGroup]="postExperimentRuleForm"
+      class="post-experiment-rule-form"
     >
-      {{ 'global.cancel.text' | translate }}
-    </button>
+      <mat-form-field class="ft-14-600">
+        <mat-label>{{ 'home-global.post-experiment-rule.text' | translate }}</mat-label>
+        <mat-select class="ft-14-600" formControlName="postExperimentRule">
+          <mat-option
+            *ngFor="let rule of postExperimentRules"
+            [value]="rule.value"
+          >
+            {{ rule.value | titlecase }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+    
+      <mat-form-field class="ft-14-600">
+        <mat-label>{{ 'global.condition.text' | translate }}</mat-label>
+        <mat-select class="ft-14-600" formControlName="revertTo">
+          <mat-option
+            *ngFor="let condition of experimentConditions"
+            [value]="condition.id"
+          >
+            {{ condition.value }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+    </form>
+  </section>
+  
+  <section class="modal-buttons-container">
     <button
-      matStepperNext
+      matStepperPrevious
       mat-raised-button
-      class="modal-btn default-button"
-      [ngClass]="{'default-button--disabled': !this.postExperimentRuleForm.valid}"
-      [disabled]="!this.postExperimentRuleForm.valid"
-      (click)="emitEvent(NewExperimentDialogEvents.SEND_FORM_DATA)"
+      class="modal-btn btn-back default-button"
     >
-      {{ experimentInfo ? ('global.update.text' | translate) : ('global.create.text' | translate) }}
+      {{ 'global.back.text' | translate }}
     </button>
-  </div>
+    <div>
+      <button
+        mat-raised-button
+        class="modal-btn"
+        (click)="emitEvent(NewExperimentDialogEvents.CLOSE_DIALOG)"
+      >
+        {{ 'global.cancel.text' | translate }}
+      </button>
+      <button
+        matStepperNext
+        mat-raised-button
+        class="modal-btn default-button"
+        [ngClass]="{'default-button--disabled': !this.postExperimentRuleForm.valid}"
+        [disabled]="!this.postExperimentRuleForm.valid"
+        (click)="emitEvent(NewExperimentDialogEvents.SEND_FORM_DATA)"
+      >
+        {{ experimentInfo ? ('global.update.text' | translate) : ('global.create.text' | translate) }}
+      </button>
+    </div>
+  </section>
 </div>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-post-condition/experiment-post-condition.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-post-condition/experiment-post-condition.component.html
@@ -1,5 +1,5 @@
-<div class="modal-step-container">
-  <section class="modal-form-container">
+<div class="shared-modal--step-container">
+  <section class="shared-modal--form-container">
     <form
       [formGroup]="postExperimentRuleForm"
       class="post-experiment-rule-form"
@@ -30,18 +30,20 @@
     </form>
   </section>
   
-  <section class="modal-buttons-container">
-    <button
-      matStepperPrevious
-      mat-raised-button
-      class="modal-btn btn-back default-button"
-    >
-      {{ 'global.back.text' | translate }}
-    </button>
-    <div>
+  <section class="shared-modal--buttons-container">
+    <span class="shared-modal--buttons-left">
+      <button
+        matStepperPrevious
+        mat-raised-button
+        class="shared-modal--modal-btn btn-back default-button"
+      >
+        {{ 'global.back.text' | translate }}
+      </button>
+    </span>
+    <span class="shared-modal--buttons-right">
       <button
         mat-raised-button
-        class="modal-btn"
+        class="shared-modal--modal-btn"
         (click)="emitEvent(NewExperimentDialogEvents.CLOSE_DIALOG)"
       >
         {{ 'global.cancel.text' | translate }}
@@ -49,13 +51,13 @@
       <button
         matStepperNext
         mat-raised-button
-        class="modal-btn default-button"
+        class="shared-modal--modal-btn default-button"
         [ngClass]="{'default-button--disabled': !this.postExperimentRuleForm.valid}"
         [disabled]="!this.postExperimentRuleForm.valid"
         (click)="emitEvent(NewExperimentDialogEvents.SEND_FORM_DATA)"
       >
         {{ experimentInfo ? ('global.update.text' | translate) : ('global.create.text' | translate) }}
       </button>
-    </div>
+    </span>
   </section>
 </div>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-post-condition/experiment-post-condition.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-post-condition/experiment-post-condition.component.scss
@@ -1,3 +1,10 @@
+.modal-step-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 575px;
+}
+
 .post-experiment-rule-form {
   display: flex;
   justify-content: space-between;
@@ -9,7 +16,7 @@
   }
 }
 
-.button-container {
+.modal-buttons-container {
   display: flex;
   justify-content: space-between;
   margin-top: 15px;

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-post-condition/experiment-post-condition.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-post-condition/experiment-post-condition.component.scss
@@ -1,10 +1,3 @@
-.modal-step-container {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  height: 575px;
-}
-
 .post-experiment-rule-form {
   display: flex;
   justify-content: space-between;
@@ -13,15 +6,5 @@
   mat-form-field {
     width: 45%;
     color: var(--grey-6);
-  }
-}
-
-.modal-buttons-container {
-  display: flex;
-  justify-content: space-between;
-  margin-top: 15px;
-
-  .btn-back {
-    margin-left: 0 !important;
   }
 }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-schedule/experiment-schedule.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-schedule/experiment-schedule.component.html
@@ -1,6 +1,5 @@
-<div class="modal-step-container">
-
-  <section class="modal-form-container">
+<div class="shared-modal--step-container">
+  <section class="shared-modal--form-container">
     <form class="experiment-schedule-form" [formGroup]="experimentScheduleForm">
 
       <mat-checkbox
@@ -131,25 +130,27 @@
     ></span>
   </section>
 
-  <section class="modal-buttons-container">
-    <button
-      matStepperPrevious
-      mat-raised-button
-      class="modal-btn btn-back default-button"
-    >
-      {{ 'global.back.text' | translate }}
-    </button>
-    <div>
+  <section class="shared-modal--buttons-container">
+    <span class="shared-modal--buttons-left">
+      <button
+        matStepperPrevious
+        mat-raised-button
+        class="shared-modal--modal-btn btn-back default-button"
+      >
+        {{ 'global.back.text' | translate }}
+      </button>
+    </span>
+    <span class="shared-modal--buttons-right">
       <button
         mat-raised-button
-        class="modal-btn"
+        class="shared-modal--modal-btn"
         (click)="emitEvent(NewExperimentDialogEvents.CLOSE_DIALOG)"
       >
         {{ 'global.cancel.text' | translate }}
       </button>
       <button
         mat-raised-button
-        class="modal-btn default-button"
+        class="shared-modal--modal-btn default-button"
         (click)="emitEvent(NewExperimentDialogEvents.SEND_FORM_DATA)"
       >
         {{ 'global.next.text' | translate }}
@@ -157,14 +158,13 @@
       <button
         *ngIf="experimentInfo" 
         mat-raised-button
-        class="modal-btn default-button"
+        class="shared-modal--modal-btn default-button"
         [ngClass]="{ 'default-button--disabled': experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE }"
         [disabled]= "experimentInfo && experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE"
         (click)="emitEvent(NewExperimentDialogEvents.SAVE_DATA)"
       >
         {{ 'global.update.text' | translate }}
       </button>
-    </div>
+    </span>
   </section>
-
 </div>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-schedule/experiment-schedule.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-schedule/experiment-schedule.component.html
@@ -1,134 +1,137 @@
-<div class="experiment-schedule-container">
-  <form class="experiment-schedule-form" [formGroup]="experimentScheduleForm">
+<div class="modal-step-container">
 
-    <mat-checkbox
-      class="ft-14-700"
-      color="primary"
-      [disabled]= "experimentInfo && (experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE)"
-      formControlName="startExperimentAutomatically"
-    >
-      {{ 'home.new-experiment.schedule.start-automatically.text' | translate }}
-    </mat-checkbox>
+  <section class="modal-form-container">
+    <form class="experiment-schedule-form" [formGroup]="experimentScheduleForm">
 
-    <div class="date-picker-container">
-      <mat-label
-        class="ft-14-600 starts-on-title"
-        [ngClass]="{'starts-on-title--disable': !experimentScheduleForm.get('startExperimentAutomatically').value}"
+      <mat-checkbox
+        class="ft-14-700"
+        color="primary"
+        [disabled]= "experimentInfo && (experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE)"
+        formControlName="startExperimentAutomatically"
       >
-        {{ 'home.new-experiment.schedule.start-on.text' | translate }}
-      </mat-label>
-      <mat-form-field class="ft-14-700">
-        <input
-          matInput
-          readonly
-          class="input"
-          [min]="minDate"
-          [owlDateTimeTrigger]="startDateTime" [owlDateTime]="startDateTime"
-          [placeholder]="'home.new-experiment.schedule.date-picker.placeholder.text' | translate"
-          formControlName="dateOfExperimentStart"
-        >
-        <owl-date-time #startDateTime></owl-date-time>
-      </mat-form-field>
-    </div>
+        {{ 'home.new-experiment.schedule.start-automatically.text' | translate }}
+      </mat-checkbox>
 
-    <mat-checkbox class="ft-14-700" color="primary" formControlName="endExperimentAutomatically"
-    [disabled]= "experimentInfo && experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE"
-    >
-      {{ 'home.new-experiment.schedule.end-automatically.text' | translate }}
-    </mat-checkbox>
-
-    <mat-radio-group formControlName="endCondition">
       <div class="date-picker-container">
-        <mat-radio-button class="ft-14-600" [value]="EndExperimentCondition.END_ON_DATE" color="primary"
-        [disabled]= "experimentInfo && experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE"
+        <mat-label
+          class="ft-14-600 starts-on-title"
+          [ngClass]="{'starts-on-title--disable': !experimentScheduleForm.get('startExperimentAutomatically').value}"
         >
-          {{ 'home.new-experiment.schedule.end-on.text' | translate }}
-        </mat-radio-button>
+          {{ 'home.new-experiment.schedule.start-on.text' | translate }}
+        </mat-label>
         <mat-form-field class="ft-14-700">
-            <input
-              matInput
-              readonly
-              class="input"
-              [min]="minDate"
-              [owlDateTimeTrigger]="dateTime" [owlDateTime]="dateTime"
-              [placeholder]="'home.new-experiment.schedule.date-picker.placeholder.text' | translate"
-              formControlName="dateOfExperimentEnd"
-            >
-            <owl-date-time #dateTime></owl-date-time>
+          <input
+            matInput
+            readonly
+            class="input"
+            [min]="minDate"
+            [owlDateTimeTrigger]="startDateTime" [owlDateTime]="startDateTime"
+            [placeholder]="'home.new-experiment.schedule.date-picker.placeholder.text' | translate"
+            formControlName="dateOfExperimentStart"
+          >
+          <owl-date-time #startDateTime></owl-date-time>
         </mat-form-field>
       </div>
 
-      <div class="experiment-end-criteria">
-        <mat-radio-button class="ft-14-600" [value]="EndExperimentCondition.END_CRITERIA" color="primary"
-        [disabled]= "experimentInfo && experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE"
-        >
-          {{ 'home.new-experiment.schedule.end-criteria.text' | translate }}
-        </mat-radio-button>
-        <div class="end-criteria" *ngIf="groupType">
-          <mat-form-field class="ft-12-700 group-type-control">
-            <input
-              type="number"
-              matInput
-              class="input"
-              [placeholder]="('home.new-experiment.schedule.group-count.placeholder.text' | translate) + (' ') + ('global.group-type-plural.text' | translate: { groupType: groupType })"
-              formControlName="groupCount"
-            />
-          </mat-form-field>
-          <span
-            class="ft-14-400 group-type"
-            [innerHTML]="('global.group-type-plural.text' | translate: { groupType: groupType }) + (' ') + ('home.new-experiment.schedule.group-count.text' | translate)"
-            [ngClass]="{'group-type--disable': !groupTypeValue}"
-          ></span>
-        </div>
-        <div class="end-criteria">
-          <mat-form-field class="ft-12-700">
-            <input
-              type="number"
-              matInput
-              class="input"
-              [placeholder]="'home.new-experiment.schedule.user-count.placeholder.text' | translate"
-              formControlName="userCount"
-            />
-          </mat-form-field>
-          <span
-            class="ft-14-400 group-type"
-            [innerHTML]="!!experimentScheduleForm.get('groupCount').value && groupType
-              ? ('home.new-experiment.schedule.user-count-per-group.title.text' | translate: { groupType: groupType })
-              : ('home.new-experiment.schedule.user-count.title.text' | translate)"
-            [ngClass]="{'group-type--disable': !groupTypeValue}"
-          ></span>
-        </div>
-      </div>
+      <mat-checkbox class="ft-14-700" color="primary" formControlName="endExperimentAutomatically"
+      [disabled]= "experimentInfo && experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE"
+      >
+        {{ 'home.new-experiment.schedule.end-automatically.text' | translate }}
+      </mat-checkbox>
 
-    </mat-radio-group>
-  </form>
-  <span
-    class="ft-14-600 validation-message"
-    *ngIf="experimentScheduleForm.errors?.dateOfExperimentEndError"
-    [innerHTML]="'home.new-experiment.schedule-end-date-and-time-error.text' | translate"
-  ></span>
-  <span
-    class="ft-14-600 validation-message"
-    *ngIf="experimentScheduleForm.errors?.endCriteriaError"
-    [innerHTML]="'home.new-experiment.schedule-end-criteria-error.text' | translate"
-  ></span>
-  <span
-    class="ft-14-600 validation-message"
-    *ngIf="experimentScheduleForm.errors?.selectionError"
-    [innerHTML]="'home.new-experiment.schedule-selection-error.text' | translate"
-  ></span>
-  <span
-    class="ft-14-600 validation-message"
-    *ngIf="experimentScheduleForm.errors?.startOnSelectionError"
-    [innerHTML]="'home.new-experiment.schedule-start-date-and-time-error.text' | translate"
-  ></span>
-  <span
-    class="ft-14-600 validation-message"
-    *ngIf="experimentScheduleForm.errors?.wrongDateSelectionError"
-    [innerHTML]="'home.new-experiment.schedule-wrong-date-and-time-error.text' | translate"
-  ></span>
+      <mat-radio-group formControlName="endCondition">
+        <div class="date-picker-container">
+          <mat-radio-button class="ft-14-600" [value]="EndExperimentCondition.END_ON_DATE" color="primary"
+          [disabled]= "experimentInfo && experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE"
+          >
+            {{ 'home.new-experiment.schedule.end-on.text' | translate }}
+          </mat-radio-button>
+          <mat-form-field class="ft-14-700">
+              <input
+                matInput
+                readonly
+                class="input"
+                [min]="minDate"
+                [owlDateTimeTrigger]="dateTime" [owlDateTime]="dateTime"
+                [placeholder]="'home.new-experiment.schedule.date-picker.placeholder.text' | translate"
+                formControlName="dateOfExperimentEnd"
+              >
+              <owl-date-time #dateTime></owl-date-time>
+          </mat-form-field>
+        </div>
 
-  <div class="button-container">
+        <div class="experiment-end-criteria">
+          <mat-radio-button class="ft-14-600" [value]="EndExperimentCondition.END_CRITERIA" color="primary"
+          [disabled]= "experimentInfo && experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE"
+          >
+            {{ 'home.new-experiment.schedule.end-criteria.text' | translate }}
+          </mat-radio-button>
+          <div class="end-criteria" *ngIf="groupType">
+            <mat-form-field class="ft-12-700 group-type-control">
+              <input
+                type="number"
+                matInput
+                class="input"
+                [placeholder]="('home.new-experiment.schedule.group-count.placeholder.text' | translate) + (' ') + ('global.group-type-plural.text' | translate: { groupType: groupType })"
+                formControlName="groupCount"
+              />
+            </mat-form-field>
+            <span
+              class="ft-14-400 group-type"
+              [innerHTML]="('global.group-type-plural.text' | translate: { groupType: groupType }) + (' ') + ('home.new-experiment.schedule.group-count.text' | translate)"
+              [ngClass]="{'group-type--disable': !groupTypeValue}"
+            ></span>
+          </div>
+          <div class="end-criteria">
+            <mat-form-field class="ft-12-700">
+              <input
+                type="number"
+                matInput
+                class="input"
+                [placeholder]="'home.new-experiment.schedule.user-count.placeholder.text' | translate"
+                formControlName="userCount"
+              />
+            </mat-form-field>
+            <span
+              class="ft-14-400 group-type"
+              [innerHTML]="!!experimentScheduleForm.get('groupCount').value && groupType
+                ? ('home.new-experiment.schedule.user-count-per-group.title.text' | translate: { groupType: groupType })
+                : ('home.new-experiment.schedule.user-count.title.text' | translate)"
+              [ngClass]="{'group-type--disable': !groupTypeValue}"
+            ></span>
+          </div>
+        </div>
+
+      </mat-radio-group>
+    </form>
+    <span
+      class="ft-14-600 validation-message"
+      *ngIf="experimentScheduleForm.errors?.dateOfExperimentEndError"
+      [innerHTML]="'home.new-experiment.schedule-end-date-and-time-error.text' | translate"
+    ></span>
+    <span
+      class="ft-14-600 validation-message"
+      *ngIf="experimentScheduleForm.errors?.endCriteriaError"
+      [innerHTML]="'home.new-experiment.schedule-end-criteria-error.text' | translate"
+    ></span>
+    <span
+      class="ft-14-600 validation-message"
+      *ngIf="experimentScheduleForm.errors?.selectionError"
+      [innerHTML]="'home.new-experiment.schedule-selection-error.text' | translate"
+    ></span>
+    <span
+      class="ft-14-600 validation-message"
+      *ngIf="experimentScheduleForm.errors?.startOnSelectionError"
+      [innerHTML]="'home.new-experiment.schedule-start-date-and-time-error.text' | translate"
+    ></span>
+    <span
+      class="ft-14-600 validation-message"
+      *ngIf="experimentScheduleForm.errors?.wrongDateSelectionError"
+      [innerHTML]="'home.new-experiment.schedule-wrong-date-and-time-error.text' | translate"
+    ></span>
+  </section>
+
+  <section class="modal-buttons-container">
     <button
       matStepperPrevious
       mat-raised-button
@@ -162,5 +165,6 @@
         {{ 'global.update.text' | translate }}
       </button>
     </div>
-  </div>
+  </section>
+
 </div>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-schedule/experiment-schedule.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-schedule/experiment-schedule.component.scss
@@ -1,67 +1,72 @@
-.experiment-schedule-container {
-  .experiment-schedule-form {
-    mat-checkbox {
-      &.mat-checkbox-checked {
-        color: var(--blue);
-      }
+.modal-step-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 575px;
+}
+
+.experiment-schedule-form {
+  mat-checkbox {
+    &.mat-checkbox-checked {
+      color: var(--blue);
     }
+  }
 
-    .mat-radio-button,
-    .input {
-      font-weight: 600;
+  .mat-radio-button,
+  .input {
+    font-weight: 600;
+  }
+
+  .starts-on-title {
+    &--disable {
+      color: var(--grey-5);
     }
+  }
 
-    .starts-on-title {
-      &--disable {
-        color: var(--grey-5);
-      }
+  .date-picker-container {
+    margin: 0 0 30px 25px;
+
+    mat-form-field {
+      margin-left: 16px;
+      width: 200px;
     }
+  }
 
-    .date-picker-container {
-      margin: 0 0 30px 25px;
+  .experiment-end-criteria {
+    margin-left: 25px;
 
-      mat-form-field {
-        margin-left: 16px;
-        width: 200px;
-      }
-    }
+    .end-criteria {
+      margin-left: 30px;
 
-    .experiment-end-criteria {
-      margin-left: 25px;
-
-      .end-criteria {
+      .group-type {
         margin-left: 30px;
 
-        .group-type {
-          margin-left: 30px;
+        &-control {
+          line-height: 18px;
+        }
 
-          &-control {
-            line-height: 18px;
-          }
-
-          &--disable {
-            color: var(--grey-5);
-          }
+        &--disable {
+          color: var(--grey-5);
         }
       }
     }
   }
+}
 
-  .button-container {
-    display: flex;
-    justify-content: space-between;
-    margin-top: 15px;
+::ng-deep .owl-dt-calendar-table .owl-dt-calendar-cell-selected {
+  background-color: var(--blue);
+}
 
-    .btn-back {
-      margin-left: 0 !important;
-    }
-  }
+::ng-deep .owl-dt-control .owl-dt-control-content {
+  color: var(--blue);
+}
 
-  ::ng-deep .owl-dt-calendar-table .owl-dt-calendar-cell-selected {
-    background-color: var(--blue);
-  }
+.modal-buttons-container {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 15px;
 
-  ::ng-deep .owl-dt-control .owl-dt-control-content {
-    color: var(--blue);
+  .btn-back {
+    margin-left: 0 !important;
   }
 }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-schedule/experiment-schedule.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-schedule/experiment-schedule.component.scss
@@ -1,10 +1,3 @@
-.modal-step-container {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  height: 575px;
-}
-
 .experiment-schedule-form {
   mat-checkbox {
     &.mat-checkbox-checked {
@@ -59,14 +52,4 @@
 
 ::ng-deep .owl-dt-control .owl-dt-control-content {
   color: var(--blue);
-}
-
-.modal-buttons-container {
-  display: flex;
-  justify-content: space-between;
-  margin-top: 15px;
-
-  .btn-back {
-    margin-left: 0 !important;
-  }
 }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.html
@@ -1,187 +1,189 @@
-<ng-container>
-  <form class="metric-design" [formGroup]="queryForm">
-    <span class="title">{{ 'home.new-experiment.metrics.defined-metrics.text' | translate }}</span>
-    <ng-container *ngIf="options?.length; else noAvailableMetricsMessage">
-      <!-- Metric Table -->
-      <ng-container>
-        <mat-table
-          class="metric-table"
-          [dataSource]="metricsDataSource"
-          formArrayName="queries"
-          #metricTable
-        >
-          <!-- Metric Column -->
-          <ng-container matColumnDef="keys">
-            <mat-header-cell class="ft-12-700" *matHeaderCellDef>
-              {{ 'query.metric.text' | translate }}
-            </mat-header-cell>
-            <mat-cell
-              *matCellDef="let element; let groupIndex = index"
-              [formGroupName]="groupIndex"
-            >
-            <ng-container formArrayName="keys">
-              <div class="metric-keys">
-              <mat-form-field  *ngFor="let key of getKeys(groupIndex).controls; let formIndex = index" class="ft-12-600 form-control auto-complete" floatLabel="never">
-                <ng-container [formGroupName]="formIndex">
-                  <input
-                    class = "ft-12-400"
-                    type="text"
-                    matInput
-                    [placeholder]="'Metric'"
-                    formControlName="metricKey"
-                    [matAutocomplete]="auto"
-                    >
-                  <mat-autocomplete
-                    class = "ft-12-400"
-                    (optionSelected)="selectedOption($event, null, null)"
-                    #auto="matAutocomplete"
-                    [displayWith]="displayFn.bind(this)"
-                    panelWidth="fit-content"
-                    >
-                    <mat-option class = "ft-12-400" *ngFor="let option of filteredMetrics$[formIndex] | async" [value]="option">
-                      {{ option.key }}
-                    </mat-option>
-                  </mat-autocomplete>
-                </ng-container>
-              </mat-form-field>
-            </div>
-            </ng-container>
-            </mat-cell>
-          </ng-container>
-          <!-- Statistic Column -->
-          <ng-container matColumnDef="operationType">
-            <mat-header-cell class="ft-12-700" *matHeaderCellDef>
-              {{ 'monitor.statistic.text' | translate }}
-            </mat-header-cell>
-            <mat-cell
-              *matCellDef="let element; let groupIndex = index"
-              [formGroupName]="groupIndex"
-            >
-            <div class="secondary-form" >
-              <!-- statistic -->
-              <mat-form-field class="ft-12-600 form-control" floatLabel="never">
-                <mat-label>{{ 'monitor.statistic.text' | translate | titlecase }}</mat-label>
-                <mat-select class="ft-12-400" formControlName="operationType">
-                  <mat-option
-                    *ngFor="let operation of filteredStatistic$[groupIndex]"
-                    [value]="operation.value"
-                  >
-                    {{ operation.viewValue | titlecase }}
-                  </mat-option>
-                </mat-select>
-              </mat-form-field>
-              <!-- repeated measure -->
-              <mat-form-field class="ft-12-600 form-control" *ngIf="selectedNode[groupIndex] && metricType(firstSelectedNode[groupIndex], groupIndex)" floatLabel="never">
-                <mat-label>{{ 'home.new-experiment.metrics.repeatedmeasure.placeholder.text' | translate | titlecase }}</mat-label>
-                <mat-select class="ft-12-400" formControlName="repeatedMeasure">
-                  <mat-option
-                    *ngFor="let measure of RepeatedMeasure"
-                    [value]="measure"
-                  >
-                    {{ measure | titlecase }}
-                  </mat-option>
-                </mat-select>
-              </mat-form-field>
-              <!-- comparison function -->
-              <mat-form-field class="ft-12-600 form-control" *ngIf="selectedNode[groupIndex] && selectedNode[groupIndex]?.metadata?.type !== IMetricMetadata.CONTINUOUS" floatLabel="never">
-                <mat-label>{{ 'query.form-comparison-function.text' | translate | titlecase }}</mat-label>
-                <mat-select class="ft-12-400" formControlName="compareFn">
-                  <mat-option>{{ 'query.none-option.text' | translate }}</mat-option>
-                  <mat-option
-                    *ngFor="let fn of comparisonFns"
-                    [value]="fn.value"
-                  >
-                    {{ fn.viewValue | titlecase }}
-                  </mat-option>
-                </mat-select>
-              </mat-form-field>
-              <!-- compare value -->
-              <mat-form-field class="ft-12-600 form-control" *ngIf="selectedNode[groupIndex] && selectedNode[groupIndex]?.metadata?.type !== IMetricMetadata.CONTINUOUS" floatLabel="never">
-                <mat-label>{{ 'query.form-compare-value.text' | translate | titlecase }}</mat-label>
-                <mat-select class="ft-12-400" formControlName="compareValue">
-                  <mat-option
-                    *ngFor="let value of selectedNode[groupIndex]?.allowedData"
-                    [value]="value"
-                  >
-                    {{ value | titlecase }}
-                  </mat-option>
-                </mat-select>
-              </mat-form-field>
-            </div>
-            </mat-cell>
-          </ng-container>
-          <!-- Description Column -->
-          <ng-container matColumnDef="queryName">
-            <mat-header-cell class="ft-12-700" *matHeaderCellDef>
-              {{ 'home.new-experiment.metrics.description-header.placeholder.text' | translate }}
-            </mat-header-cell>
-            <mat-cell
-              *matCellDef="let element; let groupIndex = index"
-              [formGroupName]="groupIndex"
-            >
-              <mat-form-field floatLabel="never">
-                <span>
-                  <input
-                    matInput
-                    [placeholder]="'home.new-experiment.metrics.description.placeholder.text'| translate"
-                    formControlName="queryName"
-                  />
-                </span>
-              </mat-form-field>
-            </mat-cell>
-          </ng-container>
+<div class="modal-step-container">
 
-          <ng-container matColumnDef="removeMetric">
-            <mat-header-cell class="ft-12-700" *matHeaderCellDef></mat-header-cell>
-            <mat-cell
-              *matCellDef="let element; let groupIndex = index"
-              [formGroupName]="groupIndex"
-            >
-              <mat-icon
-                class="remove-icon"
-                (click)="removeMetric(groupIndex)"
+  <section class="modal-form-containter">
+    <form class="metric-design" [formGroup]="queryForm">
+      <span class="title">{{ 'home.new-experiment.metrics.defined-metrics.text' | translate }}</span>
+      <ng-container *ngIf="options?.length; else noAvailableMetricsMessage">
+        <!-- Metric Table -->
+        <ng-container>
+          <mat-table
+            class="metric-table"
+            [dataSource]="metricsDataSource"
+            formArrayName="queries"
+            #metricTable
+          >
+            <!-- Metric Column -->
+            <ng-container matColumnDef="keys">
+              <mat-header-cell class="ft-12-700" *matHeaderCellDef>
+                {{ 'query.metric.text' | translate }}
+              </mat-header-cell>
+              <mat-cell
+                *matCellDef="let element; let groupIndex = index"
+                [formGroupName]="groupIndex"
               >
-                delete_outline
-              </mat-icon>
-            </mat-cell>
-          </ng-container>
-
-          <mat-header-row
-            *matHeaderRowDef="metricsDisplayedColumns; sticky: true"
-          ></mat-header-row>
-          <mat-row *matRowDef="let row; columns: metricsDisplayedColumns"></mat-row>
-        </mat-table>
-        
-        <button
-          type="button"
-          class="ft-12-700 add-metric"
-          (click)="addMetrics()"
-        >
-          +
-          {{ 'home.new-experiment.design.add-metric.text' | translate }}
-        </button>
-      </ng-container>
-      <br>
-      <span
-        class="ft-14-600 validation-message"
-        *ngIf="queryNameError.length > 0"
-        [innerHTML]="'home.new-experiment.metrics.description-exist.validation.text' | translate"
-      ></span>
-    </ng-container>
-    <ng-template #noAvailableMetricsMessage>
-      <br>
-      <br>
-      <div class="no-metrics-message-container">
+              <ng-container formArrayName="keys">
+                <div class="metric-keys">
+                <mat-form-field  *ngFor="let key of getKeys(groupIndex).controls; let formIndex = index" class="ft-12-600 form-control auto-complete" floatLabel="never">
+                  <ng-container [formGroupName]="formIndex">
+                    <input
+                      class = "ft-12-400"
+                      type="text"
+                      matInput
+                      [placeholder]="'Metric'"
+                      formControlName="metricKey"
+                      [matAutocomplete]="auto"
+                      >
+                    <mat-autocomplete
+                      class = "ft-12-400"
+                      (optionSelected)="selectedOption($event, null, null)"
+                      #auto="matAutocomplete"
+                      [displayWith]="displayFn.bind(this)"
+                      panelWidth="fit-content"
+                      >
+                      <mat-option class = "ft-12-400" *ngFor="let option of filteredMetrics$[formIndex] | async" [value]="option">
+                        {{ option.key }}
+                      </mat-option>
+                    </mat-autocomplete>
+                  </ng-container>
+                </mat-form-field>
+              </div>
+              </ng-container>
+              </mat-cell>
+            </ng-container>
+            <!-- Statistic Column -->
+            <ng-container matColumnDef="operationType">
+              <mat-header-cell class="ft-12-700" *matHeaderCellDef>
+                {{ 'monitor.statistic.text' | translate }}
+              </mat-header-cell>
+              <mat-cell
+                *matCellDef="let element; let groupIndex = index"
+                [formGroupName]="groupIndex"
+              >
+              <div class="secondary-form" >
+                <!-- statistic -->
+                <mat-form-field class="ft-12-600 form-control" floatLabel="never">
+                  <mat-label>{{ 'monitor.statistic.text' | translate | titlecase }}</mat-label>
+                  <mat-select class="ft-12-400" formControlName="operationType">
+                    <mat-option
+                      *ngFor="let operation of filteredStatistic$[groupIndex]"
+                      [value]="operation.value"
+                    >
+                      {{ operation.viewValue | titlecase }}
+                    </mat-option>
+                  </mat-select>
+                </mat-form-field>
+                <!-- repeated measure -->
+                <mat-form-field class="ft-12-600 form-control" *ngIf="selectedNode[groupIndex] && metricType(firstSelectedNode[groupIndex], groupIndex)" floatLabel="never">
+                  <mat-label>{{ 'home.new-experiment.metrics.repeatedmeasure.placeholder.text' | translate | titlecase }}</mat-label>
+                  <mat-select class="ft-12-400" formControlName="repeatedMeasure">
+                    <mat-option
+                      *ngFor="let measure of RepeatedMeasure"
+                      [value]="measure"
+                    >
+                      {{ measure | titlecase }}
+                    </mat-option>
+                  </mat-select>
+                </mat-form-field>
+                <!-- comparison function -->
+                <mat-form-field class="ft-12-600 form-control" *ngIf="selectedNode[groupIndex] && selectedNode[groupIndex]?.metadata?.type !== IMetricMetadata.CONTINUOUS" floatLabel="never">
+                  <mat-label>{{ 'query.form-comparison-function.text' | translate | titlecase }}</mat-label>
+                  <mat-select class="ft-12-400" formControlName="compareFn">
+                    <mat-option>{{ 'query.none-option.text' | translate }}</mat-option>
+                    <mat-option
+                      *ngFor="let fn of comparisonFns"
+                      [value]="fn.value"
+                    >
+                      {{ fn.viewValue | titlecase }}
+                    </mat-option>
+                  </mat-select>
+                </mat-form-field>
+                <!-- compare value -->
+                <mat-form-field class="ft-12-600 form-control" *ngIf="selectedNode[groupIndex] && selectedNode[groupIndex]?.metadata?.type !== IMetricMetadata.CONTINUOUS" floatLabel="never">
+                  <mat-label>{{ 'query.form-compare-value.text' | translate | titlecase }}</mat-label>
+                  <mat-select class="ft-12-400" formControlName="compareValue">
+                    <mat-option
+                      *ngFor="let value of selectedNode[groupIndex]?.allowedData"
+                      [value]="value"
+                    >
+                      {{ value | titlecase }}
+                    </mat-option>
+                  </mat-select>
+                </mat-form-field>
+              </div>
+              </mat-cell>
+            </ng-container>
+            <!-- Description Column -->
+            <ng-container matColumnDef="queryName">
+              <mat-header-cell class="ft-12-700" *matHeaderCellDef>
+                {{ 'home.new-experiment.metrics.description-header.placeholder.text' | translate }}
+              </mat-header-cell>
+              <mat-cell
+                *matCellDef="let element; let groupIndex = index"
+                [formGroupName]="groupIndex"
+              >
+                <mat-form-field floatLabel="never">
+                  <span>
+                    <input
+                      matInput
+                      [placeholder]="'home.new-experiment.metrics.description.placeholder.text'| translate"
+                      formControlName="queryName"
+                    />
+                  </span>
+                </mat-form-field>
+              </mat-cell>
+            </ng-container>
+  
+            <ng-container matColumnDef="removeMetric">
+              <mat-header-cell class="ft-12-700" *matHeaderCellDef></mat-header-cell>
+              <mat-cell
+                *matCellDef="let element; let groupIndex = index"
+                [formGroupName]="groupIndex"
+              >
+                <mat-icon
+                  class="remove-icon"
+                  (click)="removeMetric(groupIndex)"
+                >
+                  delete_outline
+                </mat-icon>
+              </mat-cell>
+            </ng-container>
+  
+            <mat-header-row
+              *matHeaderRowDef="metricsDisplayedColumns; sticky: true"
+            ></mat-header-row>
+            <mat-row *matRowDef="let row; columns: metricsDisplayedColumns"></mat-row>
+          </mat-table>
+          
+          <button
+            type="button"
+            class="ft-12-700 add-metric"
+            (click)="addMetrics()"
+          >
+            +
+            {{ 'home.new-experiment.design.add-metric.text' | translate }}
+          </button>
+        </ng-container>
+        <br>
         <span
-          class="ft-14-600 no-metrics-message"
-          [innerHTML]="'home.new-experiment.metrics.no-available-metrics.text' | translate"
+          class="ft-14-600 validation-message"
+          *ngIf="queryNameError.length > 0"
+          [innerHTML]="'home.new-experiment.metrics.description-exist.validation.text' | translate"
         ></span>
-      </div>
-    </ng-template>
+      </ng-container>
+      <ng-template #noAvailableMetricsMessage>
+        <br>
+        <br>
+        <div class="no-metrics-message-container">
+          <span
+            class="ft-14-600 no-metrics-message"
+            [innerHTML]="'home.new-experiment.metrics.no-available-metrics.text' | translate"
+          ></span>
+        </div>
+      </ng-template>
+    </form>
+  </section>
 
-    <br>
-    <br>
-    <div class="button-container">
+  <section class="modal-buttons-container">
       <button
         matStepperPrevious
         mat-raised-button
@@ -216,6 +218,5 @@
           {{ 'global.update.text' | translate }}
         </button>
       </div>
-    </div>
-  </form>
-</ng-container>
+  </section>
+</div>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.html
@@ -1,6 +1,5 @@
-<div class="modal-step-container">
-
-  <section class="modal-form-containter">
+<div class="shared-modal--step-container">
+  <section class="shared-modal--form-container">
     <form class="metric-design" [formGroup]="queryForm">
       <span class="title">{{ 'home.new-experiment.metrics.defined-metrics.text' | translate }}</span>
       <ng-container *ngIf="options?.length; else noAvailableMetricsMessage">
@@ -183,40 +182,42 @@
     </form>
   </section>
 
-  <section class="modal-buttons-container">
+  <section class="shared-modal--buttons-container">
+    <span class="shared-modal--buttons-left">
       <button
         matStepperPrevious
         mat-raised-button
-        class="modal-btn btn-back default-button"
+        class="shared-modal--modal-btn btn-back default-button"
       >
         {{ 'global.back.text' | translate }}
       </button>
-      <div>
-        <button
-          type="button"
-          mat-raised-button
-          class="modal-btn"
-          (click)="emitEvent(NewExperimentDialogEvents.CLOSE_DIALOG)"
-        >
-          {{ 'global.cancel.text' | translate }}
-        </button>
-        <button
-          type="button"
-          mat-raised-button
-          class="modal-btn default-button"
-          (click)="emitEvent(NewExperimentDialogEvents.SEND_FORM_DATA)"
-        >
-          {{ 'global.next.text' | translate }}
-        </button>
-        <button
-          type="button"
-          *ngIf="experimentInfo"
-          mat-raised-button
-          class="modal-btn default-button"
-          (click)="emitEvent(NewExperimentDialogEvents.SAVE_DATA)"
-        >
-          {{ 'global.update.text' | translate }}
-        </button>
-      </div>
+    </span>
+    <span class="shared-modal--buttons-right">
+      <button
+        type="button"
+        mat-raised-button
+        class="shared-modal--modal-btn"
+        (click)="emitEvent(NewExperimentDialogEvents.CLOSE_DIALOG)"
+      >
+        {{ 'global.cancel.text' | translate }}
+      </button>
+      <button
+        type="button"
+        mat-raised-button
+        class="shared-modal--modal-btn default-button"
+        (click)="emitEvent(NewExperimentDialogEvents.SEND_FORM_DATA)"
+      >
+        {{ 'global.next.text' | translate }}
+      </button>
+      <button
+        type="button"
+        *ngIf="experimentInfo"
+        mat-raised-button
+        class="shared-modal--modal-btn default-button"
+        (click)="emitEvent(NewExperimentDialogEvents.SAVE_DATA)"
+      >
+        {{ 'global.update.text' | translate }}
+      </button>
+    </span>
   </section>
 </div>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.scss
@@ -1,9 +1,3 @@
-.modal-step-container {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  height: 575px;
-}
 
 .metric-design {
   .metric-table {
@@ -123,14 +117,4 @@
   display: grid;
   margin-left: -80px;
   justify-content: center;
-}
-
-.modal-buttons-container {
-  display: flex;
-  justify-content: space-between;
-  margin-top: 15px;
-
-  .btn-back {
-    margin-left: 0 !important;
-  }
 }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.scss
@@ -1,3 +1,10 @@
+.modal-step-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 575px;
+}
+
 .metric-design {
   .metric-table {
     max-height: 400px;
@@ -96,16 +103,6 @@
     margin-top: 30px;
   }
 
-  .button-container {
-    display: flex;
-    justify-content: space-between;
-    margin-top: 15px;
-
-    .btn-back {
-      margin-left: 0 !important;
-    }
-  }
-
   .title {
     font-size: 20px;
     font-weight: bold;
@@ -126,4 +123,14 @@
   display: grid;
   margin-left: -80px;
   justify-content: center;
+}
+
+.modal-buttons-container {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 15px;
+
+  .btn-back {
+    margin-left: 0 !important;
+  }
 }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/experiment-end-criteria/experiment-end-criteria.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/experiment-end-criteria/experiment-end-criteria.component.html
@@ -96,12 +96,12 @@
   ></span>
 
   <div class="button-container">
-    <button class="modal-btn" mat-raised-button (click)="onCancelClick()">
+    <button class="shared-modal--modal-btn" mat-raised-button (click)="onCancelClick()">
       {{ 'global.cancel.text' | translate }}
     </button>
     <button
       mat-raised-button
-      class="modal-btn default-button"
+      class="shared-modal--modal-btn default-button"
       (click)="updateEndingCriteria()"
     >
       {{ 'global.update.text' | translate }}

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/experiment-status/experiment-status.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/experiment-status/experiment-status.component.html
@@ -48,12 +48,12 @@
   </span>
 
   <div class="button-container">
-    <button class="modal-btn" mat-raised-button (click)="onCancelClick()">
+    <button class="shared-modal--modal-btn" mat-raised-button (click)="onCancelClick()">
       {{ 'global.cancel.text' | translate }}
     </button>
     <button
       mat-raised-button
-      class="modal-btn default-button"
+      class="shared-modal--modal-btn default-button"
       [ngClass]="{ 'default-button--disabled': !this.statusForm.valid || isScheduleDateWrong || showConditionCountErrorMsg }"
       [disabled]="!this.statusForm.valid || isScheduleDateWrong || showConditionCountErrorMsg"
       (click)="changeStatus()"

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/export-experiment/export-experiment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/export-experiment/export-experiment.component.html
@@ -17,12 +17,12 @@
     [innerHTML]="'home.view-experiment.export-warning.text' | translate: { email: emailId }"
   ></span>
   <div class="button-container">
-    <button class="modal-btn" mat-raised-button (click)="onCancelClick()">
+    <button class="shared-modal--modal-btn" mat-raised-button (click)="onCancelClick()">
       {{ 'global.cancel.text' | translate }}
     </button>
     <button
       mat-raised-button
-      class="modal-btn default-button"
+      class="shared-modal--modal-btn default-button"
       (click)="exportExperiment()"
     >
       {{ 'home.view-experiment.export-button.text' | translate }}

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/import-experiment/import-experiment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/import-experiment/import-experiment.component.html
@@ -27,12 +27,12 @@
   </div>
 
   <div class="button-container">
-    <button class="modal-btn" mat-raised-button (click)="onCancelClick()">
+    <button class="shared-modal--modal-btn" mat-raised-button (click)="onCancelClick()">
       {{ 'global.cancel.text' | translate }}
     </button>
     <button
       mat-raised-button
-      class="modal-btn default-button"
+      class="shared-modal--modal-btn default-button"
       [ngClass]="{ 'default-button--disabled': !experimentInfo }"
       [disabled]="!experimentInfo || isDuplicateExperiment"
       (click)="importExperiment()"

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/post-experiment-rule/post-experiment-rule.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/post-experiment-rule/post-experiment-rule.component.html
@@ -32,14 +32,14 @@
   <div class="button-container">
     <button
       mat-raised-button
-      class="modal-btn"
+      class="shared-modal--modal-btn"
       (click)="onCancelClick()"
     >
       {{ 'global.cancel.text' | translate }}
     </button>
     <button
       mat-raised-button
-      class="modal-btn default-button"
+      class="shared-modal--modal-btn default-button"
       [ngClass]="{'default-button--disabled': !this.postExperimentRuleForm.valid}"
       [disabled]="!this.postExperimentRuleForm.valid"
       (click)="changePostExperimentRule()"

--- a/frontend/projects/upgrade/src/app/features/dashboard/profile/components/modals/add-metrics/add-metrics.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/profile/components/modals/add-metrics/add-metrics.component.html
@@ -9,12 +9,12 @@
   </div>
 
   <div class="button-container">
-    <button class="modal-btn" mat-raised-button (click)="onCancelClick()">
+    <button class="shared-modal--modal-btn" mat-raised-button (click)="onCancelClick()">
       {{ 'global.cancel.text' | translate }}
     </button>
     <button
       mat-raised-button
-      class="modal-btn default-button"
+      class="shared-modal--modal-btn default-button"
       [ngClass]="{ 'default-button--disabled': metricsEditorError }"
       [disabled]="metricsEditorError"
       (click)="addMetrics()"

--- a/frontend/projects/upgrade/src/app/features/dashboard/profile/components/modals/delete-metrics/delete-metrics.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/profile/components/modals/delete-metrics/delete-metrics.component.html
@@ -13,14 +13,14 @@
 </div>
 <div mat-dialog-actions class="metric-delete-dialog-actions">
   <button
-    class="modal-btn"
+    class="shared-modal--modal-btn"
     mat-flat-button
     (click)="onCancelClick()"
   >
     {{ 'global.cancel.text' | translate }}
   </button>
   <button
-    class="modal-btn default-button delete-btn"
+    class="shared-modal--modal-btn default-button delete-btn"
     mat-flat-button
     [ngClass]="{ 'default-button--disabled': metricName !== data.key.join(' ') }"
     [disabled]="metricName !== data.key.join(' ')"

--- a/frontend/projects/upgrade/src/app/features/dashboard/profile/components/modals/new-user/new-user.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/profile/components/modals/new-user/new-user.component.html
@@ -53,7 +53,7 @@
   </div>
   <div class="action-buttons">
     <button
-      class="modal-btn"
+      class="shared-modal--modal-btn"
       mat-raised-button
       (click)="onNoClick()"
     >
@@ -61,7 +61,7 @@
     </button>
     <button
       mat-raised-button
-      class="modal-btn default-button"
+      class="shared-modal--modal-btn default-button"
       [ngClass]="{ 'default-button--disabled': !this.newUserForm.valid }"
       [disabled]="!this.newUserForm.valid"
       (click)="addNewUser()"

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/components/modal/delete-segment/delete-segment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/components/modal/delete-segment/delete-segment.component.html
@@ -13,14 +13,14 @@
 </div>
 <div mat-dialog-actions class="delete-segment-dialog-actions">
   <button
-    class="modal-btn"
+    class="shared-modal--modal-btn"
     mat-flat-button
     (click)="onCancelClick()"
   >
     {{ 'global.cancel.text' | translate }}
   </button>
   <button
-    class="modal-btn default-button delete-btn"
+    class="shared-modal--modal-btn default-button delete-btn"
     mat-flat-button
     [ngClass]="{ 'default-button--disabled': segmentName !== data.segmentName }"
     [disabled]="segmentName !== data.segmentName"

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/components/modal/duplicate-segment/duplicate-segment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/components/modal/duplicate-segment/duplicate-segment.component.html
@@ -24,14 +24,14 @@
 </div>
 <div mat-dialog-actions class="duplicate-segment-dialog-actions">
   <button
-    class="modal-btn"
+    class="shared-modal--modal-btn"
     mat-flat-button
     (click)="onCancelClick()"
   >
     {{ 'global.cancel.text' | translate }}
   </button>
   <button
-    class="modal-btn default-button duplicate-btn"
+    class="shared-modal--modal-btn default-button duplicate-btn"
     mat-flat-button
     (click)="onDuplicateClick(segmentName, segmentDescription)"
   >

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/components/modal/import-segment/import-segment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/components/modal/import-segment/import-segment.component.html
@@ -17,12 +17,12 @@
   </div>
 
   <div class="button-container">
-    <button class="modal-btn" mat-raised-button (click)="onCancelClick()">
+    <button class="shared-modal--modal-btn" mat-raised-button (click)="onCancelClick()">
       {{ 'global.cancel.text' | translate }}
     </button>
     <button
       mat-raised-button
-      class="modal-btn default-button"
+      class="shared-modal--modal-btn default-button"
       [ngClass]="{ 'default-button--disabled': !segmentInfo }"
       [disabled]="!segmentInfo"
       (click)="importSegment()"

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/components/segment-members/segment-members.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/components/segment-members/segment-members.component.html
@@ -99,14 +99,14 @@
     <button
       matStepperPrevious
       mat-raised-button
-      class="modal-btn default-button btn-back"
+      class="shared-modal--modal-btn default-button btn-back"
     >
       {{ 'global.back.text' | translate }}
     </button>
     <div>
       <button
         mat-raised-button
-        class="modal-btn"
+        class="shared-modal--modal-btn"
         (click)="emitEvent(NewSegmentDialogEvents.CLOSE_DIALOG)"
       >
         {{ 'global.cancel.text' | translate }}
@@ -114,7 +114,7 @@
       <button
         matStepperNext
         mat-raised-button
-        class="modal-btn default-button"
+        class="shared-modal--modal-btn default-button"
         (click)="emitEvent(NewSegmentDialogEvents.SEND_FORM_DATA)"
       >
       {{ segmentInfo ? ('global.update.text' | translate) : ('global.create.text' | translate) }}

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/components/segment-overview/segment-overview.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/components/segment-overview/segment-overview.component.html
@@ -34,7 +34,7 @@
 
   <div class="button-container">
     <button
-      class="modal-btn"
+      class="shared-modal--modal-btn"
       mat-raised-button
       (click)="emitEvent(NewSegmentDialogEvents.CLOSE_DIALOG)"
     >
@@ -42,7 +42,7 @@
     </button>
     <button
       mat-raised-button
-      class="modal-btn default-button"
+      class="shared-modal--modal-btn default-button"
       (click)="emitEvent(NewSegmentDialogEvents.SEND_FORM_DATA)"
     >
       {{ 'global.next.text' | translate }}

--- a/frontend/projects/upgrade/src/app/shared/components/delete/delete.component.html
+++ b/frontend/projects/upgrade/src/app/shared/components/delete/delete.component.html
@@ -13,14 +13,14 @@
   </div>
   <div mat-dialog-actions class="dialog-actions">
     <button
-      class="modal-btn"
+      class="shared-modal--modal-btn"
       mat-flat-button
       (click)="onCancelClick()"
     >
       {{ 'global.cancel.text' | translate }}
     </button>
     <button
-      class="modal-btn default-button delete-btn"
+      class="shared-modal--modal-btn default-button delete-btn"
       mat-flat-button
       [ngClass]="{ 'default-button--disabled': isDeleteButtonClicked !== ('global.delete-input-comparison.text' | translate) }"
       [disabled]="isDeleteButtonClicked !== ('global.delete-input-comparison.text' | translate)"

--- a/frontend/projects/upgrade/src/app/shared/components/query-result/query-result.component.html
+++ b/frontend/projects/upgrade/src/app/shared/components/query-result/query-result.component.html
@@ -41,7 +41,7 @@
   </div>
 
   <div class="button-container">
-    <button class="modal-btn" mat-raised-button (click)="onCancelClick()">
+    <button class="shared-modal--modal-btn" mat-raised-button (click)="onCancelClick()">
       {{ 'global.cancel.text' | translate }}
     </button>
   </div>

--- a/frontend/projects/upgrade/src/styles.scss
+++ b/frontend/projects/upgrade/src/styles.scss
@@ -10,6 +10,7 @@
 @import './themes/light-theme';
 @import './themes/dark-theme';
 @import './styles/utility.scss';
+@import './styles/shared-modal.scss';
 @import './app/features/dashboard/dashboard-root/dashboard-root.theme.scss';
 @import './app/features/dashboard/home/root/home.theme.scss';
 @import './app/features/dashboard/home/components/experiment-list/experiment-list.theme.scss';
@@ -218,18 +219,6 @@
 
 .new-user-modal {
   width: 805px;
-}
-
-// Common style for modal button
-.modal-btn {
-  margin-left: 20px !important;
-  border-radius: 3px !important;
-  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.5) !important;
-  width: 100px;
-  height: 36px;
-  font-family: 'Open Sans';
-  font-size: var(--text-size-normal);
-  font-weight: 600;
 }
 
 .mat-button,

--- a/frontend/projects/upgrade/src/styles/shared-modal.scss
+++ b/frontend/projects/upgrade/src/styles/shared-modal.scss
@@ -1,0 +1,46 @@
+// SHARED MODAL CLASSES
+// 
+// shared-modal--step-container
+// shared-modal--form-container
+// shared-modal--buttons-container
+// 
+// shared-modal--buttons-left
+// shared-modal--buttons-right
+// shared-modal--modal-btn
+
+
+.shared-modal--step-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    height: 575px;
+}
+
+.shared-modal--buttons-container {
+    display: flex;
+    justify-content: space-between;
+
+    .shared-modal--buttons-left {
+        .btn-back {
+            // TODO use parent container to position buttons
+            margin-left: 0 !important;
+        }
+    }
+
+    // .shared-modal--buttons-right {
+    //     // TODO use parent container to position buttons
+    // }
+}
+
+// Common style for modal button
+// TODO remove margin/padding from buttons (allow parent to control positioning)
+.shared-modal--modal-btn {
+    margin-left: 20px !important;
+    border-radius: 3px !important;
+    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.5) !important;
+    width: 100px;
+    height: 36px;
+    font-family: 'Open Sans';
+    font-size: var(--text-size-normal);
+    font-weight: 600;
+}


### PR DESCRIPTION
#413

As a user, one will now see the buttons always at bottom of experiment-stepper.

Part of this fix is a small refactor to generalize modal styles / basic html layout and shared naming.

You'll see a new `shared-modal.scss` stylesheet, which at this point is imported into the global `style.scss` so the following classes can be made to all modals automatically at the component-level.

These were only applied to experiment-stepper to start with as it was most important. I will look into expanding this where needed for other modals where it makes sense so all is consistent. FYI, you will see some file changes where `modal-btn` was already a global style class, I just renamed it to `shared-modal--modal-btn` and tucked it into this new stylesheet because it was already serving this purpose.

Basic layout classes:
```
div.shared-modal--step-container
   section.shared-modal--form-container
   section.shared-modal--buttons-container
```

Bottom modal button:
```
shared-modal--buttons-left
shared-modal--buttons-right
shared-modal--modal-btn
```

