### PR TITLE
node 16 docker-nix, package-lock for node types

### DIFF
--- a/docker.nix
+++ b/docker.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
     name = "upgrade-shell";
     buildInputs = 
         # packages everyone gets
-        [ bash nodejs-12_x python38 cacert ]
+        [ bash nodejs-16_x python38 cacert ]
         ++ lib.optional stdenv.isDarwin
         [ darwin.apple_sdk.frameworks.CoreServices ];
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -49,7 +49,7 @@
         "@angular/compiler-cli": "~13.3.11",
         "@angular/language-service": "~13.3.11",
         "@types/jest": "^27.0.0",
-        "@types/node": "^16.0.00",
+        "@types/node": "^16.0.0",
         "@types/uuid": "^8.3.4",
         "codelyzer": "^6.0.2",
         "coverage-badge-creator": "^1.0.11",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -76,7 +76,7 @@
     "@angular/compiler-cli": "~13.3.11",
     "@angular/language-service": "~13.3.11",
     "@types/jest": "^27.0.0",
-    "@types/node": "^16.0.00",
+    "@types/node": "^16.0.0",
     "@types/uuid": "^8.3.4",
     "codelyzer": "^6.0.2",
     "coverage-badge-creator": "^1.0.11",


### PR DESCRIPTION
Changes for local docker setup to run post-node 16 update with the `make` commands as described in updated gitbook quickstart guide: https://upgrade-platform.gitbook.io/upgrade-documentation/developer-guide/usage-guide