### PR TITLE
Unify experiment stepper's checkbox label design

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.html
@@ -160,7 +160,7 @@
       <!-- apply equal condition weights -->
       <div class="header-group">
         <mat-checkbox
-        class="ft-8-100"
+        class="ft-13-700"
         color="primary"
         [disabled]= "experimentInfo && (experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE)"
         [checked]="equalWeightFlag"

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.scss
@@ -84,9 +84,6 @@
     margin-top: 10px;
     margin-bottom: 10px;
     font-size: 13px;
-    &.mat-checkbox-checked {
-      color: var(--blue);
-    }
   }
 
   .partition-table {

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.html
@@ -106,7 +106,7 @@
           />
         </mat-chip-list>
       </mat-form-field>
-      <mat-checkbox class="ft-14-700" color="primary" formControlName="logging">
+      <mat-checkbox class="ft-13-700" color="primary" formControlName="logging">
         {{ 'home.view-experiment.logging.text' | translate }}
       </mat-checkbox>
     </form>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-schedule/experiment-schedule.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-schedule/experiment-schedule.component.html
@@ -3,7 +3,7 @@
     <form class="experiment-schedule-form" [formGroup]="experimentScheduleForm">
 
       <mat-checkbox
-        class="ft-14-700"
+        class="ft-13-700"
         color="primary"
         [disabled]= "experimentInfo && (experimentInfo.state == ExperimentState.ENROLLING || experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE)"
         formControlName="startExperimentAutomatically"
@@ -32,7 +32,7 @@
         </mat-form-field>
       </div>
 
-      <mat-checkbox class="ft-14-700" color="primary" formControlName="endExperimentAutomatically"
+      <mat-checkbox class="ft-13-700" color="primary" formControlName="endExperimentAutomatically"
       [disabled]= "experimentInfo && experimentInfo.state == ExperimentState.ENROLLMENT_COMPLETE"
       >
         {{ 'home.new-experiment.schedule.end-automatically.text' | translate }}

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-schedule/experiment-schedule.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-schedule/experiment-schedule.component.scss
@@ -1,9 +1,4 @@
 .experiment-schedule-form {
-  mat-checkbox {
-    &.mat-checkbox-checked {
-      color: var(--blue);
-    }
-  }
 
   .mat-radio-button,
   .input {

--- a/frontend/projects/upgrade/src/styles/utility.scss
+++ b/frontend/projects/upgrade/src/styles/utility.scss
@@ -125,6 +125,10 @@ button,
   @include set-font(12, 700);
 }
 
+.ft-13-700 {
+  @include set-font(13, 700);
+}
+
 .ft-14-400 {
   @include set-font(14, 400);
 }


### PR DESCRIPTION
We have the following checkboxes in the experiment stepper:
  * Overview: Logging
  * Design: Weight Equally
  * Schedule: Start/End Automatically

They currently use different label font sizes/weights and behavior (e.g. blue colored when checked). So I made all the checkbox labels use the same following style/behavior for consistency, just like in the [Figma design](https://www.figma.com/file/uYxnCT2dXTftSZKFQ00Q0y/UpGrade-UI-Prototype-(latest)).
  * Font size: 13
  * Font weight: 700
  * Behavior: no color change when checked

Current/ununified checkbox label designs
<img width="750" alt="before-overview" src="https://user-images.githubusercontent.com/90279765/181789760-81e84fec-c75a-4eba-9dc5-9e11a185a977.png">
<img width="750" alt="before-design" src="https://user-images.githubusercontent.com/90279765/181789777-d71ae9e6-43cf-4b25-ac0b-8f1b2279c82a.png">
<img width="750" alt="before-schedule" src="https://user-images.githubusercontent.com/90279765/181789805-ac8a17de-2317-4c35-888b-9ceafc5d116b.png">

New/unified checkbox label designs
<img width="750" alt="after-overview" src="https://user-images.githubusercontent.com/90279765/181789848-b94c8372-aaa2-4d21-8d94-746eacc73744.png">
<img width="750" alt="after-design" src="https://user-images.githubusercontent.com/90279765/181789855-97265f03-df6b-4b58-b8cb-c94429d31e9a.png">
<img width="750" alt="after-schedule" src="https://user-images.githubusercontent.com/90279765/181789864-82e7a242-37cb-4f07-b97a-4f6ca7f1081d.png">

