### PR TITLE
Refine the participants step UI

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.scss
@@ -38,9 +38,9 @@
     }
 
     .cdk-column-target {
-      margin-right: 160px;
+      margin-left: 30px;
       width: 100%;
-      max-width: 320px;
+      max-width: 530px;
     }
 
     .cdk-column-conditionCode {
@@ -56,7 +56,7 @@
     .cdk-column-description {
       margin-left: 30px;
       width: 100%;
-      max-width: 320px;
+      max-width: 350px;
     }
 
     .remove-icon {
@@ -64,9 +64,10 @@
       justify-content: center;
       align-items: center;
       margin-top: -3px;
-      width: 60px;
+      min-width: 60px;
       height: 16px;
       font-size: var(--text-size-x-large);
+      color: gray;
 
       &:hover {
         cursor: pointer;

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-participants/experiment-participants.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-participants/experiment-participants.component.html
@@ -20,7 +20,7 @@
           class="member-table"
           [dataSource]="members1DataSource"
           formArrayName="members1"
-          #membersTable
+          #members1Table
         >
           <!-- Members Type Column -->
           <ng-container matColumnDef="type">
@@ -63,7 +63,7 @@
               <mat-form-field floatLabel="never" class="form-control">
                 <input
                   matInput
-                  [placeholder]="'segments.global-members-id/name.text' | translate"
+                  [placeholder]="'segments.members-placeholder-id/name.text' | translate"
                   formControlName="id"
                 />
               </mat-form-field>
@@ -74,7 +74,7 @@
           <ng-container matColumnDef="removeMember">
             <mat-header-cell class="ft-14-700" *matHeaderCellDef></mat-header-cell>
             <mat-cell
-              style="justify-content: flex-end;"
+              style="justify-content: flex-start;"
               *matCellDef="let element; let groupIndex = index"
               [formGroupName]="groupIndex"
             >
@@ -114,7 +114,7 @@
           class="member-table"
           [dataSource]="members2DataSource"
           formArrayName="members2"
-          #membersExceptTable
+          #members2Table
         >
           <!-- Members NUMBER Column -->
           <ng-container matColumnDef="memberNumber">
@@ -167,7 +167,7 @@
               <mat-form-field floatLabel="never" class="form-control">
                 <input
                   matInput
-                  [placeholder]="'segments.global-members-id/name.text' | translate"
+                  [placeholder]="'segments.members-placeholder-id/name.text' | translate"
                   formControlName="id"
                 />
               </mat-form-field>
@@ -178,7 +178,7 @@
           <ng-container matColumnDef="removeMember">
             <mat-header-cell class="ft-14-700" *matHeaderCellDef></mat-header-cell>
             <mat-cell
-              style="justify-content: flex-end;"
+              style="justify-content: flex-start;"
               *matCellDef="let element; let groupIndex = index"
               [formGroupName]="groupIndex"
             >

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-participants/experiment-participants.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-participants/experiment-participants.component.scss
@@ -7,50 +7,59 @@
   flex-direction: column;
 
   .title {
-    font-size: 20px;
+    font-size: 18px;
     font-weight: bold;
-    margin-bottom: 10px;
   }
 
   .member-table {
-    max-height: 140px;
+    margin-top: 5px;
+    max-height: 135px;
     overflow: auto;
 
     mat-header-row {
       min-height: 35px;
+      justify-content: space-between;
     }
 
     mat-row {
-      min-height: 66px;
-      max-height: 66px;
+      min-height: 46px;
+      max-height: 46px;
+      justify-content: space-between;
     }
 
     mat-header-cell {
       justify-content: left;
-      margin-right: 15px;
       color: var(--grey-6);
     }
 
     mat-cell {
       justify-content: left;
-      margin-right: 15px;
+      margin-bottom: -5px;
     }
 
     .cdk-column-removeMember {
-      flex: 0 0 15%;
-
+      flex: 0 0 60px;
+      width: 60px;
     }
 
-    .mat-column-id,
     .mat-column-type {
-      flex: 0 0 40%;
+      flex: 0 0 180px;
+      width: 180px;
+    }
+
+    .mat-column-id {
+      margin-left: 30px;
+      width: 100%;
+      max-width: 400px;
     }
 
     .remove-icon {
-      position: right;
-      top: -3px;
-      width: 18px;
-      height: 18px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      margin-top: -3px;
+      min-width: 60px;
+      height: 16px;
       font-size: var(--text-size-x-large);
       color: gray;
 
@@ -66,7 +75,7 @@
   }
 
   .add-member {
-    // margin-top: 10px;
+    margin-top: 10px;
     outline: 0;
     border: 0;
     background-color: transparent;
@@ -84,13 +93,18 @@
       width: 25%;
     }
   }
-  
-  .member-table {
-    margin-top: 30px;
-  }
 
 
   ::ng-deep .mat-form-field-label {
     color: var(--grey-6);
+  }
+  
+  ::ng-deep .form-control .mat-form-field-underline {
+    bottom: unset;
+    background-color: unset !important;
+  }
+
+  ::ng-deep .mat-form-field-appearance-legacy.mat-form-field-invalid:not(.mat-focused) .mat-form-field-ripple {
+    display: none;
   }
 }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-participants/experiment-participants.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-participants/experiment-participants.component.ts
@@ -183,7 +183,7 @@ export class ExperimentParticipantsComponent implements OnInit {
     this.members1DataSource.next(this.members1.controls);
     if (this.members1Table) {
       this.members1Table.nativeElement.scroll({
-        top: this.members1Table.nativeElement.scrollHeight,
+        top: this.members1Table.nativeElement.scrollHeight - 94,
         behavior: 'smooth'
       });
     }
@@ -193,7 +193,7 @@ export class ExperimentParticipantsComponent implements OnInit {
     this.members2DataSource.next(this.members2.controls);
     if (this.members2Table) {
       this.members2Table.nativeElement.scroll({
-        top: this.members2Table.nativeElement.scrollHeight,
+        top: this.members2Table.nativeElement.scrollHeight - 94,
         behavior: 'smooth'
       });
     }

--- a/frontend/projects/upgrade/src/assets/i18n/en.json
+++ b/frontend/projects/upgrade/src/assets/i18n/en.json
@@ -309,6 +309,7 @@
   "segments.overview.segment-app-context.text": "App Context",
   "segments.members-add-members.text": "Add Member",
   "segments.members-placeholder-type.text": "Type",
+  "segments.members-placeholder-id/name.text": "ID/Name",
   "segments.include.text": "Include",
   "segments.except.text": "Except",
   "segments.global-members-type.text": "TYPE",


### PR DESCRIPTION
Updated the Participants step so that it can be like the [Figma design](https://www.figma.com/file/uYxnCT2dXTftSZKFQ00Q0y/UpGrade-UI-Prototype-(latest)). Also, fixed the members table so that it can auto-scrolled to the bottom row when a new row is added.

Before:
<img width="750" alt="before" src="https://user-images.githubusercontent.com/90279765/182707122-ea2d34c7-381b-4599-832f-31bd6f327fdf.png">

After:
<img width="750" alt="after" src="https://user-images.githubusercontent.com/90279765/182707150-9103b637-ffe4-482c-956b-8a6f2935830f.png">
