### PR TITLE
Remove default rows in the experiment stepper

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
@@ -101,8 +101,6 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
       this.isContextChanged = false;
       this.partition.clear();
       this.condition.clear();
-      this.partition.push(this.addPartitions());
-      this.condition.push(this.addConditions());
       this.partitionDataSource.next(this.partition.controls);
       this.conditionDataSource.next(this.condition.controls);
     }
@@ -355,7 +353,7 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
     let defaultConditionCodeErrorText = this.translate.instant('home.new-experiment.design.condition-name-validation.text');
     if (conditions.length) {
       const hasDefaultConditionCode = conditions.filter(
-        condition => condition.conditionCode.toUpperCase() === defaultKeyword
+        condition => condition.conditionCode && condition.conditionCode.toUpperCase().trim() === defaultKeyword
       );
       if (hasDefaultConditionCode.length && this.conditionCodeErrors.indexOf(defaultConditionCodeErrorText) === -1) {
         this.conditionCodeErrors.push(defaultConditionCodeErrorText);

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
@@ -353,7 +353,7 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
     let defaultConditionCodeErrorText = this.translate.instant('home.new-experiment.design.condition-name-validation.text');
     if (conditions.length) {
       const hasDefaultConditionCode = conditions.filter(
-        condition => condition.conditionCode && condition.conditionCode.toUpperCase().trim() === defaultKeyword
+        condition => typeof condition.conditionCode === 'string' && condition.conditionCode.toUpperCase().trim() === defaultKeyword
       );
       if (hasDefaultConditionCode.length && this.conditionCodeErrors.indexOf(defaultConditionCodeErrorText) === -1) {
         this.conditionCodeErrors.push(defaultConditionCodeErrorText);

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-participants/experiment-participants.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-participants/experiment-participants.component.ts
@@ -76,7 +76,6 @@ export class ExperimentParticipantsComponent implements OnInit {
       this.members2.clear();
       this.members1DataSource.next(this.members1.controls);
       this.members2DataSource.next(this.members2.controls);
-      this.addMember1();
     }
   }
 
@@ -135,9 +134,7 @@ export class ExperimentParticipantsComponent implements OnInit {
         });
       }
 
-      if (this.members1.length !== 1) {
-        this.members1.removeAt(0);
-      }
+      this.members1.removeAt(0);
       this.members2.removeAt(0);
     }
 
@@ -205,10 +202,12 @@ export class ExperimentParticipantsComponent implements OnInit {
 
     if (includedMembersFiltered.length === 0) {
       this.members1.clear();
+      this.updateView1();
     }
 
     if (excludedMembersFiltered.length === 0) {
       this.members2.clear();
+      this.updateView2();
     }
   }
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.ts
@@ -519,7 +519,6 @@ export class MonitoredMetricsComponent implements OnInit, OnChanges, OnDestroy {
     if (this.isContextChanged) {
       this.isContextChanged = false;
       this.queries.clear();
-      this.queries.push(this.addMetric());
       this.metricsDataSource.next(this.queries.controls);
     }
   }


### PR DESCRIPTION
Changes:
  * Remove default rows in all tables in the stepper
  * Handle if the `conditionCode` is null, and if the user adds spaces to the condition when checking the `defaultKeyword`
  * Unfilled rows in the Participants step will be removed when the user clicks the "Next" or "Update" button (temporary solution)

Note: I will later add validation messages to the Participants step so we can show a message when the user clicks the "Next" button while `ID/Name` field is empty. Just like how it works in the Metrics step.

<img width="600" alt="Screen Shot 2022-08-08 at 11 53 42 AM" src="https://user-images.githubusercontent.com/90279765/183460185-0a4ace11-ee18-4635-817e-3ef97356beec.png">
<img width="600" alt="Screen Shot 2022-08-08 at 11 55 33 AM" src="https://user-images.githubusercontent.com/90279765/183460615-bd57cb05-fa6a-4058-9fd7-da05c04e5989.png">
 