### PR TITLE
Refine the Metrics step UI

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.html
@@ -2,8 +2,6 @@
   <section class="shared-modal--form-container">
     <form class="metric-design" [formGroup]="queryForm">
       <span class="title">{{ 'home.new-experiment.metrics.text' | translate }}</span>
-      <br>
-      <br>
       <ng-container *ngIf="allMetrics?.length; else noAvailableMetricsMessage">
         <!-- Metric Table -->
         <ng-container>
@@ -15,7 +13,7 @@
           >
             <!-- Metric Column -->
             <ng-container matColumnDef="keys">
-              <mat-header-cell class="ft-13-700" *matHeaderCellDef>
+              <mat-header-cell class="ft-14-700" *matHeaderCellDef>
                 {{ 'query.metric.text' | translate }}
               </mat-header-cell>
               <mat-cell
@@ -24,10 +22,10 @@
               >
               <ng-container formArrayName="keys">
                 <div class="metric-keys">
-                <mat-form-field *ngFor="let key of getKeys(queryIndex).controls; let keyIndex = index" class="ft-12-600 form-control auto-complete" floatLabel="never">
+                <mat-form-field *ngFor="let key of getKeys(queryIndex).controls; let keyIndex = index" class="ft-14-400 form-control auto-complete" floatLabel="never">
                   <ng-container [formGroupName]="keyIndex">
                     <input
-                      class = "ft-12-400"
+                      class = "ft-14-400"
                       type="text"
                       matInput
                       [placeholder]="getMetricPlaceHolder(keyIndex)"
@@ -35,24 +33,24 @@
                       [matAutocomplete]="auto"
                       >
                     <mat-autocomplete
-                      class = "ft-12-400"
+                      class = "ft-14-400"
                       (optionSelected)="selectedOption($event, null, null, queryIndex, keyIndex)"
                       #auto="matAutocomplete"
                       [displayWith]="displayFn"
                       panelWidth="fit-content"
                       >
                       <div *ngIf="keyIndex == 0">
-                        <mat-option class = "ft-12-400" *ngFor="let option of filteredMetrics1$[queryIndex] | async" [value]="option">
+                        <mat-option class = "ft-14-400" *ngFor="let option of filteredMetrics1$[queryIndex] | async" [value]="option">
                           {{ option.key }}
                         </mat-option>
                       </div>
                       <div *ngIf="keyIndex == 1">
-                        <mat-option class = "ft-12-400" *ngFor="let option of filteredMetrics2$[queryIndex] | async" [value]="option">
+                        <mat-option class = "ft-14-400" *ngFor="let option of filteredMetrics2$[queryIndex] | async" [value]="option">
                           {{ option.key }}
                         </mat-option>
                       </div>
                       <div *ngIf="keyIndex == 2">
-                        <mat-option class = "ft-12-400" *ngFor="let option of filteredMetrics3$[queryIndex] | async" [value]="option">
+                        <mat-option class = "ft-14-400" *ngFor="let option of filteredMetrics3$[queryIndex] | async" [value]="option">
                           {{ option.key }}
                         </mat-option>
                       </div>
@@ -65,7 +63,7 @@
             </ng-container>
             <!-- Statistic Column -->
             <ng-container matColumnDef="operationType">
-              <mat-header-cell class="ft-13-700" *matHeaderCellDef>
+              <mat-header-cell class="ft-14-700" *matHeaderCellDef>
                 {{ 'monitor.statistic.text' | translate }}
               </mat-header-cell>
               <mat-cell
@@ -74,9 +72,9 @@
               >
               <div class="secondary-form">
                 <!-- statistic -->
-                <mat-form-field class="ft-12-600 form-control" floatLabel="never">
+                <mat-form-field class="ft-14-400 form-control" floatLabel="never">
                   <mat-label>{{ 'monitor.statistic.text' | translate | titlecase }}</mat-label>
-                  <mat-select class="ft-12-400" formControlName="operationType">
+                  <mat-select class="ft-14-400" formControlName="operationType">
                     <mat-option
                       *ngFor="let operation of filteredStatistic$[queryIndex]"
                       [value]="operation.value"
@@ -86,9 +84,9 @@
                   </mat-select>
                 </mat-form-field>
                 <!-- repeated measure -->
-                <mat-form-field class="ft-12-600 form-control" *ngIf="firstSelectedNode[queryIndex] && isMetricRepeated(firstSelectedNode[queryIndex], queryIndex, editMode)" floatLabel="never">
+                <mat-form-field class="ft-14-400 form-control" *ngIf="firstSelectedNode[queryIndex] && isMetricRepeated(firstSelectedNode[queryIndex], queryIndex, editMode)" floatLabel="never">
                   <mat-label>{{ 'home.new-experiment.metrics.repeatedmeasure.placeholder.text' | translate | titlecase }}</mat-label>
-                  <mat-select class="ft-12-400" formControlName="repeatedMeasure">
+                  <mat-select class="ft-14-400" formControlName="repeatedMeasure">
                     <mat-option
                       *ngFor="let measure of RepeatedMeasure"
                       [value]="measure"
@@ -98,9 +96,9 @@
                   </mat-select>
                 </mat-form-field>
                 <!-- comparison function -->
-                <mat-form-field class="ft-12-600 form-control" *ngIf="selectedNode[queryIndex] && selectedNode[queryIndex]?.metadata?.type !== IMetricMetadata.CONTINUOUS" floatLabel="never">
+                <mat-form-field class="ft-14-400 form-control" *ngIf="selectedNode[queryIndex] && selectedNode[queryIndex]?.metadata?.type !== IMetricMetadata.CONTINUOUS" floatLabel="never">
                   <mat-label>{{ 'query.form-comparison-function.text' | translate | titlecase }}</mat-label>
-                  <mat-select class="ft-12-400" formControlName="compareFn">
+                  <mat-select class="ft-14-400" formControlName="compareFn">
                     <mat-option>{{ 'query.none-option.text' | translate }}</mat-option>
                     <mat-option
                       *ngFor="let fn of comparisonFns"
@@ -111,9 +109,9 @@
                   </mat-select>
                 </mat-form-field>
                 <!-- compare value -->
-                <mat-form-field class="ft-12-600 form-control" *ngIf="selectedNode[queryIndex] && selectedNode[queryIndex]?.metadata?.type !== IMetricMetadata.CONTINUOUS" floatLabel="never">
+                <mat-form-field class="ft-14-400 form-control" *ngIf="selectedNode[queryIndex] && selectedNode[queryIndex]?.metadata?.type !== IMetricMetadata.CONTINUOUS" floatLabel="never">
                   <mat-label>{{ 'query.form-compare-value.text' | translate | titlecase }}</mat-label>
-                  <mat-select class="ft-12-400" formControlName="compareValue">
+                  <mat-select class="ft-14-400" formControlName="compareValue">
                     <mat-option
                       *ngFor="let value of selectedNode[queryIndex]?.allowedData"
                       [value]="value"
@@ -127,16 +125,16 @@
             </ng-container>
             <!-- Description Column -->
             <ng-container matColumnDef="queryName">
-              <mat-header-cell class="ft-13-700" *matHeaderCellDef>
+              <mat-header-cell class="ft-14-700" *matHeaderCellDef>
                 {{ 'home.new-experiment.metrics.description-header.placeholder.text' | translate }}
               </mat-header-cell>
               <mat-cell
                 *matCellDef="let element; let queryIndex = index"
                 [formGroupName]="queryIndex"
               >
-                <mat-form-field  class="ft-12-600" floatLabel="never">
+                <mat-form-field  class="ft-14-400" floatLabel="never">
                     <input
-                      class = "ft-12-400"
+                      class = "ft-14-400"
                       matInput
                       [placeholder]="'home.new-experiment.metrics.description.placeholder.text'| translate"
                       formControlName="queryName"
@@ -147,10 +145,11 @@
             </ng-container>
   
             <ng-container matColumnDef="removeMetric">
-              <mat-header-cell class="ft-12-700" *matHeaderCellDef></mat-header-cell>
+              <mat-header-cell class="ft-14-700" *matHeaderCellDef></mat-header-cell>
               <mat-cell
                 *matCellDef="let element; let queryIndex = index"
                 [formGroupName]="queryIndex"
+                style="justify-content: flex-start;"
               >
                 <mat-icon
                   class="remove-icon"

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.scss
@@ -26,10 +26,10 @@
     }
 
     .metric-keys {
-      display: grid;
-      flex-direction: row;
-      flex-wrap: wrap;
+      display: flex;
+      flex-direction: column;
       padding: 10px 0;
+      width: 250px;
 
       .dropdown {
         position: absolute;
@@ -39,7 +39,10 @@
     }
 
     .secondary-form {
-      flex-wrap: wrap;
+      display: flex;
+      flex-direction: column;
+      padding: 10px 0;
+      width: 160px;
 
       .form-control {
         margin-top: -13px;
@@ -54,20 +57,19 @@
     }
 
     .cdk-column-keys {
-      flex: 0 0 35%;
-      width: 35%;
+      flex: 0 0 250px;
+      width: 250px;
     }
 
     .cdk-column-operationType {
-      margin-left: -30px;
+      margin-left: 30px;
       flex: 0 0 160px;
       width: 160px;
     }
 
     .cdk-column-queryName {
-      margin-left: 30px;
-      width: 43%;
-      max-width: 280px;
+      width: 100%;
+      max-width: 350px;
     }
 
     .remove-icon {

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.scss
@@ -1,16 +1,18 @@
 
 .metric-design {
   .metric-table {
+    margin-top: 5px;
     max-height: 400px;
     overflow: auto;
-    overflow-x: hidden;
 
     mat-header-row {
       min-height: 35px;
+      justify-content: space-between;
     }
 
     mat-row {
-      min-height: 40px;
+      min-height: 46px;
+      justify-content: space-between;
     }
 
     mat-header-cell {
@@ -20,13 +22,14 @@
 
     mat-cell {
       justify-content: left;
-      width: 100%;
+      margin-bottom: -5px;
     }
 
     .metric-keys {
       display: grid;
       flex-direction: row;
       flex-wrap: wrap;
+      padding: 10px 0;
 
       .dropdown {
         position: absolute;
@@ -39,15 +42,15 @@
       flex-wrap: wrap;
 
       .form-control {
-        margin-top: -10px;
-        margin-bottom: -10px;
+        margin-top: -13px;
+        margin-bottom: -13px;
         width: 80%;
       }
     }
 
     .cdk-column-removeMetric {
-      flex: 0 0 10%;
-      width: 10%;
+      flex: 0 0 60px;
+      width: 60px;
     }
 
     .cdk-column-keys {
@@ -56,20 +59,24 @@
     }
 
     .cdk-column-operationType {
-      flex: 0 0 21%;
-      width: 20%;
+      margin-left: -30px;
+      flex: 0 0 160px;
+      width: 160px;
     }
 
     .cdk-column-queryName {
-      flex: 0 0 35%;
-      width: 35%;
+      margin-left: 30px;
+      width: 43%;
+      max-width: 280px;
     }
 
     .remove-icon {
-      position: center;
-      top: -7px;
-      width: 18px;
-      height: 18px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      margin-top: -3px;
+      min-width: 60px;
+      height: 16px;
       font-size: var(--text-size-x-large);
       color: gray;
 
@@ -79,12 +86,12 @@
     }
 
     .auto-complete {
-      margin-top: -10px;
-      margin-bottom: -10px;
+      margin-top: -13px;
+      margin-bottom: -13px;
     }
 
     mat-form-field {
-      width: 130%;
+      width: 100%;
       text-align: left;
     }
   }
@@ -97,14 +104,9 @@
     color: var(--blue);
   }
 
-  .metrics-table {
-    margin-top: 30px;
-  }
-
   .title {
-    font-size: 20px;
+    font-size: 18px;
     font-weight: bold;
-    margin-bottom: 10px;
   }
 
   ::ng-deep .mat-form-field-appearance-legacy .mat-form-field-underline {
@@ -115,10 +117,4 @@
   ::ng-deep .mat-form-field-appearance-legacy.mat-form-field-invalid:not(.mat-focused) .mat-form-field-ripple {
     display: none;
   }
-}
-
-.header-group {
-  display: grid;
-  margin-left: -80px;
-  justify-content: center;
 }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.ts
@@ -492,7 +492,7 @@ export class MonitoredMetricsComponent implements OnInit, OnChanges, OnDestroy {
     this.metricsDataSource.next(this.queries.controls);
     if (type) {
       this[type].nativeElement.scroll({
-        top: this[type].nativeElement.scrollHeight,
+        top: this[type].nativeElement.scrollHeight - 96,
         behavior: 'smooth'
       });
     }


### PR DESCRIPTION
Refined the Metrics step UI so that it looks more consistent with the other steps (e.g. same font size) and more similar to the [Figma design](https://www.figma.com/file/uYxnCT2dXTftSZKFQ00Q0y/UpGrade-UI-Prototype-(latest)). 

Before:
<img width="750" alt="before" src="https://user-images.githubusercontent.com/90279765/184033175-26a9e253-7cfd-4b47-9efd-102f6b13033c.png">

After:
<img width="750" alt="after2" src="https://user-images.githubusercontent.com/90279765/184054421-ffeb782e-6d94-401a-8aa9-550da4c531ef.png">

