### PR TITLE
Refine the Overview step UI

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.html
@@ -108,7 +108,7 @@
           />
         </mat-chip-list>
       </mat-form-field>
-      <mat-checkbox class="ft-13-700" color="primary" formControlName="logging">
+      <mat-checkbox class="ft-13-700 logging" color="primary" formControlName="logging">
         {{ 'home.view-experiment.logging.text' | translate }}
       </mat-checkbox>
     </form>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.scss
@@ -7,7 +7,7 @@
   }
 
   .name {
-    width: 30%;
+    width: 230px;
   }
   .description {
     width: 100%;
@@ -15,30 +15,30 @@
 
   .property-container {
     .unit-of-assignment {
-      width: 30%;
+      width: 230px;
     }
 
     .group-type {
-      margin-left: 10%;
-      width: 25%;
+      margin-left: 50px;
+      width: 230px;
     }
   }
 
   .consistency-rule,
   .context {
-    width: 30%;
+    width: 230px;
   }
 
   .chips {
-    margin-top: 5px;
-    margin-bottom: 5px;
-    width: 30%;
+    width: 230px;
   }
 
   .tags {
-    margin-top: 5px;
-    margin-bottom: 5px;
     width: 100%;
+  }
+
+  .logging {
+    margin-top: 5px;
   }
 
   ::ng-deep .mat-chip-list-wrapper {

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-post-condition/experiment-post-condition.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-post-condition/experiment-post-condition.component.html
@@ -6,7 +6,7 @@
     >
       <mat-form-field class="ft-14-600">
         <mat-label>{{ 'home-global.post-experiment-rule.text' | translate }}</mat-label>
-        <mat-select class="ft-14-600" formControlName="postExperimentRule">
+        <mat-select class="ft-14-400" formControlName="postExperimentRule">
           <mat-option
             *ngFor="let rule of postExperimentRules"
             [value]="rule.value"
@@ -18,7 +18,7 @@
     
       <mat-form-field class="ft-14-600">
         <mat-label>{{ 'global.condition.text' | translate }}</mat-label>
-        <mat-select class="ft-14-600" formControlName="revertTo">
+        <mat-select class="ft-14-400" formControlName="revertTo">
           <mat-option
             *ngFor="let condition of experimentConditions"
             [value]="condition.id"


### PR DESCRIPTION
Changes: 
  * Set the equal vertical spacing between the fields in the Overview step
  * Use fixed pixel width for the Name input and the dropdowns (`30%` -> `230px`)
  * Unbold selected text of the dropdowns in the Post Rule step so they can be like the dropdowns in the Overview step

Before:
<img width="750" alt="before1" src="https://user-images.githubusercontent.com/90279765/184442705-4037b264-baf9-4940-90a1-e897c6d365d8.png">
After:
<img width="750" alt="after1" src="https://user-images.githubusercontent.com/90279765/184442723-bea28344-3dc0-4c4f-9322-77bd6652577b.png">

Before:
<img width="500" alt="before3" src="https://user-images.githubusercontent.com/90279765/184443706-10c50203-5214-4727-a097-ff9d461511e2.png">
After:
<img width="500" alt="after3" src="https://user-images.githubusercontent.com/90279765/184443716-b9cadfb9-5822-4f85-9de6-b866eafec4fc.png">

Before:
<img width="750" alt="before2" src="https://user-images.githubusercontent.com/90279765/184442742-306561c0-a865-45d8-aee6-a0845b543901.png">
After:
<img width="750" alt="after2" src="https://user-images.githubusercontent.com/90279765/184442771-7cdd58c2-31ab-4c6b-a36d-7cdf4f6cad21.png">

