### PR TITLE
Fix for creating experiment and adding segments after consistent import-export PR

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-participants/experiment-participants.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-participants/experiment-participants.component.ts
@@ -291,8 +291,8 @@ export class ExperimentParticipantsComponent implements OnInit {
           this.emitExperimentDialogEvent.emit({
             type: eventType,
             formData: ( filterMode === FILTER_MODE.EXCLUDE_ALL )
-              ? { segmentInclude: segmentMembers1FormData, segmentExclude: segmentMembers2FormData, filterMode: filterMode }
-              : { segmentInclude: segmentMembers2FormData, segmentExclude: segmentMembers1FormData, filterMode: filterMode },
+              ? { experimentSegmentInclusion: segmentMembers1FormData, experimentSegmentExclusion: segmentMembers2FormData, filterMode: filterMode }
+              : { experimentSegmentInclusion: segmentMembers2FormData, experimentSegmentExclusion: segmentMembers1FormData, filterMode: filterMode },
             path: NewExperimentPaths.EXPERIMENT_PARTICIPANTS
           });
         }


### PR DESCRIPTION
There was a small bug after fixing the last few failed test cases for consistent import-export PR merged yesterday. This was not allowing to create and edit the experiment due to changed segments structure. Now, it should be resolved with this quick PR. Need's to be merged ASAP.