### PR TITLE
Add pending state for stepper, wait for contextmetadata

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -4,13 +4,13 @@ A/B Testing Tool
 
 Frontend Unit Test Coverage
 
-![](https://img.shields.io/badge/Coverage-80%25-83A603.svg?style=flat&logo=jest&label=Statements&prefix=$statements$)
-![](https://img.shields.io/badge/Coverage-67%25-5A7302.svg?style=flat&logo=jest&label=Branches&prefix=$branches$)
-![](https://img.shields.io/badge/Coverage-63%25-F2E96B.svg?style=flat&logo=jest&label=Functions&prefix=$functions$)
-![](https://img.shields.io/badge/Coverage-79%25-5A7302.svg?style=flat&logo=jest&label=Lines&prefix=$lines$)
+![](https://img.shields.io/badge/Coverage-87%25-83A603.svg?style=flat&logo=jest&label=Statements&prefix=$statements$)
+![](https://img.shields.io/badge/Coverage-75%25-5A7302.svg?style=flat&logo=jest&label=Branches&prefix=$branches$)
+![](https://img.shields.io/badge/Coverage-75%25-5A7302.svg?style=flat&logo=jest&label=Functions&prefix=$functions$)
+![](https://img.shields.io/badge/Coverage-86%25-83A603.svg?style=flat&logo=jest&label=Lines&prefix=$lines$)
 
 Overall (average of all 4) Goal: 80%
 
-![](https://img.shields.io/badge/Coverage-72%25-5A7302.svg?style=flat&logo=jest&label=Overall&prefix=$coverage$)
+![](https://img.shields.io/badge/Coverage-81%25-83A603.svg?style=flat&logo=jest&label=Overall&prefix=$coverage$)
 
 ---

--- a/frontend/projects/upgrade/src/app/core/experiments/experiments.service.spec.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/experiments.service.spec.ts
@@ -448,7 +448,7 @@ describe('ExperimentService', () => {
         it('should dispatch actionUpdateExperimentState with the given input', () => {
             service.fetchContextMetaData();
 
-            expect(mockStore.dispatch).toHaveBeenCalledWith(actionFetchContextMetaData());
+            expect(mockStore.dispatch).toHaveBeenCalledWith(actionFetchContextMetaData({ isLoadingContextMetaData: true }));
         })
     })
 

--- a/frontend/projects/upgrade/src/app/core/experiments/experiments.service.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/experiments.service.ts
@@ -36,7 +36,8 @@ import {
   selectIsPollingExperimentDetailStats,
   selectIsAliasTableEditMode,
   selectAliasTableEditIndex,
-  selectCurrentContextMetaDataConditions
+  selectCurrentContextMetaDataConditions,
+  selectIsLoadingContextMetaData
 } from './store/experiments.selectors';
 import * as experimentAction from './store//experiments.actions';
 import { AppState } from '../core.state';
@@ -76,6 +77,7 @@ export class ExperimentService {
   isGraphLoading$ = this.store$.pipe(select(selectIsGraphLoading));
   experimentStatById$ = (experimentId) => this.store$.pipe(select(selectExperimentStatById, { experimentId }));
   contextMetaData$ = this.store$.pipe(select(selectContextMetaData));
+  isLoadingContextMetaData$ = this.store$.pipe(select(selectIsLoadingContextMetaData))
   groupSatisfied$ = (experimentId) => this.store$.pipe(select(selectGroupAssignmentStatus, { experimentId }));
   pollingEnabled: boolean = this.environment.pollingEnabled;
   isAliasTableEditMode$ = this.store$.pipe(select(selectIsAliasTableEditMode));
@@ -154,7 +156,7 @@ export class ExperimentService {
   }
 
   fetchContextMetaData() {
-    this.store$.dispatch(experimentAction.actionFetchContextMetaData());
+    this.store$.dispatch(experimentAction.actionFetchContextMetaData({ isLoadingContextMetaData: true }));
   }
 
   setCurrentContext(context: string) {

--- a/frontend/projects/upgrade/src/app/core/experiments/store/experiments.actions.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/store/experiments.actions.ts
@@ -209,6 +209,11 @@ export const actionFetchContextMetaData = createAction(
   props<{ isLoadingContextMetaData: boolean }>()
 );
 
+export const actionSetIsLoadingContextMetaData = createAction(
+  '[Experiment] Set IsLoadingContextMetaData',
+  props<{ isLoadingContextMetaData: boolean }>()
+)
+
 export const actionFetchContextMetaDataSuccess = createAction(
   '[Experiment] Fetch contextMetaData Success',
   props<{ contextMetaData: IContextMetaData, isLoadingContextMetaData: boolean }>()

--- a/frontend/projects/upgrade/src/app/core/experiments/store/experiments.actions.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/store/experiments.actions.ts
@@ -206,15 +206,17 @@ export const actionFetchExperimentDetailStatFailure = createAction(
 
 export const actionFetchContextMetaData = createAction(
   '[Experiment] Fetch contextMetaData',
+  props<{ isLoadingContextMetaData: boolean }>()
 );
 
 export const actionFetchContextMetaDataSuccess = createAction(
   '[Experiment] Fetch contextMetaData Success',
-  props<{ contextMetaData: IContextMetaData }>()
+  props<{ contextMetaData: IContextMetaData, isLoadingContextMetaData: boolean }>()
 );
 
 export const actionFetchContextMetaDataFailure = createAction(
   '[Experiment] Fetch contextMetaData Failure',
+  props<{ isLoadingContextMetaData: boolean }>()
 );
 
 export const actionSetCurrentContext = createAction(

--- a/frontend/projects/upgrade/src/app/core/experiments/store/experiments.effects.spec.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/store/experiments.effects.spec.ts
@@ -1096,7 +1096,7 @@ describe('ExperimentEffects', () => {
                 neverEmitted = false;
             })
 
-            actions$.next(actionFetchContextMetaData());
+            actions$.next(actionFetchContextMetaData({ isLoadingContextMetaData: true }));
 
             tick(0);
 
@@ -1113,13 +1113,13 @@ describe('ExperimentEffects', () => {
                 contextMetadata: {}
             }))
 
-            const expectedAction = actionFetchContextMetaDataSuccess({ contextMetaData })
+            const expectedAction = actionFetchContextMetaDataSuccess({ contextMetaData, isLoadingContextMetaData: false })
 
             service.fetchContextMetaData$.subscribe(resultingActions => {
                 expect(resultingActions).toEqual(expectedAction);
             })
 
-            actions$.next(actionFetchContextMetaData());
+            actions$.next(actionFetchContextMetaData({ isLoadingContextMetaData: false }));
 
             tick(0);
         }))
@@ -1130,13 +1130,13 @@ describe('ExperimentEffects', () => {
             });
             experimentDataService.fetchContextMetaData = jest.fn().mockReturnValue(throwError(() => new Error('test')));
 
-            const expectedAction = actionFetchContextMetaDataFailure();
+            const expectedAction = actionFetchContextMetaDataFailure({ isLoadingContextMetaData: false });
 
             service.fetchContextMetaData$.subscribe(resultingActions => {
                 expect(resultingActions).toEqual(expectedAction);
             })
 
-            actions$.next(actionFetchContextMetaData());
+            actions$.next(actionFetchContextMetaData({ isLoadingContextMetaData: true }));
 
             tick(0);
         }))

--- a/frontend/projects/upgrade/src/app/core/experiments/store/experiments.effects.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/store/experiments.effects.ts
@@ -409,8 +409,8 @@ export class ExperimentEffects {
       }),
       switchMap(() =>
         this.experimentDataService.fetchContextMetaData().pipe(
-          map((contextMetaData: IContextMetaData) => experimentAction.actionFetchContextMetaDataSuccess({ contextMetaData })),
-          catchError(() => [experimentAction.actionFetchContextMetaDataFailure()])
+          map((contextMetaData: IContextMetaData) => experimentAction.actionFetchContextMetaDataSuccess({ contextMetaData, isLoadingContextMetaData: false })),
+          catchError(() => [experimentAction.actionFetchContextMetaDataFailure({ isLoadingContextMetaData: false })])
         )
       )
     )

--- a/frontend/projects/upgrade/src/app/core/experiments/store/experiments.effects.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/store/experiments.effects.ts
@@ -405,7 +405,12 @@ export class ExperimentEffects {
         this.store$.pipe(select(selectContextMetaData))
       ),
       filter(([, contextMetaData]) => {
-        return !Object.keys(contextMetaData.contextMetadata).length
+        // check if contextmetadata is already fetched. cancel if so.
+        const metaDataExists = Object.keys(contextMetaData.contextMetadata).length;
+        if (metaDataExists) {
+          this.store$.dispatch(experimentAction.actionSetIsLoadingContextMetaData({ isLoadingContextMetaData: false }))
+        }
+        return !metaDataExists;
       }),
       switchMap(() =>
         this.experimentDataService.fetchContextMetaData().pipe(

--- a/frontend/projects/upgrade/src/app/core/experiments/store/experiments.model.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/store/experiments.model.ts
@@ -260,6 +260,7 @@ export interface ExperimentState extends EntityState<Experiment> {
   allPartitions: {};
   allExperimentNames: {};
   contextMetaData: IContextMetaData;
+  isLoadingContextMetaData: boolean;
   currentUserSelectedContext: ISingleContextMetadata;
   updatedStat?: IExperimentEnrollmentDetailStats;
   isAliasTableEditMode: boolean;

--- a/frontend/projects/upgrade/src/app/core/experiments/store/experiments.reducer.spec.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/store/experiments.reducer.spec.ts
@@ -567,7 +567,8 @@ describe('ExperimentsReducer', () => {
         const testAction: Action = actionFetchContextMetaDataSuccess({
             contextMetaData: {
                 contextMetadata: null
-            }
+            },
+            isLoadingContextMetaData: false
         })
 
         const newState = experimentsReducer(previousState, testAction);

--- a/frontend/projects/upgrade/src/app/core/experiments/store/experiments.reducer.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/store/experiments.reducer.ts
@@ -33,6 +33,7 @@ export const initialState: ExperimentState = adapter.getInitialState({
   contextMetaData: {
     contextMetadata: {}
   },
+  isLoadingContextMetaData: false,
   currentUserSelectedContext: null,
   isAliasTableEditMode: false,
   aliasTableEditIndex: null
@@ -173,8 +174,13 @@ const reducer = createReducer(
     (state, { allExperimentNames }) => ({ ...state, allExperimentNames })
   ),
   on(
-    experimentsAction.actionFetchContextMetaDataSuccess,
-    (state, { contextMetaData }) => ({ ...state, contextMetaData })
+    experimentsAction.actionFetchContextMetaData,
+    experimentsAction.actionFetchContextMetaDataFailure,
+    (state, { isLoadingContextMetaData }) => ({ ...state, isLoadingContextMetaData })
+  ),
+  on(
+    experimentsAction.actionFetchContextMetaDataSuccess, 
+    (state, { contextMetaData, isLoadingContextMetaData }) => ({ ...state, contextMetaData, isLoadingContextMetaData })
   ),
   on(
     experimentsAction.actionSetCurrentContext,

--- a/frontend/projects/upgrade/src/app/core/experiments/store/experiments.reducer.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/store/experiments.reducer.ts
@@ -176,6 +176,7 @@ const reducer = createReducer(
   on(
     experimentsAction.actionFetchContextMetaData,
     experimentsAction.actionFetchContextMetaDataFailure,
+    experimentsAction.actionSetIsLoadingContextMetaData,
     (state, { isLoadingContextMetaData }) => ({ ...state, isLoadingContextMetaData })
   ),
   on(

--- a/frontend/projects/upgrade/src/app/core/experiments/store/experiments.selectors.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/store/experiments.selectors.ts
@@ -129,6 +129,11 @@ export const selectCurrentContextMetaData = createSelector(
   (state) => state.currentUserSelectedContext
 )
 
+export const selectIsLoadingContextMetaData = createSelector(
+  selectExperimentState,
+  (state) => state.isLoadingContextMetaData
+)
+
 export const selectCurrentContextMetaDataConditions = createSelector(
   selectExperimentState,
   (state) => state.currentUserSelectedContext?.CONDITIONS || []

--- a/frontend/projects/upgrade/src/app/core/local-storage/local-storage.service.spec.ts
+++ b/frontend/projects/upgrade/src/app/core/local-storage/local-storage.service.spec.ts
@@ -37,6 +37,7 @@ describe('LocalStorageService', () => {
             contextMetaData: {
                 contextMetadata: {}
             },
+            isLoadingContextMetaData: false,
             currentUserSelectedContext: null,
             isAliasTableEditMode: false,
             aliasTableEditIndex: null
@@ -62,6 +63,7 @@ describe('LocalStorageService', () => {
             contextMetaData: {
                 contextMetadata: {}
             },
+            isLoadingContextMetaData: false,
             currentUserSelectedContext: null,
             isAliasTableEditMode: false,
             aliasTableEditIndex: null

--- a/frontend/projects/upgrade/src/app/core/local-storage/local-storage.service.ts
+++ b/frontend/projects/upgrade/src/app/core/local-storage/local-storage.service.ts
@@ -42,6 +42,7 @@ export class LocalStorageService {
       contextMetaData: {
         contextMetadata: {}
       },
+      isLoadingContextMetaData: false,
       currentUserSelectedContext: null,
       isAliasTableEditMode: false,
       aliasTableEditIndex: null

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.html
@@ -1,4 +1,4 @@
-<div class="shared-modal--step-container">
+<div *ngIf="!(isLoadingContextMetaData$ | async); else loadingExperimentOverview;" class="shared-modal--step-container">
   <section class="shared-modal--form-container">
     <form class="experiment-overview" [formGroup]="overviewForm">
       <mat-form-field class="ft-14-600 name">
@@ -164,3 +164,9 @@
     </span>
   </section>
 </div>
+
+<ng-template #loadingExperimentOverview>
+  <div class="loading-container">
+    <mat-spinner diameter="60"></mat-spinner>
+  </div>
+</ng-template>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.scss
@@ -50,3 +50,11 @@
     color: var(--grey-6);
   }
 }
+
+.loading-container {
+  display: flex;
+  height: 500px;
+  flex-grow: 1;
+  align-items: center;
+  justify-content: center;
+}

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.ts
@@ -122,7 +122,6 @@ export class ExperimentOverviewComponent implements OnInit, OnDestroy {
 
       // populate values in form to update experiment if experiment data is available
       if (this.experimentInfo) {
-        // debugger;
         if (this.experimentInfo.state == this.ExperimentState.ENROLLING || this.experimentInfo.state == this.ExperimentState.ENROLLMENT_COMPLETE) {
           this.overviewForm.disable();
         }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.ts
@@ -12,7 +12,7 @@ import { ENTER, COMMA } from '@angular/cdk/keycodes';
 import { FormGroup, FormBuilder, Validators, FormArray } from '@angular/forms';
 import * as find from 'lodash.find';
 import { ExperimentService } from '../../../../../core/experiments/experiments.service';
-import { Subscription } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 import { MatChipInputEvent } from '@angular/material/chips';
 
 @Component({
@@ -51,6 +51,7 @@ export class ExperimentOverviewComponent implements OnInit, OnDestroy {
   // Used for autocomplete context input
   contextMetaData: IContextMetaData | {} = {};
   contextMetaDataSub: Subscription;
+  isLoadingContextMetaData$: Observable<boolean>;
 
   readonly separatorKeysCodes: number[] = [ENTER, COMMA];
 
@@ -60,9 +61,10 @@ export class ExperimentOverviewComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
+    this.isLoadingContextMetaData$ = this.experimentService.isLoadingContextMetaData$;
     this.contextMetaDataSub = this.experimentService.contextMetaData$.subscribe(contextMetaData => {
       this.contextMetaData = contextMetaData;
-      
+
       if (this.overviewForm && this.contextMetaData && this.experimentInfo) {
         this.checkExperiment();
         this.overviewForm.patchValue(this.setGroupTypeControlValue());
@@ -71,74 +73,75 @@ export class ExperimentOverviewComponent implements OnInit, OnDestroy {
       if (this.contextMetaData && this.contextMetaData['contextMetadata']) {
         this.allContexts = Object.keys(this.contextMetaData['contextMetadata']);
       }
-    });
 
-    this.overviewForm = this._formBuilder.group(
-      {
-        experimentName: [null, Validators.required],
-        description: [null],
-        unitOfAssignment: [null, Validators.required],
-        groupType: [null],
-        consistencyRule: [null, Validators.required],
-        designType: [ExperimentDesignTypes.SIMPLE, Validators.required],
-        context: [null, Validators.required],
-        tags: [[]],
-        logging: [false]
-      }
-    );
+      this.overviewForm = this._formBuilder.group(
+        {
+          experimentName: [null, Validators.required],
+          description: [null],
+          unitOfAssignment: [null, Validators.required],
+          groupType: [null],
+          consistencyRule: [null, Validators.required],
+          designType: [ExperimentDesignTypes.SIMPLE, Validators.required],
+          context: [null, Validators.required],
+          tags: [[]],
+          logging: [false]
+        }
+      );
 
-    this.overviewForm.get('unitOfAssignment').valueChanges.subscribe(assignmentUnit => {
-      this.overviewForm.get('consistencyRule').reset();
-      switch (assignmentUnit) {
-        case ASSIGNMENT_UNIT.INDIVIDUAL:
-          this.overviewForm.get('groupType').disable();
-          this.overviewForm.get('groupType').reset();
-          this.consistencyRules = [{ value: CONSISTENCY_RULE.INDIVIDUAL }, { value: CONSISTENCY_RULE.EXPERIMENT }];
-          break;
-        case ASSIGNMENT_UNIT.GROUP:
-          if (this.overviewForm.get('context')) {
-            this.overviewForm.get('groupType').enable();
-            this.overviewForm.get('groupType').setValidators(Validators.required);
-            this.setGroupTypes();
-            this.consistencyRules = [
-              { value: CONSISTENCY_RULE.INDIVIDUAL },
-              { value: CONSISTENCY_RULE.GROUP },
-              { value: CONSISTENCY_RULE.EXPERIMENT }
-            ];
-          } else {
-            this.overviewForm.get('groupType').reset();
+      this.overviewForm.get('unitOfAssignment').valueChanges.subscribe(assignmentUnit => {
+        this.overviewForm.get('consistencyRule').reset();
+        switch (assignmentUnit) {
+          case ASSIGNMENT_UNIT.INDIVIDUAL:
             this.overviewForm.get('groupType').disable();
-          }
-          break;
-      }
-    });
-
-    this.overviewForm.get('context').valueChanges.subscribe(context => {
-      this.currentContext = context;
-      this.experimentService.setCurrentContext(context);
-      this.setGroupTypes();
-    });
-
-    // populate values in form to update experiment if experiment data is available
-    if (this.experimentInfo) {
-      if (this.experimentInfo.state == this.ExperimentState.ENROLLING || this.experimentInfo.state == this.ExperimentState.ENROLLMENT_COMPLETE) {
-        this.overviewForm.disable();
-      }
-      this.currentContext = this.experimentInfo.context[0];
-      const { groupType } = this.setGroupTypeControlValue();
-      this.overviewForm.setValue({
-        experimentName: this.experimentInfo.name,
-        description: this.experimentInfo.description,
-        unitOfAssignment: this.experimentInfo.assignmentUnit,
-        groupType,
-        consistencyRule: this.experimentInfo.consistencyRule,
-        designType: ExperimentDesignTypes.SIMPLE,
-        context: this.currentContext,
-        tags: this.experimentInfo.tags,
-        logging: this.experimentInfo.logging
+            this.overviewForm.get('groupType').reset();
+            this.consistencyRules = [{ value: CONSISTENCY_RULE.INDIVIDUAL }, { value: CONSISTENCY_RULE.EXPERIMENT }];
+            break;
+          case ASSIGNMENT_UNIT.GROUP:
+            if (this.overviewForm.get('context')) {
+              this.overviewForm.get('groupType').enable();
+              this.overviewForm.get('groupType').setValidators(Validators.required);
+              this.setGroupTypes();
+              this.consistencyRules = [
+                { value: CONSISTENCY_RULE.INDIVIDUAL },
+                { value: CONSISTENCY_RULE.GROUP },
+                { value: CONSISTENCY_RULE.EXPERIMENT }
+              ];
+            } else {
+              this.overviewForm.get('groupType').reset();
+              this.overviewForm.get('groupType').disable();
+            }
+            break;
+        }
       });
-      this.checkExperiment();
-    }
+
+      this.overviewForm.get('context').valueChanges.subscribe(context => {
+        this.currentContext = context;
+        this.experimentService.setCurrentContext(context);
+        this.setGroupTypes();
+      });
+
+      // populate values in form to update experiment if experiment data is available
+      if (this.experimentInfo) {
+        // debugger;
+        if (this.experimentInfo.state == this.ExperimentState.ENROLLING || this.experimentInfo.state == this.ExperimentState.ENROLLMENT_COMPLETE) {
+          this.overviewForm.disable();
+        }
+        this.currentContext = this.experimentInfo.context[0];
+        const { groupType } = this.setGroupTypeControlValue();
+        this.overviewForm.setValue({
+          experimentName: this.experimentInfo.name,
+          description: this.experimentInfo.description,
+          unitOfAssignment: this.experimentInfo.assignmentUnit,
+          groupType,
+          consistencyRule: this.experimentInfo.consistencyRule,
+          designType: ExperimentDesignTypes.SIMPLE,
+          context: this.currentContext,
+          tags: this.experimentInfo.tags,
+          logging: this.experimentInfo.logging
+        });
+        this.checkExperiment();
+      }
+    });
   }
 
   setGroupTypeControlValue() {


### PR DESCRIPTION
This change adds some `ngrx` actions for managing pending state for contextMetaData data fetch.
It will also force the experiment stepper to finish loading contextMetaData before proceeding.
In some circumstances they may now see a load-spinner briefly.

This change was necessary to solve for certain situations where the stepper form was loading before data was finished fetching, resulting in incomplete autofill details. #532

ngrx changes implicate a lot of files, but these changes are pretty straightforward i promise.