### PR TITLE
Refine Aliases Table UI

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/aliases-table/aliases-table.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/aliases-table/aliases-table.component.html
@@ -1,16 +1,16 @@
 <section class="aliases-table-component">
   <div class="aliases-header-container">
-    <span class="ft-18-700">{{ 'home.new-experiment.design.aliases.header.text' | translate }}</span>
+    <span class="title">{{ 'home.new-experiment.design.aliases.header.text' | translate }}</span>
     <button
       type="button"
       mat-flat-button
       color="primary"
-      class="ft-14-600"
+      class="ft-14-600 toggle-button"
       (click)="handleHideClick()"
       [disabled]="(isAliasTableEditMode$ | async)"
     >
       <mat-icon class="icon icon-bump-left">expand_less</mat-icon>
-      <span>{{ 'home.new-experiment.design.toggle-actions.conditions' | translate }}</span>
+      <span class="toggle-text">{{ 'home.new-experiment.design.toggle-actions.conditions' | translate }}</span>
     </button>
   </div>
 
@@ -90,7 +90,7 @@
     <!-- Actions Column -->
     <ng-container matColumnDef="actions">
       <mat-header-cell *matHeaderCellDef class="ft-14-700"></mat-header-cell>
-      <mat-cell *matCellDef="let rowData; let rowIndex = index" class="actions-cell">
+      <mat-cell *matCellDef="let rowData; let rowIndex = index" class="actions-cell" style="justify-content: flex-start;">
           <button
             type="button"
             class="row-action-btn"

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/aliases-table/aliases-table.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/aliases-table/aliases-table.component.scss
@@ -5,15 +5,86 @@
     display: flex;  
     justify-content: space-between;
 
-    .icon-bump-left {
-      margin-left: -5px;
+    .title {
+      font-size: 18px;
+      font-weight: bold;
+    }
+    
+    .toggle-button {
+      margin-top: -5px;
+      .icon-bump-left {
+        margin-left: -5px;
+      }
+      .toggle-text {
+        margin-left: 5px;
+      }
     }
   }
 
   .alias-table {
-    width: 100%;
     height: 475px;
     overflow: auto;
+
+    mat-header-row {
+      min-height: 35px;
+      justify-content: space-between;
+    }
+
+    mat-row {
+      min-height: 46px;
+      max-height: 46px;
+      justify-content: space-between;
+    }
+
+    mat-header-cell {
+      justify-content: left;
+      color: var(--grey-6);
+    }
+
+    mat-cell {
+      justify-content: left;
+    }
+
+    .cdk-column-site {
+      flex: 0 0 calc(25% - 15px);
+      width: calc(25% - 15px);
+    }
+
+    .cdk-column-target {
+      flex: 0 0 calc(25% - 15px);
+      width: calc(25% - 15px);
+    }
+
+    .cdk-column-condition {
+      flex: 0 0 calc(25% - 15px);
+      width: calc(25% - 15px);
+    }
+
+    .cdk-column-alias {
+      flex: 0 0 calc(25% - 15px);
+      width: calc(25% - 15px);
+    }
+
+    .cdk-column-actions {
+      flex: 0 0 60px;
+      width: 60px;
+    }
+
+    .icon {
+      margin-top: 2px;
+      margin-left: -6px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-width: 60px;
+      height: 16px;
+      font-size: var(--text-size-x-large);
+      color: gray;
+
+      &:hover {
+        cursor: pointer;
+      }
+    }
 
     .mat-cell:last-of-type {
       justify-content: center;
@@ -22,10 +93,10 @@
         border: none;
         background-color: transparent;
 
-        &:hover {
-          border-radius: 5px;
-          background-color: rgba(224, 224, 224);
-        }
+        // &:hover {
+        //   border-radius: 5px;
+        //   background-color: rgba(224, 224, 224);
+        // }
       }
     }
   }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.html
@@ -6,17 +6,17 @@
       <form class="experiment-design" [formGroup]="experimentDesignForm">
         <section [hidden]="isAliasTableDisplayed" class="simple-experiment-decision-point-conditions-view">
           <div class="decision-point-header-container">
-            <span class="ft-18-700">{{ 'home.new-experiment.design.decision-point.text' | translate }}</span>
+            <span class="title">{{ 'home.new-experiment.design.decision-point.text' | translate }}</span>
             <button
               type="button"
               mat-flat-button
               color="primary"
-              class="ft-14-600"
+              class="ft-14-600 toggle-button"
               (click)="toggleAliasTable()"
               [disabled]="aliasTableData.length === 0 || partition.length === 0 || condition.length === 0"
             >
               <mat-icon class="icon icon-bump-left">expand_more</mat-icon>
-              <span>{{ 'home.new-experiment.design.toggle-actions.aliases' | translate }}</span>
+              <span class="toggle-text">{{ 'home.new-experiment.design.toggle-actions.aliases' | translate }}</span>
             </button>
           </div>
 
@@ -175,7 +175,7 @@
           </div>
 
           <!-- Condition table -->
-          <span class="ft-18-700">{{ 'home.new-experiment.design.condition.text' | translate }}</span>
+          <span class="title">{{ 'home.new-experiment.design.condition.text' | translate }}</span>
           <!-- apply equal condition weights -->
           <div class="conditions-header-container">
             <mat-checkbox

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.scss
@@ -2,22 +2,32 @@
   .simple-experiment-decision-point-conditions-view {
     height: 515px;
 
+    .title {
+      font-size: 18px;
+      font-weight: bold;
+    }
+
     .decision-point-header-container {
       display: flex;
       justify-content: space-between;
   
-      .icon-bump-left {
-        margin-left: -5px;
+      .toggle-button {
+        margin-top: -5px;
+        .icon-bump-left {
+          margin-left: -5px;
+        }
+        .toggle-text {
+          margin-left: 5px;
+        }
       }
     }
 
     .conditions-header-container {
-      margin-top: 5px;
+      margin-top: 10px;
     }
 
     .condition-table,
     .partition-table {
-      margin-top: 5px;
       max-height: 135px;
       overflow: auto;
 
@@ -61,6 +71,10 @@
 
       .cdk-column-excludeIfReached {
         justify-content: center;
+
+        mat-checkbox {
+          margin-top: -5px;
+        }
       }
 
       .cdk-column-conditionCode {
@@ -113,25 +127,36 @@
     }
   }
 
-  .simple-experiment-aliases-view {
-    height: 500px;
-    border: blue 1px solid;
+  // .simple-experiment-aliases-view {
+  //   height: 500px;
+  //   border: blue 1px solid;
 
-    .aliases-header-container {
-      display: flex;  
-      justify-content: space-between;
+  //   .aliases-header-container {
+  //     display: flex;  
+  //     justify-content: space-between;
   
-      .icon-bump-left {
-        margin-left: -5px;
-      }
-    }
+  //     .title {
+  //       font-size: 18px;
+  //       font-weight: bold;
+  //     }
+      
+  //     .toggle-button {
+  //       margin-top: -5px;
+  //       .icon-bump-left {
+  //         margin-left: -5px;
+  //       }
+  //       .toggle-text {
+  //         margin-left: 5px;
+  //       }
+  //     }
+  //   }
 
-    .alias-table {
-      width: 100%;
+  //   .alias-table {
+  //     width: 100%;
 
       
-    }
-  }
+  //   }
+  // }
 
   .validation-container {
     min-height: 30px;

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.scss
@@ -127,37 +127,6 @@
     }
   }
 
-  // .simple-experiment-aliases-view {
-  //   height: 500px;
-  //   border: blue 1px solid;
-
-  //   .aliases-header-container {
-  //     display: flex;  
-  //     justify-content: space-between;
-  
-  //     .title {
-  //       font-size: 18px;
-  //       font-weight: bold;
-  //     }
-      
-  //     .toggle-button {
-  //       margin-top: -5px;
-  //       .icon-bump-left {
-  //         margin-left: -5px;
-  //       }
-  //       .toggle-text {
-  //         margin-left: 5px;
-  //       }
-  //     }
-  //   }
-
-  //   .alias-table {
-  //     width: 100%;
-
-      
-  //   }
-  // }
-
   .validation-container {
     min-height: 30px;
     margin-top: 5px;


### PR DESCRIPTION
Just an update on the style of the tables so that they can look like the Figma prototype and be consistent with other tables.

I didn't work on the scrolling transition yet because it is easier to compare the two tables this way.
I will work on the scrolling transition after this is merged.

Before:
<img width="750" alt="before1" src="https://user-images.githubusercontent.com/90279765/189413347-9ebbea73-7fd7-47ce-8ec2-67bdf226d566.png">

After: (Updated the gap between the header and the table, button/icon position, check boxes position)
<img width="750" alt="after1" src="https://user-images.githubusercontent.com/90279765/189413406-21b67baa-c52f-48ef-97b6-7ef3a5c75b30.png">

Before:
<img width="750" alt="before2" src="https://user-images.githubusercontent.com/90279765/189413362-99a3e482-8cba-44c6-96d3-8576ed403c5e.png">

After: (Updated the gap between the header and the table, column header height, column widths, icon size/color, row height)
<img width="750" alt="after2" src="https://user-images.githubusercontent.com/90279765/189413414-d19bf76d-2f42-4a7f-9650-5cb426e53986.png">