### PR TITLE
Bugfix/equal weight checkbox on edit

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
@@ -141,7 +141,6 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
 
     // populate values in form to update experiment if experiment data is available
     if (this.experimentInfo) {
-      console.log('info', this.experimentInfo)
       this.equalWeightFlag = this.experimentInfo.conditions.every(condition => {
         return 100 / this.experimentInfo.conditions.length === condition.assignmentWeight;
       });

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
@@ -141,8 +141,9 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
 
     // populate values in form to update experiment if experiment data is available
     if (this.experimentInfo) {
+      debugger;
       this.equalWeightFlag = this.experimentInfo.conditions.every(condition => {
-        return 100 / this.experimentInfo.conditions.length === condition.assignmentWeight;
+        return condition.assignmentWeight === this.experimentInfo.conditions[0].assignmentWeight;
       });
       // Remove previously added group of conditions and partitions
       this.condition.removeAt(0);

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
@@ -141,7 +141,10 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
 
     // populate values in form to update experiment if experiment data is available
     if (this.experimentInfo) {
-      this.equalWeightFlag = false;
+      console.log('info', this.experimentInfo)
+      this.equalWeightFlag = this.experimentInfo.conditions.every(condition => {
+        return 100 / this.experimentInfo.conditions.length === condition.assignmentWeight;
+      });
       // Remove previously added group of conditions and partitions
       this.condition.removeAt(0);
       this.partition.removeAt(0);


### PR DESCRIPTION
#532 also, currently the "weighted equally" checkbox is always false when editing an existing experiment. This is probably because the backend isn't sending a value for this, so I added some logic in edit flow to mark it as true manually if all the conditions are actually equal.