### PR TITLE
533 missing validation errors

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.html
@@ -12,6 +12,11 @@
           autocomplete="off"
           cdkFocusInitial
         />
+        <mat-error class = "margin-top-5-px"
+            *ngIf="overviewForm.controls.experimentName.hasError('required')"
+          >
+            {{ 'home.new-experiment.overview.name.error.text' | translate }}
+          </mat-error>
       </mat-form-field>
 
       <mat-form-field class="ft-14-600 description">
@@ -33,7 +38,7 @@
             {{ context }}
           </mat-option>
         </mat-select>
-        <mat-error
+        <mat-error class = "margin-top-5-px"
           *ngIf="overviewForm.controls.context.hasError('required')"
         >
           {{ 'home.new-experiment.overview.context.error.text' | translate }}
@@ -51,7 +56,7 @@
               {{ unitOfAssignment.value | titlecase }}
             </mat-option>
           </mat-select>
-          <mat-error
+          <mat-error class = "margin-top-5-px"
             *ngIf="overviewForm.controls.unitOfAssignment.hasError('required')"
           >
             {{ 'home.new-experiment.overview.unit-of-assignment.error.text' | translate }}
@@ -79,7 +84,7 @@
             {{ consistencyRule.value | titlecase }}
           </mat-option>
         </mat-select>
-        <mat-error
+        <mat-error class = "margin-top-5-px"
           *ngIf="overviewForm.controls.consistencyRule.hasError('required')"
         >
           {{ 'home.new-experiment.overview.consistency-rule.error.text' | translate }}

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.html
@@ -12,11 +12,6 @@
           autocomplete="off"
           cdkFocusInitial
         />
-        <mat-error class = "margin-top-5-px"
-            *ngIf="overviewForm.controls.experimentName.hasError('required')"
-          >
-            {{ 'home.new-experiment.overview.name.error.text' | translate }}
-          </mat-error>
       </mat-form-field>
 
       <mat-form-field class="ft-14-600 description">
@@ -38,11 +33,6 @@
             {{ context }}
           </mat-option>
         </mat-select>
-        <mat-error class = "margin-top-5-px"
-          *ngIf="overviewForm.controls.context.hasError('required')"
-        >
-          {{ 'home.new-experiment.overview.context.error.text' | translate }}
-        </mat-error>
       </mat-form-field>
 
       <div class="property-container">
@@ -56,11 +46,6 @@
               {{ unitOfAssignment.value | titlecase }}
             </mat-option>
           </mat-select>
-          <mat-error class = "margin-top-5-px"
-            *ngIf="overviewForm.controls.unitOfAssignment.hasError('required')"
-          >
-            {{ 'home.new-experiment.overview.unit-of-assignment.error.text' | translate }}
-          </mat-error>
         </mat-form-field>
 
         <mat-form-field class="ft-14-600 group-type" *ngIf="unitOfAssignmentValue">
@@ -68,9 +53,6 @@
           <mat-select class="ft-14-400" formControlName="groupType">
             <mat-option *ngFor="let group of groupTypes" [value]="group.value">{{ group.value }}</mat-option>
           </mat-select>
-          <mat-error *ngIf="overviewForm.controls.groupType.hasError('required')">
-            {{ 'home.new-experiment.overview.group-type.error.text' | translate }}
-          </mat-error>
         </mat-form-field>
       </div>
 
@@ -84,11 +66,6 @@
             {{ consistencyRule.value | titlecase }}
           </mat-option>
         </mat-select>
-        <mat-error class = "margin-top-5-px"
-          *ngIf="overviewForm.controls.consistencyRule.hasError('required')"
-        >
-          {{ 'home.new-experiment.overview.consistency-rule.error.text' | translate }}
-        </mat-error>
       </mat-form-field>
 
       <mat-form-field class="ft-14-600 design-type">

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.scss
@@ -6,10 +6,6 @@
     line-height: 20px;
   }
 
-  .margin-top-5-px {
-    margin-top: -5px
-  }
-
   .name {
     width: 230px;
   }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.scss
@@ -6,6 +6,10 @@
     line-height: 20px;
   }
 
+  .margin-top-5-px {
+    margin-top: -5px
+  }
+
   .name {
     width: 230px;
   }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.ts
@@ -206,6 +206,7 @@ export class ExperimentOverviewComponent implements OnInit, OnDestroy {
         this.emitExperimentDialogEvent.emit({ type: eventType });
         break;
       case NewExperimentDialogEvents.SEND_FORM_DATA:
+        this.overviewForm.markAllAsTouched();
       case NewExperimentDialogEvents.SAVE_DATA:
         if (this.experimentInfo && (this.experimentInfo.state == this.ExperimentState.ENROLLING || this.experimentInfo.state == this.ExperimentState.ENROLLMENT_COMPLETE)) {
           this.emitExperimentDialogEvent.emit({


### PR DESCRIPTION
Triggered validation by touching all form elements on submit. This is what the page looks like now:
<img width="500" alt="Screen Shot 2022-09-09 at 4 16 09 PM" src="https://user-images.githubusercontent.com/97543136/189436064-19383699-c099-445f-8de9-93ec3ccbcd99.png">


To make all fields consistent, I added an error message to the name field but I could also remove all error messages.
<img width="500" alt="Screen Shot 2022-09-09 at 4 09 43 PM" src="https://user-images.githubusercontent.com/97543136/189435312-7565c60d-5643-4e40-8839-3ea50cf817ad.png">
