### PR TITLE
Fix metrics rows margin

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.scss
@@ -23,7 +23,7 @@
 
     mat-cell {
       justify-content: left;
-      margin-bottom: -5px;
+      margin-bottom: -11px;
     }
 
     .metric-keys {
@@ -71,6 +71,9 @@
     .cdk-column-queryName {
       width: 100%;
       max-width: 350px;
+      &.mat-cell {
+        margin-top: -3px;
+      }
     }
 
     .remove-icon {

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.scss
@@ -31,6 +31,7 @@
       flex-direction: column;
       padding: 10px 0;
       width: 250px;
+      margin-bottom: 7px;
 
       .dropdown {
         position: absolute;

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.scss
@@ -81,7 +81,7 @@
       display: flex;
       justify-content: center;
       align-items: center;
-      margin-top: -3px;
+      margin-top: 1px;
       min-width: 60px;
       height: 16px;
       font-size: var(--text-size-x-large);


### PR DESCRIPTION
Just a small fix that makes the row height the same as the other table rows (more compact), and also aligns the text vertically (the display name field and the remove icon were a little off).

Before:
<img width="500" alt="before" src="https://user-images.githubusercontent.com/90279765/190725979-a3b53347-bb54-439c-8b86-86110d861756.png">

After:
<img width="500" alt="after" src="https://user-images.githubusercontent.com/90279765/190728873-776a8c76-d078-470c-826c-211440ac957c.png">
