### PR TITLE
Adding total time inside morgan logger

### DIFF
--- a/backend/packages/Upgrade/src/api/middlewares/LogMiddleware.ts
+++ b/backend/packages/Upgrade/src/api/middlewares/LogMiddleware.ts
@@ -17,6 +17,7 @@ export class LogMiddleware implements ExpressMiddlewareInterface {
     return JSON.stringify({
       remote_address: tokens['remote-addr'](req, res),
       time: tokens['date'](req, res, 'iso'),
+      "total-time": tokens['total-time'](req, res),
       method: tokens['method'](req, res),
       url: tokens['url'](req, res),
       http_version: tokens['http-version'](req, res),


### PR DESCRIPTION
Morgan logs this type of json at the end of the request

```
{
  http_request_id: '00c02d48-4387-4a59-a7d0-3858bdcb6669',
  endpoint: '/favicon.ico',
  request_method_type: 'GET',
  level: 'info',
  message: {
    remote_address: '::1',
    time: '2022-10-13T13:36:33.966Z',
    'total-time': '2.302',
    method: 'GET',
    url: '/favicon.ico',
    http_version: '1.1',
    status_code: '304',
    referrer: 'http://localhost:3030/api/experiments',
    user_agent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36'
  },
  timestamp: '2022-10-13T13:36:33.966Z'
}
```
I have added `total-time` inside the logger