### PR TITLE
Update twoCharacterId generator function

### DIFF
--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -1001,14 +1001,14 @@ export class ExperimentService {
 
   // Used to generate twoCharacterId for condition and decision point
   private getUniqueIdentifier(uniqueIdentifiers: string[]): string {
-    let identifier;
-    while (true) {
-      identifier = Math.random().toString(36).substring(2, 4).toUpperCase();
+    const numCombinations = 36 * 36;
+    while (uniqueIdentifiers.length < numCombinations) {
+      const identifier = Math.random().toString(36).substring(2, 4).toUpperCase();
       if (uniqueIdentifiers.indexOf(identifier) === -1) {
-        break;
+        return identifier;
       }
     }
-    return identifier;
+    return "";
   }
 
   private setConditionOrPartitionIdentifiers(


### PR DESCRIPTION
This could just be a minor improvement but I noticed the `getUniqueIdentifier()` function could potentially cause the app to freeze if there are more than 36 * 36 conditions and decision points (26 capital letters + 10 numbers per character). While it's unlikely to reach this number, I think it's still safe to handle this.

In my updated version, the `getUniqueIdentifier()` function returns an empty string if it reaches the limit instead of causing the app to freeze. I'm not sure if it would be better to throw an error instead of returning an empty string though.

Before:
```
  private getUniqueIdentifier(uniqueIdentifiers: string[]): string {
    let identifier;
    while (true) {
      identifier = Math.random().toString(36).substring(2, 4).toUpperCase();
      if (uniqueIdentifiers.indexOf(identifier) === -1) {
        break;
      }
    }
    return identifier;
  }
```

After:
```
  private getUniqueIdentifier(uniqueIdentifiers: string[]): string {
    const numCombinations = 36 * 36;
    while (uniqueIdentifiers.length < numCombinations) {
      const identifier = Math.random().toString(36).substring(2, 4).toUpperCase();
      if (uniqueIdentifiers.indexOf(identifier) === -1) {
        return identifier;
      }
    }
    return "";
  }
```