### PR TITLE
fix for assign call fail after clearDB

### DIFF
--- a/backend/packages/Upgrade/src/api/repositories/ExperimentRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/ExperimentRepository.ts
@@ -3,6 +3,7 @@ import { Repository, EntityRepository, EntityManager, Brackets } from 'typeorm';
 import { Experiment } from '../models/Experiment';
 import repositoryError from './utils/repositoryError';
 import { UpgradeLogger } from 'src/lib/logger/UpgradeLogger';
+import { createGlobalExcludeSegment } from '../../../src/init/seed/globalExcludeSegment';
 
 @EntityRepository(Experiment)
 export class ExperimentRepository extends Repository<Experiment> {
@@ -221,6 +222,8 @@ export class ExperimentRepository extends Repository<Experiment> {
           await repository.query(`TRUNCATE ${entity.tableName} CASCADE;`);
         }
       }
+      // Create global exclude segment
+      await createGlobalExcludeSegment(logger);
       return 'DB truncate successful';
     } catch (error) {
       error = new Error('DB truncate error. DB truncate unsuccessful');

--- a/backend/packages/Upgrade/test/unit/repositories/ExperimentRepository.test.ts
+++ b/backend/packages/Upgrade/test/unit/repositories/ExperimentRepository.test.ts
@@ -4,6 +4,8 @@ import { ExperimentRepository } from "../../../src/api/repositories/ExperimentRe
 import { Experiment } from "../../../src/api/models/Experiment";
 import { EXPERIMENT_STATE } from "upgrade_types";
 import { UpgradeLogger } from "../../../src/lib/logger/UpgradeLogger";
+import * as globalExcludeSegment from '../../../src/init/seed/globalExcludeSegment';
+
 
 let sandbox;
 let connection;
@@ -20,7 +22,7 @@ const err =  new Error("test error")
 let experiment = new Experiment();
 experiment.id = 'id1';
 
-beforeEach(() => {
+beforeEach(async () => {
     sandbox = sinon.createSandbox();
     
     const repocallback = sinon.stub()
@@ -484,9 +486,12 @@ describe('ExperimentRepository Testing', () => {
         let queryStub = sandbox.stub(ExperimentRepository.prototype, 
             'query').returns(Promise.resolve());
 
+        let segStub = sandbox.stub(globalExcludeSegment, 'createGlobalExcludeSegment').returns(Promise.resolve());
+
         let res = await repo.clearDB(manager, new UpgradeLogger());
 
         sinon.assert.calledOnce(queryStub);
+        sinon.assert.calledOnce(segStub);
         
         expect(res).toEqual('DB truncate successful')
     });


### PR DESCRIPTION
Fix for issue #569 
clearDB removed the default Global Exclude Segment that was returning 500 internal server error if the backend is not restarted.