### PR TITLE
Feature/use no vars with targeted exceptions

### DIFF
--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -613,7 +613,6 @@ export class ExperimentService {
           experiment.partitions = response[0];
           uniqueIdentifiers = response[1];
         }
-        // TODO: Please review this eslint error
 
         const {
           conditions,
@@ -733,7 +732,6 @@ export class ExperimentService {
           (conditions &&
             conditions.length > 0 &&
             conditions.map((condition: ExperimentCondition) => {
-              // TODO: please review this eslint error
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
               const { createdAt, updatedAt, versionNumber, ...rest } = condition;
               rest.experiment = experimentDoc;
@@ -756,7 +754,6 @@ export class ExperimentService {
                   },
                 })
               );
-              // TODO: please review this eslint error
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
               const { createdAt, updatedAt, versionNumber, ...rest } = decisionPoint;
               rest.experiment = experimentDoc;
@@ -772,7 +769,6 @@ export class ExperimentService {
             queries.length > 0 &&
             queries.map((query: any) => {
               promiseArray.push(this.metricRepository.findOne(query.metric.key));
-              // TODO: please review this eslint error
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
               const { createdAt, updatedAt, versionNumber, metric, ...rest } = query;
               rest.experiment = experimentDoc;
@@ -889,7 +885,6 @@ export class ExperimentService {
         const queryDocToReturn =
           !!queryDocs &&
           queryDocs.map((queryDoc, index) => {
-            // TODO: please review this eslint error
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const { metricKey, ...rest } = queryDoc as any;
             return { ...rest, metric: queriesDocToSave[index].metric };
@@ -1175,14 +1170,12 @@ export class ExperimentService {
       const includeTempDoc = new ExperimentSegmentInclusion();
       includeTempDoc.segment = segmentIncludeDoc;
       includeTempDoc.experiment = experimentDoc;
-      // TODO: Please review this eslint error
       var { createdAt, updatedAt, versionNumber, ...segmentIncludeDocToSave } = includeTempDoc;
 
       // creating segmentExclude doc
       const excludeTempDoc = new ExperimentSegmentExclusion();
       excludeTempDoc.segment = segmentExcludeDoc;
       excludeTempDoc.experiment = experimentDoc;
-      // TODO: Please review this eslint error
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       var { createdAt, updatedAt, versionNumber, ...segmentExcludeDocToSave } = excludeTempDoc;
       // creating queries docs
@@ -1192,7 +1185,6 @@ export class ExperimentService {
           queries.length > 0 &&
           queries.map((query: any) => {
             promiseArray.push(this.metricRepository.findOne(query.metric.key));
-            // TODO: please review this eslint error
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const { createdAt, updatedAt, versionNumber, metric, ...rest } = query;
             rest.experiment = experimentDoc;
@@ -1251,13 +1243,11 @@ export class ExperimentService {
         throw error;
       }
       const conditionDocToReturn = conditionDocs.map((conditionDoc) => {
-        // TODO: please review this eslint error
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { experimentId, ...restDoc } = conditionDoc as any;
         return restDoc;
       });
       const decisionPointDocToReturn = decisionPointDocs.map((decisionPointDoc) => {
-        // TODO: please review this eslint error
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { experimentId, ...restDoc } = decisionPointDoc as any;
         return restDoc;

--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -1170,14 +1170,13 @@ export class ExperimentService {
       const includeTempDoc = new ExperimentSegmentInclusion();
       includeTempDoc.segment = segmentIncludeDoc;
       includeTempDoc.experiment = experimentDoc;
-      var { createdAt, updatedAt, versionNumber, ...segmentIncludeDocToSave } = includeTempDoc;
+      const segmentIncludeDocToSave = this.getSegmentDoc(includeTempDoc);
 
       // creating segmentExclude doc
       const excludeTempDoc = new ExperimentSegmentExclusion();
       excludeTempDoc.segment = segmentExcludeDoc;
       excludeTempDoc.experiment = experimentDoc;
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      var { createdAt, updatedAt, versionNumber, ...segmentExcludeDocToSave } = excludeTempDoc;
+      const segmentExcludeDocToSave = this.getSegmentDoc(excludeTempDoc);
       // creating queries docs
       const promiseArray = [];
       let queryDocsToSave =
@@ -1357,5 +1356,11 @@ export class ExperimentService {
       });
     });
     return { ...experiment, conditionAliases: conditionAlias };
+  }
+
+  private getSegmentDoc(doc: ExperimentSegmentExclusion | ExperimentSegmentInclusion) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { createdAt, updatedAt, versionNumber, ...newDoc } = doc;
+    return newDoc;
   }
 }

--- a/backend/packages/Upgrade/src/api/services/ExperimentUserService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentUserService.ts
@@ -252,7 +252,6 @@ export class ExperimentUserService {
           return userDoc[0].originalUser;
         } else {
           // If user is original user
-          // TODO: please review this eslint error
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const { originalUser, ...rest } = userDoc[0];
           return rest as any;

--- a/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
+++ b/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
@@ -134,7 +134,6 @@ export class FeatureFlagService {
       }
 
       const variationDocToReturn = variationDocs.map((variationDoc) => {
-        // TODO: please review this eslint error
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { featureFlagId, ...rest } = variationDoc as any;
         return rest;
@@ -155,7 +154,6 @@ export class FeatureFlagService {
     const oldVariations = oldFeatureFlag[0].variations;
 
     return getConnection().transaction(async (transactionalEntityManager) => {
-      // TODO: please review this eslint error
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { variations, versionNumber, createdAt, updatedAt, ...flagDoc } = flag;
       let featureFlagDoc: FeatureFlag;
@@ -173,7 +171,6 @@ export class FeatureFlagService {
         (variations &&
           variations.length > 0 &&
           variations.map((variation: FlagVariation) => {
-            // TODO: please review this eslint error
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const { createdAt, updatedAt, versionNumber, ...rest } = variation;
             rest.featureFlag = featureFlagDoc;
@@ -215,7 +212,6 @@ export class FeatureFlagService {
       }
 
       const variationDocToReturn = variationDocs.map((variationDoc) => {
-        // TODO: please review this eslint error
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { featureFlagId, ...rest } = variationDoc as any;
         return { ...rest, featureFlag: variationDoc.featureFlag };

--- a/backend/packages/Upgrade/src/api/services/PreviewUserService.ts
+++ b/backend/packages/Upgrade/src/api/services/PreviewUserService.ts
@@ -88,7 +88,6 @@ export class PreviewUserService {
       (newAssignments &&
         newAssignments.length > 0 &&
         newAssignments.map((assignment: ExplicitIndividualAssignment) => {
-          // TODO: please review this eslint error
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const { createdAt, updatedAt, versionNumber, ...rest } = assignment;
           rest.previewUser = previewUser;

--- a/clientlibs/js/src/functions/addMetrics.ts
+++ b/clientlibs/js/src/functions/addMetrics.ts
@@ -18,6 +18,7 @@ export default async function addMetrics(
     );
     if (response.status) {
       response.data = response.data.map((metric) => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { createdAt, updatedAt, versionNumber, ...rest } = metric;
         return rest;
       });

--- a/clientlibs/js/src/functions/getAllfeatureFlags.ts
+++ b/clientlibs/js/src/functions/getAllfeatureFlags.ts
@@ -11,6 +11,7 @@ export default async function getAllFeatureFlags(
     const featureFlagResponse = await fetchDataService(url, token, clientSessionId, {}, Types.REQUEST_TYPES.GET);
     if (featureFlagResponse.status) {
       return featureFlagResponse.data.map((flag) => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { createdAt, updatedAt, versionNumber, variations, ...rest } = flag;
         const updatedVariations = variations.map((variation) => {
           const {


### PR DESCRIPTION
this is mostly disabling eslint `use-no-vars` for a particular pattern when we are doing this kind of thing where we use deconstruction pattern to create a new object with only the properties we want. We had an exception already for this in `tslint` in some places, and I think that's probably okay for this. it's a pretty useful pattern to know, as other methods of stripping out properties doing this are pretty clunky, so it's a good place for an exception:

```
const { experimentId, ...rest } = decisionPointDoc;
return rest;
```

BUT this pattern can still cause problems... This does fix a spot though where this usage was not safe because the "unused" vars that are left behind in this pattern caused namespace conflicts, so it's not a rule we want to ignore unless we're sure it's fine.