### PR TITLE
Reduce the space between the tabs on the experiment details page

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.scss
@@ -283,8 +283,12 @@ $font-size-small: 15px;
     font-size: 22px;
     font-weight: 600;
     line-height: 48px;
-    margin: 28px 18px 21px 32px;
+    margin: 28px 0px 21px 0px;
     padding: 0px;
+
+    &:first-of-type {
+      margin-left: 34px;
+    }
   }
 
   .mat-tab-label-active {


### PR DESCRIPTION
We've decided to reduce the space between the tabs on the experiment details page to look more consistent with the tab space on the Logs page and make all the tabs visible in the demo app.

Before:
<img width="750" alt="before" src="https://user-images.githubusercontent.com/90279765/202757134-13f8a2b7-40a0-4937-8047-08da1e6f01d6.png">

After:
<img width="750" alt="after" src="https://user-images.githubusercontent.com/90279765/202757150-5a3fa9ac-a1af-4863-91e0-ed4c569cbf11.png">

Demo app (after change):
<img width="750" alt="Screen Shot 2022-11-18 at 11 45 41 AM" src="https://user-images.githubusercontent.com/90279765/202757482-e4841d42-8870-4086-b3db-e54fd4088d46.png">
