### PR TITLE
added themed alias table shading

### DIFF
--- a/frontend/projects/upgrade/src/app/core/experiments/store/experiments.model.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/store/experiments.model.ts
@@ -207,6 +207,7 @@ export interface ExperimentAliasTableRow {
   condition: string;
   alias: string;
   isEditing: boolean;
+  rowStyle?: 'odd' | 'even';
 }
 
 export const NUMBER_OF_EXPERIMENTS = 20;

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/aliases-table/aliases-table.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/aliases-table/aliases-table.component.html
@@ -14,7 +14,7 @@
     </button>
   </div>
 
-  <mat-table [dataSource]="aliasTableData$" class="alias-table">
+  <mat-table [dataSource]="aliasTableData$" class="alias-table-design-stepper">
     <!-- Site Column -->
     <ng-container matColumnDef="site">
       <mat-header-cell *matHeaderCellDef class="ft-14-700">
@@ -111,6 +111,6 @@
     </ng-container>
 
     <mat-header-row *matHeaderRowDef="aliasesDisplayedColumns"></mat-header-row>
-    <mat-row *matRowDef="let row; columns: aliasesDisplayedColumns"></mat-row>
+    <mat-row *matRowDef="let row; columns: aliasesDisplayedColumns" [ngClass]="row?.rowStyle"></mat-row>
   </mat-table>
 </section>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/aliases-table/aliases-table.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/aliases-table/aliases-table.component.scss
@@ -21,7 +21,7 @@
     }
   }
 
-  .alias-table {
+  .alias-table-design-stepper {
     height: 475px;
     overflow: auto;
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/aliases-table/aliases-table.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/aliases-table/aliases-table.component.ts
@@ -102,7 +102,7 @@ export class AliasesTableComponent implements OnInit, OnDestroy {
     const aliasTableData: ExperimentAliasTableRow[] = [];
     const useExistingAliasData = !!(conditionAliases && this.initialLoad);
 
-    decisionPoints.forEach((decisionPoint) => {
+    decisionPoints.forEach((decisionPoint, index) => {
       conditions.forEach((condition) => {
         // check the list of condtionAliases, if exist, to see if this parentCondition has an alias match
         let existingAlias: ExperimentConditionAlias = null;
@@ -123,6 +123,7 @@ export class AliasesTableComponent implements OnInit, OnDestroy {
           condition: condition.conditionCode,
           alias: existingAlias?.aliasName || condition.conditionCode,
           isEditing: false,
+          rowStyle: index % 2 === 0 ? 'even' : 'odd',
         });
       });
     });

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/aliases-table/aliases-table.theme.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/aliases-table/aliases-table.theme.scss
@@ -1,0 +1,9 @@
+@use '@angular/material' as mat;
+
+@mixin aliases-table-component-theme($theme) {
+  $background: map-get($theme, background);
+
+  .alias-table-design-stepper .mat-row.even {
+    background-color: mat.get-color-from-palette($background, table-shading);
+  }
+}

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
@@ -493,7 +493,7 @@
           <div class="table-container table-container-aliases">
             <span class="ft-24-700">{{ 'home.view-experiment.experiment-aliases-title.text' | translate }}</span>
             <ng-container *ngIf="aliasTableData.length">
-              <mat-table [dataSource]="aliasTableData" class="table alias-table">
+              <mat-table [dataSource]="aliasTableData" class="table alias-table-overview">
                 <ng-container matColumnDef="site">
                   <mat-header-cell class="ft-12-700" *matHeaderCellDef>
                     {{ 'home.view-experiment.experiment-aliases.column-label.site' | translate }}
@@ -539,7 +539,7 @@
                 </ng-container>
 
                 <mat-header-row *matHeaderRowDef="displayedAliasConditionColumns"></mat-header-row>
-                <mat-row *matRowDef="let row; columns: displayedAliasConditionColumns"></mat-row>
+                <mat-row *matRowDef="let row; columns: displayedAliasConditionColumns" [ngClass]="row?.rowStyle"></mat-row>
               </mat-table>
             </ng-container>
           </div>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.scss
@@ -324,7 +324,7 @@ $font-size-small: 15px;
       }
     }
 
-    &-aliases .alias-table {
+    &-aliases .alias-table-overview {
       justify-content: space-between;
 
       .mat-header-cell {

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.ts
@@ -169,7 +169,7 @@ export class ViewExperimentComponent implements OnInit, OnDestroy {
         this.experiment.experimentSegmentExclusion.segment.subSegments.forEach((id) => {
           this.excludeParticipants.push({ participant_Type: MemberTypes.SEGMENT, participant_id: id.name });
         });
-      } else if(this.experiment.experimentSegmentExclusion?.segment){
+      } else if (this.experiment.experimentSegmentExclusion?.segment) {
         this.experiment.experimentSegmentExclusion.segment.individualForSegment.forEach((id) => {
           this.includeParticipants.push({ participant_Type: MemberTypes.INDIVIDUAL, participant_id: id.userId });
         });
@@ -219,7 +219,7 @@ export class ViewExperimentComponent implements OnInit, OnDestroy {
 
     let existingAlias: ExperimentConditionAlias;
 
-    decisionPoints.forEach((decisionPoint) => {
+    decisionPoints.forEach((decisionPoint, index) => {
       conditions.forEach((condition) => {
         existingAlias = conditionAliases.find(
           (alias) =>
@@ -235,6 +235,7 @@ export class ViewExperimentComponent implements OnInit, OnDestroy {
           condition: condition.conditionCode,
           alias: existingAlias?.aliasName || condition.conditionCode,
           isEditing: false,
+          rowStyle: index % 2 === 0 ? 'even' : 'odd',
         });
       });
     });

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.theme.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.theme.scss
@@ -79,4 +79,8 @@
   .owl-dt-calendar-table .owl-dt-calendar-header .owl-dt-calendar-table-divider:after {
     border-bottom: 1px solid mat.get-color-from-palette($background, shadow-color);
   }
+
+  .alias-table-overview .mat-row.even {
+    background-color: mat.get-color-from-palette($background, table-shading);
+  }
 }

--- a/frontend/projects/upgrade/src/styles.scss
+++ b/frontend/projects/upgrade/src/styles.scss
@@ -17,6 +17,7 @@
 @import './app/features/dashboard/home/components/modal/experiment-status/experiment-status.theme.scss';
 @import './app/features/dashboard/home/components/modal/post-experiment-rule/post-experiment-rule.theme.scss';
 @import './app/features/dashboard/home/components/experiment-design/experiment-design.theme.scss';
+@import './app/features/dashboard/home/components/experiment-design/aliases-table/aliases-table.theme.scss';
 @import './app/features/dashboard/home/components/enrollment-over-time/enrollment-over-time.theme.scss';
 @import './app/features/dashboard/home/components/modal/new-experiment/new-experiment.theme.scss';
 @import './app/features/dashboard/profile/components/profile-info/profile-info.theme.scss';
@@ -54,6 +55,7 @@
   @include experiment-status-component-theme($theme);
   @include post-experiment-rule-component-theme($theme);
   @include experiment-design-component-theme($theme);
+  @include aliases-table-component-theme($theme);
   @include enrollment-over-time-component-theme($theme);
   @include new-experiment-component-theme($theme);
   @include experiment-users-component-theme($theme);

--- a/frontend/projects/upgrade/src/themes/dark-theme.scss
+++ b/frontend/projects/upgrade/src/themes/dark-theme.scss
@@ -71,6 +71,7 @@ mat.$red-palette: (
 $background-color: #111111;
 $card-dialog-color: #1d1d1d;
 $shadow-color: #000000;
+$table-shading: #333;
 $chart-border: rgba(255, 255, 255, 0.12);
 
 $primary: mat.define-palette(mat.$blue-palette);
@@ -89,6 +90,7 @@ $background: map_merge(
     card: $card-dialog-color,
     dialog: $card-dialog-color,
     shadow-color: $shadow-color,
+    table-shading: $table-shading
   )
 );
 $foreground: map_merge(

--- a/frontend/projects/upgrade/src/themes/light-theme.scss
+++ b/frontend/projects/upgrade/src/themes/light-theme.scss
@@ -70,6 +70,7 @@ mat.$red-palette: (
 // Background colors for light themes.
 $background-color: #f0f2f9;
 $shadow-color: rgba(0, 0, 0, 0.12);
+$table-shading: #f5f5f5;
 $chart-border: #ddd;
 
 // Foreground colors for light themes.
@@ -90,6 +91,7 @@ $background: map_merge(
   (
     background: $background-color,
     shadow-color: $shadow-color,
+    table-shading: $table-shading
   )
 );
 $foreground: map_merge(


### PR DESCRIPTION
- Adds shading to visually highlight site + target groupings on alias table on overview page and stepper page.
- Uses $theme to make sure this works for both light and dark themes.
- Set up to be reusable for other tables if we want shading used elsewhere.

<img width="1008" alt="Screen Shot 2022-12-02 at 5 17 28 PM" src="https://user-images.githubusercontent.com/97542869/205399602-6e08d8e7-77c6-4e5d-af73-82882f7e9bde.png">
<img width="1792" alt="Screen Shot 2022-12-02 at 5 17 13 PM" src="https://user-images.githubusercontent.com/97542869/205399604-5526bce5-359d-4057-8bce-2ee9b6ebb139.png">
<img width="1012" alt="Screen Shot 2022-12-02 at 5 16 57 PM" src="https://user-images.githubusercontent.com/97542869/205399606-17b57fb2-095f-4f81-9330-ecae122b6435.png">
<img width="1792" alt="Screen Shot 2022-12-02 at 5 16 27 PM" src="https://user-images.githubusercontent.com/97542869/205399607-575d3d74-59f2-405d-a2c6-a879ff4f0921.png">
