### PR TITLE
Set the exported experiment's status to inactive

### DIFF
--- a/frontend/projects/upgrade/src/app/core/experiments/store/experiments.effects.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/store/experiments.effects.ts
@@ -45,6 +45,7 @@ import { interval } from 'rxjs';
 import { selectCurrentUser } from '../../auth/store/auth.selectors';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ENV, Environment } from '../../../../environments/environment-types';
+import { EXPERIMENT_STATE } from 'upgrade_types';
 import JSZip from 'jszip';
 
 @Injectable()
@@ -486,6 +487,7 @@ export class ExperimentEffects {
                 this.download('Experiments.zip', content, true);
               });
             } else {
+              data[0].state = EXPERIMENT_STATE.INACTIVE;
               this.download(data[0].name + '.json', data[0], false);
             }
             return experimentAction.actionExportExperimentDesignSuccess();


### PR DESCRIPTION
This PR fixes the https://github.com/CarnegieLearningWeb/UpGrade/issues/644

It seems to work fine but I'm not sure if this is the proper way to do it.