### PR TITLE
Set the imported experiment's status to inactive

### DIFF
--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -422,6 +422,9 @@ export class ExperimentService {
         uniqueIdentifiers = [...uniqueIdentifiers, twoCharacterId];
         return decisionPoint;
       });
+
+      // Always set the imported experiment to "inactive".
+      experiment.state = EXPERIMENT_STATE.INACTIVE;
     }
     return this.addBulkExperiments(experiments, user, logger);
   }


### PR DESCRIPTION
This PR fixes the https://github.com/CarnegieLearningWeb/UpGrade/issues/644

It seems to work fine but please check if this is the proper way to do it.