### PR TITLE
remove unneccesary and breaking conditional

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.ts
@@ -118,10 +118,7 @@ export class ViewExperimentComponent implements OnInit, OnDestroy {
         ),
         filter(
           ({ isLoadingDetails, experiment }) =>
-            !isLoadingDetails &&
-            !!experiment?.partitions?.length &&
-            !!experiment?.conditions?.length &&
-            !!experiment?.conditionAliases?.length
+            !isLoadingDetails && !!experiment?.partitions?.length && !!experiment?.conditions?.length
         )
       )
       .subscribe(({ experiment, isPolling }) => {


### PR DESCRIPTION
this correct my recent change w/ alias tables, it was making experiments that had no conditionAliases show as a blank page, it was incorrectly filtering out valid experiments and thus the experiment data was undefined