### PR TITLE
Don't fetch enviroment.json when environment.prod.ts is used

### DIFF
--- a/frontend/projects/upgrade/src/app/app.module.ts
+++ b/frontend/projects/upgrade/src/app/app.module.ts
@@ -16,7 +16,7 @@ import { ENV, Environment } from '../environments/environment-types';
 export const getEnvironmentConfig = (http: HttpClient, env: Environment) => {
   // in non-prod build, all env vars can be provided on .environment.ts,
   // so skip fetch
-  if (!environment.production) {
+  if (!environment.production || (environment.apiBaseUrl && environment.gapiClientId)) {
     return () => Promise.resolve();
   }
 


### PR DESCRIPTION
@danoswaltCL suggested this change.

Currently, UpGrade tries to fetch the `environment.json` file when `environment.production` is set to `true`. But the user might not use `environment.json` because the `apiBaseUrl` and `gapiClientId` can be set through the `environment.prod.ts` file instead, and we don't want the user to get undefined errors (e.g. undefined `endpointApi`) when the following code is executed while the `environment.json` file is missing.
```
return () =>
    http
      .get('/environment.json')
      .toPromise()
      .then((data) => {
        env.apiBaseUrl = (data as any).endpointApi;
        env.gapiClientId = (data as any).gapiClientId;
      })
      .catch((error) => {
        console.log({ error });
      });
```

So this change basically prevents executing the above code when it is for production and the `apiBaseUrl` and `gapiClientId` are already set through the `environment.prod.ts` file.

In other words, if `apiBaseUrl` and `gapiClientId` are empty in [environment.prod.ts](https://github.com/CarnegieLearningWeb/UpGrade/blob/dev/frontend/projects/upgrade/src/environments/environment.prod.ts) which is the default, the `environment.json` file will be fetched to set them in production mode. Otherwise, the `environment.json` file won't be fetched because it's not needed.