### PR TITLE
Rename Defined Metrics to Metrics in the details page

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
@@ -640,7 +640,7 @@
         <div class="tab-body-container tab-table-body-container">
           <!-- Experiment metrics table -->
           <div class="table-container table-container-metrics">
-            <span class="ft-24-700">{{ 'home.view-experiment.mattab.metrics.tabletitle.text' | translate }}</span>
+            <span class="ft-24-700">{{ 'home.view-experiment.mattab.metrics.text' | translate }}</span>
             <mat-table [dataSource]="displayMetrics" class="table">
               <!-- Metrics Column -->
               <ng-container matColumnDef="metricsKey">

--- a/frontend/projects/upgrade/src/assets/i18n/en.json
+++ b/frontend/projects/upgrade/src/assets/i18n/en.json
@@ -218,7 +218,6 @@
   "home.view-experiment.mattab.design.text": "Design",
   "home.view-experiment.mattab.participants.text": "Participants",
   "home.view-experiment.mattab.metrics.text": "Metrics",
-  "home.view-experiment.mattab.metrics.tabletitle.text": "Defined Metrics",
   "home.import-experiment.message.text": "Select the JSON to import experiment:",
   "home.import-experiment.error.message.text": "Invalid Experiment JSON data",
   "home.import-experiment.version-error.message.text": "Imported experiment version is older/newer than current version. Some parts may not function as intended. (Still you can import it)",


### PR DESCRIPTION
Related to: https://github.com/CarnegieLearningWeb/UpGrade/issues/414

Currently, the title for the Metrics tab on the details page is "Defined Metrics", but we've decided to change this to "Metrics" for consistency.

Before:
<img width="750" alt="Screen Shot 2022-12-08 at 12 28 42 PM" src="https://user-images.githubusercontent.com/90279765/206522089-eb747f6b-2787-4af0-84ff-cc8ee940d065.png">

After:
<img width="750" alt="Screen Shot 2022-12-08 at 12 31 39 PM" src="https://user-images.githubusercontent.com/90279765/206522714-a6151856-6134-4975-b517-a32ab23c826e.png">

Latest Figma Design (Future design):
<img width="750" alt="Experiment Detail - Metrics (Inactive) 1" src="https://user-images.githubusercontent.com/90279765/206522768-41a71b2e-4ccb-4e22-a0bd-a798751b2055.png">
