### PR TITLE
Add Edit Mode to the Decision Points table

### DIFF
--- a/frontend/projects/upgrade/src/app/core/experiment-design-stepper/experiment-design-stepper.service.ts
+++ b/frontend/projects/upgrade/src/app/core/experiment-design-stepper/experiment-design-stepper.service.ts
@@ -10,14 +10,17 @@ import {
 import * as experimentDesignStepperAction from './store/experiment-design-stepper.actions';
 import {
   selectAliasTableEditIndex,
+  selectDecisionPointsEditModePreviousRowData,
   selectConditionsEditModePreviousRowData,
+  selectDecisionPointsTableEditIndex,
   selectConditionsTableEditIndex,
   selecthasExperimentStepperDataChanged,
   selectIsAliasTableEditMode,
+  selectIsDecisionPointsTableEditMode,
   selectIsConditionsTableEditMode,
   selectIsFormLockedForEdit,
 } from './store/experiment-design-stepper.selectors';
-import { ConditionsTableRowData, ExperimentAliasTableRow } from './store/experiment-design-stepper.model';
+import { ConditionsTableRowData, DecisionPointsTableRowData, ExperimentAliasTableRow } from './store/experiment-design-stepper.model';
 
 @Injectable({
   providedIn: 'root',
@@ -28,6 +31,11 @@ export class ExperimentDesignStepperService {
   hasExperimentStepperDataChanged$ = this.store$.pipe(select(selecthasExperimentStepperDataChanged));
   isAliasTableEditMode$ = this.store$.pipe(select(selectIsAliasTableEditMode));
   aliasTableEditIndex$ = this.store$.pipe(select(selectAliasTableEditIndex));
+
+  isDecisionPointsTableEditMode$ = this.store$.pipe(select(selectIsDecisionPointsTableEditMode));
+  decisionPointsTableEditIndex$ = this.store$.pipe(select(selectDecisionPointsTableEditIndex));
+  decisionPointsEditModePreviousRowData$ = this.store$.pipe(select(selectDecisionPointsEditModePreviousRowData));
+
   isConditionsTableEditMode$ = this.store$.pipe(select(selectIsConditionsTableEditMode));
   conditionsTableEditIndex$ = this.store$.pipe(select(selectConditionsTableEditIndex));
   conditionsEditModePreviousRowData$ = this.store$.pipe(select(selectConditionsEditModePreviousRowData));
@@ -128,6 +136,15 @@ export class ExperimentDesignStepperService {
     );
   }
 
+  setDecisionPointTableEditModeDetails(rowIndex: number, rowData: DecisionPointsTableRowData): void {
+    this.store$.dispatch(
+      experimentDesignStepperAction.actionToggleDecisionPointsTableEditMode({
+        decisionPointsTableEditIndex: rowIndex,
+        decisionPointsRowData: rowData,
+      })
+    );
+  }
+
   setConditionTableEditModeDetails(rowIndex: number, rowData: ConditionsTableRowData): void {
     this.store$.dispatch(
       experimentDesignStepperAction.actionToggleConditionsTableEditMode({
@@ -135,6 +152,10 @@ export class ExperimentDesignStepperService {
         conditionsRowData: rowData,
       })
     );
+  }
+
+  clearDecisionPointTableEditModeDetails(): void {
+    this.store$.dispatch(experimentDesignStepperAction.actionClearDecisionPointTableEditDetails());
   }
 
   clearConditionTableEditModeDetails(): void {

--- a/frontend/projects/upgrade/src/app/core/experiment-design-stepper/store/experiment-design-stepper.actions.ts
+++ b/frontend/projects/upgrade/src/app/core/experiment-design-stepper/store/experiment-design-stepper.actions.ts
@@ -1,14 +1,23 @@
 import { createAction, props } from '@ngrx/store';
-import { ConditionsTableRowData } from './experiment-design-stepper.model';
+import { DecisionPointsTableRowData, ConditionsTableRowData } from './experiment-design-stepper.model';
 
 export const actionUpdateAliasTableEditMode = createAction(
   '[Experiment-Design-Stepper] Update Alias Table Edit Mode Details',
   props<{ isAliasTableEditMode: boolean; aliasTableEditIndex: number | null }>()
 );
 
+export const actionToggleDecisionPointsTableEditMode = createAction(
+  '[Experiment-Design-Stepper] Update Decision Points Table Edit Mode Details',
+  props<{ decisionPointsTableEditIndex: number | null; decisionPointsRowData: DecisionPointsTableRowData }>()
+);
+
 export const actionToggleConditionsTableEditMode = createAction(
   '[Experiment-Design-Stepper] Update Conditions Table Edit Mode Details',
   props<{ conditionsTableEditIndex: number | null; conditionsRowData: ConditionsTableRowData }>()
+);
+
+export const actionClearDecisionPointTableEditDetails = createAction(
+  `[Experiment-Design-Stepper] Clear Decision Point Table Edit Details`
 );
 
 export const actionClearConditionTableEditDetails = createAction(

--- a/frontend/projects/upgrade/src/app/core/experiment-design-stepper/store/experiment-design-stepper.model.ts
+++ b/frontend/projects/upgrade/src/app/core/experiment-design-stepper/store/experiment-design-stepper.model.ts
@@ -18,6 +18,13 @@ export interface ExperimentAliasTableRow {
   rowStyle?: 'odd' | 'even';
 }
 
+export interface DecisionPointsTableRowData {
+  site: string;
+  target: string;
+  excludeIfReached: boolean;
+  order: number;
+}
+
 export interface ConditionsTableRowData {
   conditionCode: string;
   assignmentWeight: string;
@@ -27,10 +34,13 @@ export interface ConditionsTableRowData {
 
 export interface ExperimentDesignStepperState {
   isAliasTableEditMode: boolean;
+  isDecisionPointsTableEditMode: boolean;
   isConditionsTableEditMode: boolean;
   aliasTableEditIndex: number | null;
+  decisionPointsTableEditIndex: number | null;
   conditionsTableEditIndex: number | null;
   hasExperimentStepperDataChanged: boolean;
+  decisionPointsEditModePreviousRowData: DecisionPointsTableRowData;
   conditionsEditModePreviousRowData: ConditionsTableRowData;
 }
 

--- a/frontend/projects/upgrade/src/app/core/experiment-design-stepper/store/experiment-design-stepper.reducer.ts
+++ b/frontend/projects/upgrade/src/app/core/experiment-design-stepper/store/experiment-design-stepper.reducer.ts
@@ -4,9 +4,12 @@ import * as experimentDesignStepperAction from './experiment-design-stepper.acti
 
 const initialState: ExperimentDesignStepperState = {
   isAliasTableEditMode: false,
+  isDecisionPointsTableEditMode: false,
   isConditionsTableEditMode: false,
   aliasTableEditIndex: null,
+  decisionPointsTableEditIndex: null,
   conditionsTableEditIndex: null,
+  decisionPointsEditModePreviousRowData: null,
   conditionsEditModePreviousRowData: null,
   hasExperimentStepperDataChanged: false,
 };
@@ -28,6 +31,30 @@ const reducer = createReducer(
   on(experimentDesignStepperAction.experimentStepperDataReset, (state) => ({
     ...state,
     hasExperimentStepperDataChanged: false,
+  })),
+  on(
+    experimentDesignStepperAction.actionToggleDecisionPointsTableEditMode,
+    (state, { decisionPointsTableEditIndex, decisionPointsRowData }) => {
+      // toggle edit mode
+      const editMode = !state.isDecisionPointsTableEditMode;
+
+      // if not in edit mode, use null for row-index
+      const editIndex = editMode ? decisionPointsTableEditIndex : null;
+      const previousRowData = editMode ? decisionPointsRowData : null;
+
+      return {
+        ...state,
+        isDecisionPointsTableEditMode: editMode,
+        decisionPointsTableEditIndex: editIndex,
+        decisionPointsEditModePreviousRowData: previousRowData,
+      };
+    }
+  ),
+  on(experimentDesignStepperAction.actionClearDecisionPointTableEditDetails, (state) => ({
+    ...state,
+    isDecisionPointsTableEditMode: false,
+    decisionPointsTableEditIndex: null,
+    decisionPointsEditModePreviousRowData: null,
   })),
   on(
     experimentDesignStepperAction.actionToggleConditionsTableEditMode,

--- a/frontend/projects/upgrade/src/app/core/experiment-design-stepper/store/experiment-design-stepper.selectors.ts
+++ b/frontend/projects/upgrade/src/app/core/experiment-design-stepper/store/experiment-design-stepper.selectors.ts
@@ -20,6 +20,21 @@ export const selecthasExperimentStepperDataChanged = createSelector(
   (state) => state.hasExperimentStepperDataChanged
 );
 
+export const selectIsDecisionPointsTableEditMode = createSelector(
+  selectExperimentDesignStepperState,
+  (state) => state.isDecisionPointsTableEditMode
+);
+
+export const selectDecisionPointsTableEditIndex = createSelector(
+  selectExperimentDesignStepperState,
+  (state) => state.decisionPointsTableEditIndex
+);
+
+export const selectDecisionPointsEditModePreviousRowData = createSelector(
+  selectExperimentDesignStepperState,
+  (state) => state.decisionPointsEditModePreviousRowData
+);
+
 export const selectIsConditionsTableEditMode = createSelector(
   selectExperimentDesignStepperState,
   (state) => state.isConditionsTableEditMode
@@ -31,7 +46,7 @@ export const selectConditionsTableEditIndex = createSelector(
 );
 
 export const selectIsFormLockedForEdit = createSelector(selectExperimentDesignStepperState, (state) => {
-  const lockSources = [state.isAliasTableEditMode, state.isConditionsTableEditMode];
+  const lockSources = [state.isAliasTableEditMode, state.isDecisionPointsTableEditMode, state.isConditionsTableEditMode];
   return lockSources.some((lockSource) => !!lockSource);
 });
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.html
@@ -39,24 +39,31 @@
                   {{ 'home.new-experiment.design.partition-point.text' | translate }}
                 </mat-header-cell>
                 <mat-cell *matCellDef="let element; let groupIndex = index" [formGroupName]="groupIndex">
-                  <mat-form-field floatLabel="never">
-                    <span
-                      [matTooltip]="experimentDesignForm.getRawValue('site')?.partitions[groupIndex]?.site"
-                      matTooltipPosition="above"
-                    >
-                      <input
-                        matInput
-                        [placeholder]="'home.new-experiment.design.partition-point.placeholder.text' | translate"
-                        formControlName="site"
-                        [matAutocomplete]="autoCompleteExperimentPoints"
-                      />
-                      <mat-autocomplete #autoCompleteExperimentPoints="matAutocomplete" panelWidth="fit-content">
-                        <mat-option *ngFor="let site of filteredExpPoints$[groupIndex] | async" [value]="site">
-                          {{ site }}
-                        </mat-option>
-                      </mat-autocomplete>
+                  <ng-container *ngIf="(decisionPointsTableEditIndex$ | async) !== groupIndex">
+                    <span [matTooltip]="partition.at(groupIndex).get('site').value" matTooltipPosition="above">
+                      {{ partition.at(groupIndex).get('site').value | truncate: 35 }}
                     </span>
-                  </mat-form-field>
+                  </ng-container>
+                  <ng-container *ngIf="(decisionPointsTableEditIndex$ | async) === groupIndex">
+                    <mat-form-field floatLabel="never">
+                      <span
+                        [matTooltip]="experimentDesignForm.getRawValue('site')?.partitions[groupIndex]?.site"
+                        matTooltipPosition="above"
+                      >
+                        <input
+                          matInput
+                          [placeholder]="'home.new-experiment.design.partition-point.placeholder.text' | translate"
+                          formControlName="site"
+                          [matAutocomplete]="autoCompleteExperimentPoints"
+                        />
+                        <mat-autocomplete #autoCompleteExperimentPoints="matAutocomplete" panelWidth="fit-content">
+                          <mat-option *ngFor="let site of filteredExpPoints$[groupIndex] | async" [value]="site">
+                            {{ site }}
+                          </mat-option>
+                        </mat-autocomplete>
+                      </span>
+                    </mat-form-field>
+                  </ng-container>
                 </mat-cell>
               </ng-container>
 
@@ -66,24 +73,31 @@
                   {{ 'home.new-experiment.design.partition-id.text' | translate }}
                 </mat-header-cell>
                 <mat-cell *matCellDef="let element; let groupIndex = index" [formGroupName]="groupIndex">
-                  <mat-form-field floatLabel="never">
-                    <span
-                      [matTooltip]="experimentDesignForm.getRawValue('target')?.partitions[groupIndex]?.target"
-                      matTooltipPosition="above"
-                    >
-                      <input
-                        matInput
-                        [placeholder]="'home.new-experiment.design.partition-id.placeholder.text' | translate"
-                        formControlName="target"
-                        [matAutocomplete]="autoCompleteExperimentIds"
-                      />
-                      <mat-autocomplete #autoCompleteExperimentIds="matAutocomplete" panelWidth="fit-content">
-                        <mat-option *ngFor="let target of filteredExpIds$[groupIndex] | async" [value]="target">
-                          {{ target }}
-                        </mat-option>
-                      </mat-autocomplete>
+                  <ng-container *ngIf="(decisionPointsTableEditIndex$ | async) !== groupIndex">
+                    <span [matTooltip]="partition.at(groupIndex).get('target').value" matTooltipPosition="above">
+                      {{ partition.at(groupIndex).get('target').value | truncate: 35 }}
                     </span>
-                  </mat-form-field>
+                  </ng-container>
+                  <ng-container *ngIf="(decisionPointsTableEditIndex$ | async) === groupIndex">
+                    <mat-form-field floatLabel="never">
+                      <span
+                        [matTooltip]="experimentDesignForm.getRawValue('target')?.partitions[groupIndex]?.target"
+                        matTooltipPosition="above"
+                      >
+                        <input
+                          matInput
+                          [placeholder]="'home.new-experiment.design.partition-id.placeholder.text' | translate"
+                          formControlName="target"
+                          [matAutocomplete]="autoCompleteExperimentIds"
+                        />
+                        <mat-autocomplete #autoCompleteExperimentIds="matAutocomplete" panelWidth="fit-content">
+                          <mat-option *ngFor="let target of filteredExpIds$[groupIndex] | async" [value]="target">
+                            {{ target }}
+                          </mat-option>
+                        </mat-autocomplete>
+                      </span>
+                    </mat-form-field>
+                  </ng-container>
                 </mat-cell>
               </ng-container>
 
@@ -93,36 +107,62 @@
                   {{ 'home.new-experiment.design.exclude-if-reached.text' | translate }}
                 </mat-header-cell>
                 <mat-cell *matCellDef="let element; let groupIndex = index" [formGroupName]="groupIndex">
-                  <mat-checkbox class="ft-8-100" color="primary" formControlName="excludeIfReached"> </mat-checkbox>
+                  <mat-checkbox class="ft-8-100" color="primary" [disabled]="(decisionPointsTableEditIndex$ | async) !== groupIndex" formControlName="excludeIfReached"> </mat-checkbox>
                 </mat-cell>
               </ng-container>
 
-              <ng-container matColumnDef="removePartition">
-                <mat-header-cell class="ft-14-700" *matHeaderCellDef></mat-header-cell>
-                <mat-cell
-                  *matCellDef="let element; let groupIndex = index"
-                  [formGroupName]="groupIndex"
-                  style="justify-content: flex-start"
-                >
+              <!-- Actions Column -->
+              <ng-container matColumnDef="actions">
+                <mat-header-cell *matHeaderCellDef class="ft-14-700"></mat-header-cell>
+                <mat-cell *matCellDef="let rowData; let rowIndex = index" class="actions-cell">
                   <button
-                    mat-icon-button
                     type="button"
-                    [disabled]="!isExperimentEditable"
-                    [disableRipple]="true"
-                    (click)="removeConditionOrPartition('partition', groupIndex)"
+                    class="row-action-btn"
+                    [disabled]="(isFormLockedForEdit$ | async) && (decisionPointsTableEditIndex$ | async) !== rowIndex"
+                    (click)="handleDecisionPointTableEditClick(rowIndex, rowData.getRawValue())"
                   >
-                    <mat-icon class="remove-icon"> delete_outline </mat-icon>
+                    <!-- Edit Icon -->
+                    <ng-container *ngIf="(decisionPointsTableEditIndex$ | async) !== rowIndex">
+                      <mat-icon class="icon">create</mat-icon>
+                    </ng-container>
+
+                    <!-- Done Icon -->
+                    <ng-container *ngIf="(decisionPointsTableEditIndex$ | async) === rowIndex">
+                      <mat-icon class="icon">done</mat-icon>
+                    </ng-container>
+                  </button>
+
+                  <button
+                    type="button"
+                    class="row-action-btn"
+                    [disabled]="(isFormLockedForEdit$ | async) && (decisionPointsTableEditIndex$ | async) !== rowIndex"
+                    (click)="handleDecisionPointTableClearOrRemoveRow(rowIndex)"
+                  >
+                    <ng-container *ngIf="(decisionPointsTableEditIndex$ | async) !== rowIndex">
+                      <mat-icon class="icon">delete_outline</mat-icon>
+                    </ng-container>
+                    <ng-container *ngIf="(decisionPointsTableEditIndex$ | async) === rowIndex">
+                      <mat-icon class="icon">clear</mat-icon>
+                    </ng-container>
                   </button>
                 </mat-cell>
               </ng-container>
 
               <mat-header-row *matHeaderRowDef="partitionDisplayedColumns; sticky: true"></mat-header-row>
-              <mat-row *matRowDef="let row; columns: partitionDisplayedColumns"></mat-row>
+              <mat-row
+                *matRowDef="let row; let rowIndex = index; columns: partitionDisplayedColumns"
+                [ngClass]="{
+                  'row-is-locked': (isFormLockedForEdit$ | async) && (decisionPointsTableEditIndex$ | async) !== rowIndex
+                }"
+              ></mat-row>
+
             </mat-table>
             <button
               type="button"
               class="ft-12-700 add-partition"
               *ngIf="!experimentInfo"
+              [ngClass]="{ 'add-partition--disabled': (isFormLockedForEdit$ | async) }"
+              [disabled]="isFormLockedForEdit$ | async"
               (click)="addConditionOrPartition('partition')"
             >
               +
@@ -132,8 +172,8 @@
               type="button"
               class="ft-12-700 add-partition"
               *ngIf="experimentInfo"
-              [ngClass]="{ 'add-partition--disabled': !isExperimentEditable }"
-              [disabled]="!isExperimentEditable"
+              [ngClass]="{ 'add-partition--disabled': !isExperimentEditable || (isFormLockedForEdit$ | async) }"
+              [disabled]="!isExperimentEditable || (isFormLockedForEdit$ | async)"
               (click)="addConditionOrPartition('partition')"
             >
               +

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
@@ -31,6 +31,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { DialogService } from '../../../../../shared/services/dialog.service';
 import { ExperimentDesignStepperService } from '../../../../../core/experiment-design-stepper/experiment-design-stepper.service';
 import {
+  DecisionPointsTableRowData,
   ConditionsTableRowData,
   ExperimentAliasTableRow,
   ExperimentConditionAliasRequestObject,
@@ -72,7 +73,7 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
   previousAssignmentWeightValues = [];
 
   conditionDisplayedColumns = ['conditionCode', 'assignmentWeight', 'description', 'actions'];
-  partitionDisplayedColumns = ['site', 'target', 'excludeIfReached', 'removePartition'];
+  partitionDisplayedColumns = ['site', 'target', 'excludeIfReached', 'actions'];
 
   // Used for condition code, experiment point and ids auto complete dropdown
   filteredConditionCodes$: Observable<string[]>[] = [];
@@ -91,6 +92,11 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
   designData$ = new BehaviorSubject<[ExperimentPartition[], ExperimentCondition[]]>([[], []]);
   aliasTableData: ExperimentAliasTableRow[] = [];
   isAliasTableEditMode$ = this.experimentDesignStepperService.isAliasTableEditMode$;
+
+  // Decision Point table store references
+  previousDecisionPointTableRowDataBehaviorSubject$ = new BehaviorSubject<DecisionPointsTableRowData>(null);
+  isDecisionPointsTableEditMode$ = this.experimentDesignStepperService.isDecisionPointsTableEditMode$;
+  decisionPointsTableEditIndex$ = this.experimentDesignStepperService.decisionPointsTableEditIndex$;
 
   // Condition table store references
   previousRowDataBehaviorSubject$ = new BehaviorSubject<ConditionsTableRowData>(null);
@@ -161,6 +167,9 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
       partitions: this._formBuilder.array([this.addPartitions()]),
     });
     this.createDesignDataSubject();
+    this.experimentDesignStepperService.decisionPointsEditModePreviousRowData$.subscribe(
+      this.previousDecisionPointTableRowDataBehaviorSubject$
+    );
     this.experimentDesignStepperService.conditionsEditModePreviousRowData$.subscribe(
       this.previousRowDataBehaviorSubject$
     );
@@ -275,9 +284,26 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
     return this.experimentDesignForm.dirty && this.experimentDesignStepperService.experimentStepperDataChanged();
   }
 
+  handleDecisionPointTableEditClick(rowIndex: number, rowData: DecisionPointsTableRowData) {
+    if (this.isDecisionPointTableRowValid()) {
+      this.experimentDesignStepperService.setDecisionPointTableEditModeDetails(rowIndex, rowData);
+    }
+  }
+
   handleConditionTableEditClick(rowIndex: number, rowData: ConditionsTableRowData) {
     if (this.isConditionTableRowValid()) {
       this.experimentDesignStepperService.setConditionTableEditModeDetails(rowIndex, rowData);
+    }
+  }
+
+  handleDecisionPointTableClearOrRemoveRow(rowIndex: number): void {
+    // grab previous data before dispatching reset to store
+    const previousRowData = this.previousDecisionPointTableRowDataBehaviorSubject$.value;
+
+    if (previousRowData) {
+      this.resetPreviousDecisionPointRowDataOnEditCancel(previousRowData, rowIndex);
+    } else {
+      this.removeConditionOrPartition('partition', rowIndex);
     }
   }
 
@@ -290,6 +316,19 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
     } else {
       this.removeConditionOrPartition('condition', rowIndex);
     }
+  }
+
+  resetPreviousDecisionPointRowDataOnEditCancel(previousRowData: DecisionPointsTableRowData, rowIndex: number): void {
+    const decisionPointTableRow = this.partition.controls.at(rowIndex);
+
+    if (decisionPointTableRow) {
+      decisionPointTableRow.get('site').setValue(previousRowData.site, { emitEvent: false });
+      decisionPointTableRow.get('target').setValue(previousRowData.target, { emitEvent: false });
+      decisionPointTableRow.get('excludeIfReached').setValue(previousRowData.excludeIfReached, { emitEvent: false });
+      decisionPointTableRow.get('order').setValue(previousRowData.order, { emitEvent: false });
+    }
+
+    this.experimentDesignStepperService.clearDecisionPointTableEditModeDetails();
   }
 
   resetPreviousConditionRowDataOnEditCancel(previousRowData: ConditionsTableRowData, rowIndex: number): void {
@@ -364,6 +403,10 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
     if (isPartition) {
       const partitionFormControl = this.experimentDesignForm.get('partitions') as FormArray;
       this.manageExpPointAndIdControl(partitionFormControl.controls.length - 1);
+      this.experimentDesignStepperService.setDecisionPointTableEditModeDetails(
+        partitionFormControl.controls.length - 1,
+        null
+      );
     } else {
       const conditionFormControl = this.experimentDesignForm.get('conditions') as FormArray;
       this.manageConditionCodeControl(conditionFormControl.controls.length - 1);
@@ -375,23 +418,37 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   removeConditionOrPartition(type: string, groupIndex: number) {
+    const isPartition = type === 'partition';
     this[type].removeAt(groupIndex);
-    if (type === 'condition' && this.experimentInfo) {
-      const deletedCondition = this.experimentInfo.conditions.find((condition) => condition.order === groupIndex + 1);
-      if (deletedCondition) {
-        this.experimentInfo.conditions = this.experimentInfo.conditions.filter(
-          (condition) => condition == deletedCondition
-        );
-        if (this.experimentInfo.revertTo === deletedCondition.id) {
-          this.experimentInfo.revertTo = null;
+    if (this.experimentInfo) {
+      if (isPartition) {
+        const deletedPartition = this.experimentInfo.partitions.find((partition) => partition.order === groupIndex + 1);
+        if (deletedPartition) {
+          this.experimentInfo.partitions = this.experimentInfo.partitions.filter(
+            (partition) => partition == deletedPartition
+          );
+          if (this.experimentInfo.revertTo === deletedPartition.id) {
+            this.experimentInfo.revertTo = null;
+          }
+        }
+      } else {
+        const deletedCondition = this.experimentInfo.conditions.find((condition) => condition.order === groupIndex + 1);
+        if (deletedCondition) {
+          this.experimentInfo.conditions = this.experimentInfo.conditions.filter(
+            (condition) => condition == deletedCondition
+          );
+          if (this.experimentInfo.revertTo === deletedCondition.id) {
+            this.experimentInfo.revertTo = null;
+          }
         }
       }
     }
-    if (type === 'condition') {
+    if (!isPartition) {
       this.previousAssignmentWeightValues.splice(groupIndex, 1);
       this.applyEqualWeight();
     }
     this.experimentDesignStepperService.experimentStepperDataChanged();
+    this.experimentDesignStepperService.clearDecisionPointTableEditModeDetails();
     this.experimentDesignStepperService.clearConditionTableEditModeDetails();
     this.updateView();
   }
@@ -445,6 +502,16 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
     } else if (duplicatePartitions.length > 1) {
       this.partitionPointErrors.push(duplicatePartitions.join(', ') + this.partitionErrorMessages[3]);
     }
+  }
+
+  isDecisionPointTableRowValid(): boolean {
+    const partitions = this.experimentDesignForm.get('partitions').value;
+
+    this.validatePartitionNames(partitions);
+    this.validatePartitionCount(partitions);
+    this.validatePartitions();
+    
+    return !this.partitionPointErrors.length && !this.partitionCountError && !this.expPointAndIdErrors.length;
   }
 
   isConditionTableRowValid(): boolean {


### PR DESCRIPTION
https://user-images.githubusercontent.com/90279765/210600102-c7394b7b-9bb1-4e4a-a345-9cb3c720cc1c.mov

I've mostly just copied the code written for the Conditions table by @danoswaltCL so I feel most changes are done correctly, but please review them, especially the `removeConditionOrPartition()` and `isDecisionPointTableRowValid()` functions in the `experiment-design.component.ts` file. And I will update the styles in a separate PR once this is merged.

@danoswaltCL I have a question, the Decision Points table currently validates the duplicated names while editing (as you can see from the video) so I think this should be fixed. To do this, can I simply delete the following code from the `experiment-design.component.ts` file?
```
this.experimentDesignForm.get('partitions').valueChanges.subscribe((newValues) => {
      this.validatePartitionNames(newValues);
});
```

