### PR TITLE
Fix/search in pagination

### DIFF
--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -109,7 +109,6 @@ export class ExperimentService {
     searchParams?: IExperimentSearchParams,
     sortParams?: IExperimentSortParams
   ): Promise<Experiment[]> {
-    take = 1;
     logger.info({ message: `Find paginated experiments` });
 
     let queryBuilder = this.experimentRepository

--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -109,12 +109,15 @@ export class ExperimentService {
     searchParams?: IExperimentSearchParams,
     sortParams?: IExperimentSortParams
   ): Promise<Experiment[]> {
+    take = 1;
     logger.info({ message: `Find paginated experiments` });
 
     let queryBuilder = this.experimentRepository
       .createQueryBuilder('experiment')
       .leftJoinAndSelect('experiment.conditions', 'conditions')
-      .leftJoinAndSelect('experiment.partitions', 'partitions');
+      .leftJoinAndSelect('experiment.partitions', 'partitions')
+      .take(take)
+      .skip(skip);
 
     if (searchParams) {
       const customSearchString = searchParams.string.split(' ').join(`:*&`);
@@ -150,9 +153,7 @@ export class ExperimentService {
       .leftJoinAndSelect('conditions.levelCombinationElements', 'levelCombinationElements')
       .leftJoinAndSelect('levelCombinationElements.level', 'level')
       .leftJoinAndSelect('conditions.conditionAliases', 'conditionAlias')
-      .whereInIds(expIds)
-      .limit(take)
-      .offset(skip);
+      .whereInIds(expIds);
 
     if (sortParams) {
       queryBuilderToReturn = queryBuilderToReturn.addOrderBy(`experiment.${sortParams.key}`, sortParams.sortAs);

--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -150,10 +150,6 @@ export class ExperimentService {
       .leftJoinAndSelect('conditions.levelCombinationElements', 'levelCombinationElements')
       .leftJoinAndSelect('levelCombinationElements.level', 'level')
       .leftJoinAndSelect('conditions.conditionAliases', 'conditionAlias')
-      .addOrderBy('conditions.order', 'ASC')
-      .addOrderBy('partitions.order', 'ASC')
-      .addOrderBy('factors.order', 'ASC')
-      .addOrderBy('levels.order', 'ASC')
       .whereInIds(expIds)
       .limit(take)
       .offset(skip);

--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -109,6 +109,7 @@ export class ExperimentService {
     searchParams?: IExperimentSearchParams,
     sortParams?: IExperimentSortParams
   ): Promise<Experiment[]> {
+    take = 2;
     logger.info({ message: `Find paginated experiments` });
 
     let queryBuilder = this.experimentRepository
@@ -126,6 +127,8 @@ export class ExperimentService {
         .addSelect(`ts_rank_cd(to_tsvector('english',${postgresSearchString}), to_tsquery(:query))`, 'rank')
         .addOrderBy('rank', 'DESC')
         .setParameter('query', `${customSearchString}:*`);
+    } else {
+      queryBuilder = queryBuilder.addOrderBy('experiment.updatedAt', 'DESC');
     }
 
     let expIds = (await queryBuilder.getMany()).map((exp) => exp.id);

--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -109,7 +109,6 @@ export class ExperimentService {
     searchParams?: IExperimentSearchParams,
     sortParams?: IExperimentSortParams
   ): Promise<Experiment[]> {
-    take = 2;
     logger.info({ message: `Find paginated experiments` });
 
     let queryBuilder = this.experimentRepository

--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -114,13 +114,7 @@ export class ExperimentService {
     let queryBuilder = this.experimentRepository
       .createQueryBuilder('experiment')
       .leftJoinAndSelect('experiment.conditions', 'conditions')
-      .leftJoinAndSelect('experiment.partitions', 'partitions')
-      .distinctOn(['experiment.id'])
-      .addOrderBy('experiment.id', 'ASC')
-      .addOrderBy('conditions.order', 'ASC')
-      .addOrderBy('partitions.order', 'ASC')
-      .limit(take)
-      .offset(skip);
+      .leftJoinAndSelect('experiment.partitions', 'partitions');
 
     if (searchParams) {
       const customSearchString = searchParams.string.split(' ').join(`:*&`);
@@ -132,7 +126,8 @@ export class ExperimentService {
         .setParameter('query', `${customSearchString}:*`);
     }
 
-    const expIds = (await queryBuilder.getMany()).map((exp) => exp.id);
+    let expIds = (await queryBuilder.getMany()).map((exp) => exp.id);
+    expIds = Array.from(new Set(expIds));
 
     let queryBuilderToReturn = this.experimentRepository
       .createQueryBuilder('experiment')
@@ -159,7 +154,9 @@ export class ExperimentService {
       .addOrderBy('partitions.order', 'ASC')
       .addOrderBy('factors.order', 'ASC')
       .addOrderBy('levels.order', 'ASC')
-      .whereInIds(expIds);
+      .whereInIds(expIds)
+      .limit(take)
+      .offset(skip);
 
     if (sortParams) {
       queryBuilderToReturn = queryBuilderToReturn.addOrderBy(`experiment.${sortParams.key}`, sortParams.sortAs);


### PR DESCRIPTION
By default most recent updated experiment will be queried. Skip and take is added during the experiment search to return distinct experimentId