### PR TITLE
set node 16 explicitly in the individual build steps for release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -86,6 +86,9 @@ jobs:
     steps:
       - name: Git Checkout
         uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
       - name: Set Backend App Version
         working-directory: backend/packages/Upgrade
         run: npm version ${{ needs.init.outputs.version }} --git-tag-version=false
@@ -108,6 +111,9 @@ jobs:
     steps:
       - name: Git Checkout
         uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
       - name: Build Frontend
         working-directory: frontend
         run: |
@@ -130,6 +136,9 @@ jobs:
     steps:
       - name: Git Checkout
         uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
       - name: Build Lambda
         working-directory: backend/packages/Scheduler
         run: |


### PR DESCRIPTION
Found that the build steps in the "Create Release" jobs were unexpectedly running node 18 when everything else uses 16, which caused build issue; this does not necessarily solve whatever node 18 doesn't like https://github.com/CarnegieLearningWeb/UpGrade/issues, but at any rate, this will get everything running on same version.