### PR TITLE
major version bump for all of the package.jsons

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ab_testing_backend",
-    "version": "1.0.0",
+    "version": "4.0",
     "description": "Backend for A/B Testing Project",
     "scripts": {
         "install:all": "npm ci && cd packages/Scheduler && npm ci && cd ../Upgrade && npm ci",

--- a/backend/packages/Scheduler/package.json
+++ b/backend/packages/Scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppl-upgrade-serverless",
-  "version": "1.0.0",
+  "version": "4.0",
   "description": "Serverless webpack example using Typescript",
   "main": "handler.js",
   "scripts": {

--- a/backend/packages/Upgrade/package.json
+++ b/backend/packages/Upgrade/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ab_testing_backend",
-    "version": "3.0.10",
+    "version": "4.0",
     "description": "Backend for A/B Testing Project",
     "main": "index.js",
     "scripts": {

--- a/clientlibs/js/package.json
+++ b/clientlibs/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upgrade_client_lib",
-  "version": "1.1.7",
+  "version": "4.0",
   "description": "Client library to communicate with the Upgrade server",
   "main": "dist/bundle.js",
   "types": "dist/clientlibs/js/src/index.d.ts",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ab-testing",
-  "version": "1.0.0",
+  "version": "4.0",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "UpGrade",
-  "version": "3.0",
+  "version": "4.0",
   "description": "This is a combined repository for UpGrade, an open-source platform to support large-scale A/B testing in educational applications.  Learn more at www.upgradeplatform.org",
   "main": "index.js",
   "devDependencies": {


### PR DESCRIPTION
We should make a practice of bumping the major (or minor) dev branch version immediately after creating a release. Otherwise the dev branch "version" remains version looks like the current release, when it actually represents the next release!

Next release will be 4.0, so I'm aligning all of the package.json versions to match, no reason to maintain those separate versions individually if we're not operating that way.

When we create the next release, we should bump `dev` to 4.1. We can always then bump it to 5.0 if we find we have major changes. As long as it out-pips the last release.
