### PR TITLE
support for caliper graded profile

### DIFF
--- a/backend/packages/Upgrade/src/api/controllers/validators/CaliperLogData.ts
+++ b/backend/packages/Upgrade/src/api/controllers/validators/CaliperLogData.ts
@@ -1,0 +1,39 @@
+import { IsNotEmpty, IsDefined, IsString, IsJSON, IsObject } from 'class-validator';
+import { Attempt, CaliperActor, ScoreObject } from '../../../../../../../types/src/Experiment/interfaces';
+
+export class CaliperLogData {
+
+  @IsDefined()
+  @IsNotEmpty()
+  @IsString()
+  public profile: string;
+
+  @IsDefined()
+  @IsNotEmpty()
+  @IsJSON()
+  public actor: CaliperActor;
+
+  @IsDefined()
+  @IsNotEmpty()
+  @IsString()
+  public action: string;
+
+  @IsDefined()
+  @IsNotEmpty()
+  @IsString()
+  public eventTime: string;
+
+  @IsDefined()
+  @IsNotEmpty()
+  @IsJSON()
+  public object: Attempt;
+
+  @IsObject()
+  public extensions: object;
+
+  @IsObject()
+  @IsNotEmpty()
+  @IsJSON()
+  public generated: ScoreObject;
+
+}

--- a/backend/packages/Upgrade/src/api/controllers/validators/CaliperLogEnvelope.ts
+++ b/backend/packages/Upgrade/src/api/controllers/validators/CaliperLogEnvelope.ts
@@ -1,0 +1,22 @@
+import { IsNotEmpty, IsDefined, IsString, IsJSON, IsObject } from 'class-validator';
+import { CaliperLogData } from './CaliperLogData';
+
+
+export class CaliperLogEnvelope {
+  @IsDefined()
+  @IsNotEmpty()
+  @IsString()
+  public sensor: string;
+
+  @IsDefined()
+  @IsNotEmpty()
+  @IsString()
+  public sendTime: string;
+
+  @IsDefined()
+  @IsNotEmpty()
+  @IsString()
+  public dataVersion: string;
+
+  public data: CaliperLogData[];
+}

--- a/clientlibs/js/src/UpgradeClient.ts
+++ b/clientlibs/js/src/UpgradeClient.ts
@@ -14,11 +14,13 @@ import getExperimentCondition from './functions/getExperimentCondition';
 import markExperimentPoint from './functions/markExperimentPoint';
 import getAllFeatureFlags from './functions/getAllfeatureFlags';
 import log from './functions/log';
+import logCaliper from './functions/logCaliper';
 import setAltUserIds from './functions/setAltUserIds';
 import addMetrics from './functions/addMetrics';
 import getFeatureFlag from './functions/getFeatureFlag';
 import init from './functions/init';
 import * as uuid from 'uuid';
+import { CaliperEnvelope } from '../../../types/src/Experiment/interfaces';
 
 export default class UpgradeClient {
   // Endpoints URLs
@@ -31,6 +33,7 @@ export default class UpgradeClient {
     failedExperimentPoint: null,
     getAllFeatureFlag: null,
     log: null,
+    logCaliper: null,
     altUserIds: null,
     addMetrics: null,
   };
@@ -59,6 +62,7 @@ export default class UpgradeClient {
       failedExperimentPoint: `${hostUrl}/api/v1/failed`,
       getAllFeatureFlag: `${hostUrl}/api/v1/featureflag`,
       log: `${hostUrl}/api/v1/log`,
+      logCaliper: `${hostUrl}/api/v1/logCaliper`,
       altUserIds: `${hostUrl}/api/v1/useraliases`,
       addMetrics: `${hostUrl}/api/v1/metric`,
     };
@@ -177,6 +181,11 @@ export default class UpgradeClient {
   async log(value: ILogInput[], sendAsAnalytics = false): Promise<Interfaces.ILog[]> {
     this.validateClient();
     return await log(this.api.log, this.userId, this.token, this.clientSessionId, value, sendAsAnalytics);
+  }
+
+  async logCaliper(value: CaliperEnvelope, sendAsAnalytics = false): Promise<Interfaces.ILog[]> {
+    this.validateClient();
+    return await logCaliper(this.api.logCaliper, this.userId, this.token, this.clientSessionId, value, sendAsAnalytics);
   }
 
   async setAltUserIds(altUserIds: string[]): Promise<Interfaces.IExperimentUserAliases> {

--- a/clientlibs/js/src/functions/logCaliper.ts
+++ b/clientlibs/js/src/functions/logCaliper.ts
@@ -1,0 +1,30 @@
+import { Types, Interfaces } from '../identifiers';
+import fetchDataService from '../common/fetchDataService';
+import { CaliperEnvelope } from '../../../../types/src/Experiment/interfaces';
+
+export default async function logCaliper(
+  url: string,
+  userId: string,
+  token: string,
+  clientSessionId: string,
+  value: CaliperEnvelope,
+  sendAsAnalytics = false
+): Promise<Interfaces.ILog[]> {
+  try {
+    const logResponse = await fetchDataService(
+      url,
+      token,
+      clientSessionId,
+      value,
+      Types.REQUEST_TYPES.POST,
+      sendAsAnalytics
+    );
+    if (logResponse.status) {
+      return logResponse.data;
+    } else {
+      throw new Error(JSON.stringify(logResponse.message));
+    }
+  } catch (error) {
+    throw new Error(error.message);
+  }
+}

--- a/types/src/Experiment/interfaces.ts
+++ b/types/src/Experiment/interfaces.ts
@@ -176,3 +176,43 @@ export interface IUserAliases {
   userId: string;
   aliases: string[];
 }
+
+
+export interface ScoreObject {
+  id: string;
+  type: string;
+  attempt: Attempt;
+  extensions?: object;
+  scoreGiven?: number;
+}
+
+export interface CaliperActor {
+  id: string;
+  type: string;
+}
+
+export interface Attempt {
+  id?: string;
+  type: string;
+  assignee?: CaliperActor;
+  assignable?: CaliperActor;
+  duration?: string;
+  extensions?: ILogInput;
+}
+
+export interface CaliperGradingProfile {
+  id: string,
+  type: string,
+  profile: string,
+  actor: object,
+  action: string,
+  object: Attempt,
+  generated: ScoreObject
+}
+
+export interface CaliperEnvelope {
+  sensor: string,
+  sendTime: string,
+  dataVersion: string,
+  data: CaliperGradingProfile[]
+}


### PR DESCRIPTION
Added an endpoint & client lib function that accepts graded events in caliper format and converts to our metric format

Envelope:
```
{
  "sensor": "https://example.edu/sensors/1",
  "sendTime": "2023-02-08T11:05:01.000Z",
  "dataVersion": "http://purl.imsglobal.org/ctx/caliper/v1p2",
  "data": [ {event1}, {event2}, {eventN} ]
}
```

Event Data:
```
{
  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
  "id": "urn:uuid:a50ca17f-5971-47bb-8fca-4e6e6879001d",
  "type": "GradeEvent",
  "profile": "GradingProfile",
  "actor": {
    "id": "https://example.edu/autograder",
    "type": "SoftwareApplication",
    "version": "v2"
  },
  "action": "Graded",
  "object": {
    "id": "https://example.edu/terms/201601/courses/7/sections/1/assess/1/users/554433/attempts/1",
    "type": "Attempt",
    "assignee": {
      "id": "https://example.edu/users/554433",
      "type": "Person"
    },
    "assignable": {
      "id": "https://example.edu/terms/201601/courses/7/sections/1/assess/1",
      "type": "Assessment"
    },
    "count": 1,
    "dateCreated": "2016-11-15T10:05:00.000Z",
    "startedAtTime": "2016-11-15T10:05:00.000Z",
    "endedAtTime": "2016-11-15T10:55:12.000Z",
    "duration": "PT50M12S"
  },
  "eventTime": "2016-11-15T10:57:06.000Z",
  "edApp": "https://example.edu",
  "generated": {
    "id": "https://example.edu/terms/201601/courses/7/sections/1/assess/1/users/554433/attempts/1/scores/1",
    "type": "Score",
    "attempt": "https://example.edu/terms/201601/courses/7/sections/1/assess/1/users/554433/attempts/1",
    "maxScore": 15.0,
    "scoreGiven": 10.0,
    "scoredBy": "https://example.edu/autograder",
    "comment": "auto-graded exam",
    "dateCreated": "2016-11-15T10:56:00.000Z"
  },
  "group": {
    "id": "https://example.edu/terms/201601/courses/7/sections/1",
    "type": "CourseSection",
    "courseNumber": "CPS 435-01",
    "academicSession": "Fall 2016"
  }
}
```
