### PR TITLE
remove storeModule code inserted by angular migration scripts

### DIFF
--- a/frontend/projects/upgrade/src/app/app.module.ts
+++ b/frontend/projects/upgrade/src/app/app.module.ts
@@ -12,7 +12,6 @@ import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { SimpleNotificationsModule } from 'angular2-notifications';
 import { environment } from '../environments/environment';
 import { ENV, Environment, RuntimeEnvironmentConfig } from '../environments/environment-types';
-import { StoreModule } from '@ngrx/store';
 
 export const getEnvironmentConfig = (http: HttpClient, env: Environment) => {
   // in non-prod build, all env vars can be provided on .environment.ts,
@@ -58,7 +57,6 @@ export const getEnvironmentConfig = (http: HttpClient, env: Environment) => {
     AppRoutingModule,
     FormsModule,
     HttpClientModule,
-    StoreModule.forRoot({}, {}),
   ],
   providers: [
     { provide: ENV, useValue: environment },


### PR DESCRIPTION
Angular migration scripts must be confused about something in our ngrx setup because it inserted this line and broke something, which makes me think we may have something set up weird... but this seems to bring us back to normal. #810 