### PR TITLE
Solved design stepper getting disabled bug

### DIFF
--- a/frontend/projects/upgrade/src/app/core/experiment-design-stepper/experiment-design-stepper.service.ts
+++ b/frontend/projects/upgrade/src/app/core/experiment-design-stepper/experiment-design-stepper.service.ts
@@ -547,10 +547,11 @@ export class ExperimentDesignStepperService {
     this.store$.dispatch(actionUpdateFactorialConditionTableData({ tableData }));
   }
 
-  setUpdatePayloadTableEditModeDetails(rowIndex: number | null): void {
+  setUpdatePayloadTableEditModeDetails(rowIndex: number | null, isNgDestroyCall: boolean): void {
     this.store$.dispatch(
       experimentDesignStepperAction.actionToggleSimpleExperimentPayloadTableEditMode({
         simpleExperimentPayloadTableEditIndex: rowIndex,
+        isNgDestroyCall: isNgDestroyCall,
       })
     );
   }

--- a/frontend/projects/upgrade/src/app/core/experiment-design-stepper/store/experiment-design-stepper.actions.ts
+++ b/frontend/projects/upgrade/src/app/core/experiment-design-stepper/store/experiment-design-stepper.actions.ts
@@ -46,6 +46,7 @@ export const actionToggleSimpleExperimentPayloadTableEditMode = createAction(
   '[Experiment-Design-Stepper] Update Simple Experiment Payload Table Edit Mode Details',
   props<{
     simpleExperimentPayloadTableEditIndex: number | null;
+    isNgDestroyCall: boolean;
   }>()
 );
 

--- a/frontend/projects/upgrade/src/app/core/experiment-design-stepper/store/experiment-design-stepper.reducer.ts
+++ b/frontend/projects/upgrade/src/app/core/experiment-design-stepper/store/experiment-design-stepper.reducer.ts
@@ -73,9 +73,12 @@ const reducer = createReducer(
   })),
   on(
     experimentDesignStepperAction.actionToggleSimpleExperimentPayloadTableEditMode,
-    (state, { simpleExperimentPayloadTableEditIndex }): ExperimentDesignStepperState => {
+    (state, { simpleExperimentPayloadTableEditIndex, isNgDestroyCall }): ExperimentDesignStepperState => {
       // toggle edit mode
-      const editMode = !state.isSimpleExperimentPayloadTableEditMode;
+      let editMode: boolean;
+      if (!isNgDestroyCall) {
+        editMode = !state.isSimpleExperimentPayloadTableEditMode;
+      }
 
       // if not in edit mode, use null for row-index
       const editIndex = editMode ? simpleExperimentPayloadTableEditIndex : null;

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/payloads-table/payloads-table.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/payloads-table/payloads-table.component.ts
@@ -50,7 +50,8 @@ export class PayloadsTableComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.experimentDesignStepperService.setUpdatePayloadTableEditModeDetails(null);
+    this.experimentDesignStepperService.clearSimpleExperimentDesignStepperData();
+    this.experimentDesignStepperService.setUpdatePayloadTableEditModeDetails(null, true);
     this.subscriptions.unsubscribe();
   }
 
@@ -118,7 +119,7 @@ export class PayloadsTableComponent implements OnInit, OnDestroy {
     }
 
     this.currentPayloadInput$.next(rowData.payload);
-    this.experimentDesignStepperService.setUpdatePayloadTableEditModeDetails(rowIndex);
+    this.experimentDesignStepperService.setUpdatePayloadTableEditModeDetails(rowIndex, false);
     this.experimentDesignStepperService.setNewSimpleExperimentPayloadTableData(payloadTableData);
   }
 


### PR DESCRIPTION
Solved error that changing experiment type in create/edit mode disables the design stepper.
Solved error of simple experiment payload data not clearing on changing experiment type.