### PR TITLE
version 4.3 bump

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ab_testing_backend",
-    "version": "4.2.0",
+    "version": "4.3.0",
     "description": "Backend for A/B Testing Project",
     "scripts": {
         "install:all": "npm ci && cd packages/Scheduler && npm ci && cd ../Upgrade && npm ci",

--- a/backend/packages/Scheduler/package.json
+++ b/backend/packages/Scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppl-upgrade-serverless",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Serverless webpack example using Typescript",
   "main": "handler.js",
   "scripts": {

--- a/backend/packages/Upgrade/package.json
+++ b/backend/packages/Upgrade/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ab_testing_backend",
-    "version": "4.2.0",
+    "version": "4.3.0",
     "description": "Backend for A/B Testing Project",
     "main": "index.js",
     "scripts": {

--- a/clientlibs/js/package.json
+++ b/clientlibs/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upgrade_client_lib",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Client library to communicate with the Upgrade server",
   "main": "dist/bundle.js",
   "types": "dist/clientlibs/js/src/index.d.ts",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ab-testing",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "UpGrade",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "This is a combined repository for UpGrade, an open-source platform to support large-scale A/B testing in educational applications.  Learn more at www.upgradeplatform.org",
   "main": "index.js",
   "devDependencies": {

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upgrade_types",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
bumping to 4.3 after js library bugfix. normally we would not do this after a bugfix but I merged dev into main in order to publish js library with bugfix in order to republish the library, which brought in 4.2.0 as the version, so dev shouldn't have same version as a published artifact.

Next time I will look for different way to re-publish library version if there is bugfix to that package (i.e. not merging dev into main).