### PR TITLE
Play arrow wasn't properly visible in by condition section 

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/table-row/table-row.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/table-row/table-row.component.html
@@ -10,7 +10,7 @@
         <span *ngIf="!key.includes('Icon'); else icon" style="padding-left: -5px;">{{ element.data[key] }}</span>
         <ng-template #icon>
           <mat-icon
-            style="margin-left: -20px;"
+            style="margin-left: -17.5px;"
             *ngIf="element.partitions && key === 'expandIcon'"
             [class.active]="element.data[referenceId] === expandedId"
             (click)="toggleExpandableSymbol(element.data[referenceId])"

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/table-row/table-row.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/table-row/table-row.component.html
@@ -10,7 +10,7 @@
         <span *ngIf="!key.includes('Icon'); else icon" style="padding-left: -5px;">{{ element.data[key] }}</span>
         <ng-template #icon>
           <mat-icon
-            style="margin-left: -10px;"
+            style="margin-left: -20px;"
             *ngIf="element.partitions && key === 'expandIcon'"
             [class.active]="element.data[referenceId] === expandedId"
             (click)="toggleExpandableSymbol(element.data[referenceId])"

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/table-row/table-row.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/table-row/table-row.component.scss
@@ -31,7 +31,7 @@ div {
 
       &.active {
         transform: rotate(90deg);
-        margin-left: -8px;
+        margin-left: -5px;
       }
     }
   }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/table-row/table-row.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/table-row/table-row.component.scss
@@ -31,7 +31,6 @@ div {
 
       &.active {
         transform: rotate(90deg);
-        margin-left: -5px;
       }
     }
   }


### PR DESCRIPTION
Play Arrow wasn't visible properly because second column was overlapping over it, arrow is moved to left to resolve this problem.
Issue:
![image](https://github.com/CarnegieLearningWeb/UpGrade/assets/50392803/7f063cc6-f0c0-413a-9d89-9a0e603c309f)
Solution:
![image](https://github.com/CarnegieLearningWeb/UpGrade/assets/50392803/0473722a-ccd6-411a-ac36-4d0807bd7014)
