### PR TITLE
Add frontend changes

### DIFF
--- a/backend/packages/Upgrade/src/api/models/Experiment.ts
+++ b/backend/packages/Upgrade/src/api/models/Experiment.ts
@@ -64,6 +64,7 @@ export class Experiment extends BaseModel {
 
   @IsNotEmpty()
   @Column({
+    nullable: true,
     type: 'enum',
     enum: CONSISTENCY_RULE,
   })

--- a/backend/packages/Upgrade/src/api/models/Experiment.ts
+++ b/backend/packages/Upgrade/src/api/models/Experiment.ts
@@ -16,7 +16,7 @@ import {
   IExperimentSearchParams,
   IExperimentSortParams,
   EXPERIMENT_TYPE,
-  WITHING_SUBJECT_ALGORITHM,
+  CONDITION_ORDER,
 } from 'upgrade_types';
 import { Type } from 'class-transformer';
 import { Query } from './Query';
@@ -102,10 +102,10 @@ export class Experiment extends BaseModel {
 
   @Column({
     type: 'enum',
-    enum: WITHING_SUBJECT_ALGORITHM,
+    enum: CONDITION_ORDER,
     nullable: true,
   })
-  public algorithm: WITHING_SUBJECT_ALGORITHM;
+  public conditionOrder: CONDITION_ORDER;
 
   @Column({
     default: false,

--- a/backend/packages/Upgrade/src/database/migrations/1684996673747-conditionOrder.ts
+++ b/backend/packages/Upgrade/src/database/migrations/1684996673747-conditionOrder.ts
@@ -1,18 +1,20 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class algorithm1684995196547 implements MigrationInterface {
-  name = 'algorithm1684995196547';
+export class conditionOrder1684996673747 implements MigrationInterface {
+  name = 'conditionOrder1684996673747';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `CREATE TYPE "public"."experiment_algorithm_enum" AS ENUM('random', 'roundRobinRandom', 'roundRobinOrdered')`
+      `CREATE TYPE "public"."experiment_conditionorder_enum" AS ENUM('random', 'random round robin', 'ordered round robin')`
     );
-    await queryRunner.query(`ALTER TABLE "public"."experiment" ADD "algorithm" "public"."experiment_algorithm_enum"`);
+    await queryRunner.query(
+      `ALTER TABLE "public"."experiment" ADD "conditionOrder" "public"."experiment_conditionorder_enum"`
+    );
     await queryRunner.query(
       `ALTER TYPE "public"."experiment_assignmentunit_enum" RENAME TO "experiment_assignmentunit_enum_old"`
     );
     await queryRunner.query(
-      `CREATE TYPE "public"."experiment_assignmentunit_enum" AS ENUM('individual', 'group', 'withinSubject')`
+      `CREATE TYPE "public"."experiment_assignmentunit_enum" AS ENUM('individual', 'group', 'within-subjects')`
     );
     await queryRunner.query(
       `ALTER TABLE "public"."experiment" ALTER COLUMN "assignmentUnit" TYPE "public"."experiment_assignmentunit_enum" USING "assignmentUnit"::"text"::"public"."experiment_assignmentunit_enum"`
@@ -29,7 +31,7 @@ export class algorithm1684995196547 implements MigrationInterface {
     await queryRunner.query(
       `ALTER TYPE "public"."experiment_assignmentunit_enum_old" RENAME TO "experiment_assignmentunit_enum"`
     );
-    await queryRunner.query(`ALTER TABLE "public"."experiment" DROP COLUMN "algorithm"`);
-    await queryRunner.query(`DROP TYPE "public"."experiment_algorithm_enum"`);
+    await queryRunner.query(`ALTER TABLE "public"."experiment" DROP COLUMN "conditionOrder"`);
+    await queryRunner.query(`DROP TYPE "public"."experiment_conditionorder_enum"`);
   }
 }

--- a/backend/packages/Upgrade/src/database/migrations/1684996673747-conditionOrder.ts
+++ b/backend/packages/Upgrade/src/database/migrations/1684996673747-conditionOrder.ts
@@ -20,6 +20,7 @@ export class conditionOrder1684996673747 implements MigrationInterface {
       `ALTER TABLE "public"."experiment" ALTER COLUMN "assignmentUnit" TYPE "public"."experiment_assignmentunit_enum" USING "assignmentUnit"::"text"::"public"."experiment_assignmentunit_enum"`
     );
     await queryRunner.query(`DROP TYPE "public"."experiment_assignmentunit_enum_old"`);
+    await queryRunner.query(`ALTER TABLE "public"."experiment" ALTER COLUMN "consistencyRule" DROP NOT NULL`);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
@@ -33,5 +34,6 @@ export class conditionOrder1684996673747 implements MigrationInterface {
     );
     await queryRunner.query(`ALTER TABLE "public"."experiment" DROP COLUMN "conditionOrder"`);
     await queryRunner.query(`DROP TYPE "public"."experiment_conditionorder_enum"`);
+    await queryRunner.query(`ALTER TABLE "public"."experiment" ALTER COLUMN "consistencyRule" SET NOT NULL`);
   }
 }

--- a/backend/packages/Upgrade/test/integration/Experiment/withinSubject/AlgorithmCheck.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/withinSubject/AlgorithmCheck.ts
@@ -4,7 +4,7 @@ import { Container } from 'typedi';
 import { UserService } from '../../../../src/api/services/UserService';
 import { systemUser } from '../../mockData/user';
 import { UpgradeLogger } from '../../../../src/lib/logger/UpgradeLogger';
-import { ASSIGNMENT_UNIT, WITHING_SUBJECT_ALGORITHM } from 'upgrade_types';
+import { ASSIGNMENT_UNIT, CONDITION_ORDER } from 'upgrade_types';
 
 export default async function AlgorithmCheck(): Promise<void> {
   // Testing for Factorial Experiment with different Decision Point
@@ -26,8 +26,8 @@ export default async function AlgorithmCheck(): Promise<void> {
         name: experimentObject.name,
         state: experimentObject.state,
         postExperimentRule: experimentObject.postExperimentRule,
-        assignmentUnit: ASSIGNMENT_UNIT.WITHIN_SUBJECT,
-        algorithm: WITHING_SUBJECT_ALGORITHM.RANDOM,
+        assignmentUnit: ASSIGNMENT_UNIT.WITHIN_SUBJECTS,
+        conditionOrder: CONDITION_ORDER.RANDOM,
         consistencyRule: experimentObject.consistencyRule,
       }),
     ])

--- a/backend/packages/Upgrade/test/integration/mockData/experiment/index.ts
+++ b/backend/packages/Upgrade/test/integration/mockData/experiment/index.ts
@@ -14,7 +14,7 @@ import {
   ASSIGNMENT_UNIT,
   POST_EXPERIMENT_RULE,
   EXPERIMENT_STATE,
-  WITHING_SUBJECT_ALGORITHM,
+  CONDITION_ORDER,
 } from 'upgrade_types';
 
 export const individualAssignmentExperiment = {
@@ -112,8 +112,8 @@ export const secondFactorialExperiment = {
 
 export const withinSubjectExperiment = {
   ...getExperiment(),
-  assignmentUnit: ASSIGNMENT_UNIT.WITHIN_SUBJECT,
-  algorithm: WITHING_SUBJECT_ALGORITHM.RANDOM,
+  assignmentUnit: ASSIGNMENT_UNIT.WITHIN_SUBJECTS,
+  conditionOrder: CONDITION_ORDER.RANDOM,
 };
 
 export const individualExperimentWithMetric = {

--- a/frontend/projects/upgrade/src/app/core/experiment-design-stepper/experiment-design-stepper.service.ts
+++ b/frontend/projects/upgrade/src/app/core/experiment-design-stepper/experiment-design-stepper.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { AppState } from '../core.state';
+import { ASSIGNMENT_UNIT } from 'upgrade_types';
 import {
   ExperimentDecisionPoint,
   ExperimentCondition,
@@ -75,6 +76,10 @@ export class ExperimentDesignStepperService {
   );
   factorialExperimentDesignData$ = this.store$.pipe(select(selectFactorialDesignData), distinctUntilChanged(isEqual));
 
+  // Unit of Assignment:
+  private assignmentUnitSource = new BehaviorSubject<ASSIGNMENT_UNIT>(ASSIGNMENT_UNIT.INDIVIDUAL);
+  currentAssignmentUnit$ = this.assignmentUnitSource.asObservable();
+
   // Payload table:
   simpleExperimentPayloadTableDataBehaviorSubject$ = new BehaviorSubject<SimpleExperimentPayloadTableRowData[]>([]);
   isSimpleExperimentPayloadTableEditMode$ = this.store$.pipe(select(selectIsSimpleExperimentPayloadTableEditMode));
@@ -129,6 +134,10 @@ export class ExperimentDesignStepperService {
     this.simpleExperimentPayloadTableData$.subscribe(this.simpleExperimentPayloadTableDataBehaviorSubject$);
     this.factorialFactorTableData$.subscribe(this.factorialFactorTableDataBehaviorSubject$);
     this.factorialLevelsTableData$.subscribe(this.factorialLevelTableDataBehaviorSubject$);
+  }
+
+  changeAssignmentUnit(unit: ASSIGNMENT_UNIT) {
+    this.assignmentUnitSource.next(unit);
   }
 
   getHasExperimentDesignStepperDataChanged() {

--- a/frontend/projects/upgrade/src/app/core/experiments/experiments.data.service.spec.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/experiments.data.service.spec.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { of } from 'rxjs';
-import { EXPERIMENT_TYPE, FILTER_MODE, SEGMENT_TYPE } from 'upgrade_types';
+import { CONDITION_ORDER, EXPERIMENT_TYPE, FILTER_MODE, SEGMENT_TYPE } from 'upgrade_types';
 import { environment } from '../../../environments/environment';
 import { Environment } from '../../../environments/environment-types';
 import { Segment } from '../segments/store/segments.model';
@@ -84,6 +84,7 @@ describe('ExperimentDataService', () => {
       startOn: 'test',
       consistencyRule: CONSISTENCY_RULE.INDIVIDUAL,
       assignmentUnit: ASSIGNMENT_UNIT.INDIVIDUAL,
+      conditionOrder: CONDITION_ORDER.RANDOM,
       postExperimentRule: POST_EXPERIMENT_RULE.ASSIGN,
       enrollmentCompleteCondition: {
         userCount: 1,

--- a/frontend/projects/upgrade/src/app/core/experiments/experiments.service.spec.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/experiments.service.spec.ts
@@ -36,7 +36,7 @@ import {
 } from './store/experiments.actions';
 import { Environment } from '../../../environments/environment-types';
 import { environment } from '../../../environments/environment';
-import { EXPERIMENT_TYPE, FILTER_MODE, SEGMENT_TYPE } from 'upgrade_types';
+import { CONDITION_ORDER, EXPERIMENT_TYPE, FILTER_MODE, SEGMENT_TYPE } from 'upgrade_types';
 import { segmentNew } from './store/experiments.model';
 import { Segment } from '../segments/store/segments.model';
 // import { SEGMENT_TYPE } from 'upgrade_types';
@@ -101,6 +101,7 @@ describe('ExperimentService', () => {
     startOn: 'test',
     consistencyRule: CONSISTENCY_RULE.INDIVIDUAL,
     assignmentUnit: ASSIGNMENT_UNIT.INDIVIDUAL,
+    conditionOrder: CONDITION_ORDER.RANDOM,
     postExperimentRule: POST_EXPERIMENT_RULE.ASSIGN,
     enrollmentCompleteCondition: {
       userCount: 1,

--- a/frontend/projects/upgrade/src/app/core/experiments/store/experiments.model.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/store/experiments.model.ts
@@ -24,6 +24,7 @@ import { Segment } from '../../segments/store/segments.model';
 export {
   CONSISTENCY_RULE,
   ASSIGNMENT_UNIT,
+  CONDITION_ORDER,
   POST_EXPERIMENT_RULE,
   EXPERIMENT_STATE,
   IExperimentEnrollmentStats,

--- a/frontend/projects/upgrade/src/app/core/experiments/store/experiments.model.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/store/experiments.model.ts
@@ -17,6 +17,7 @@ import {
   FILTER_MODE,
   EXPERIMENT_TYPE,
   PAYLOAD_TYPE,
+  CONDITION_ORDER,
 } from 'upgrade_types';
 import { Segment } from '../../segments/store/segments.model';
 
@@ -209,6 +210,7 @@ export interface Experiment {
   context: string[];
   startOn: string;
   consistencyRule: CONSISTENCY_RULE;
+  conditionOrder: CONDITION_ORDER;
   assignmentUnit: ASSIGNMENT_UNIT;
   postExperimentRule: POST_EXPERIMENT_RULE;
   enrollmentCompleteCondition: EnrollmentCompleteCondition;

--- a/frontend/projects/upgrade/src/app/core/experiments/store/experiments.selector.spec.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/store/experiments.selector.spec.ts
@@ -8,6 +8,7 @@ import {
   POST_EXPERIMENT_RULE,
   ASSIGNMENT_UNIT,
   CONSISTENCY_RULE,
+  CONDITION_ORDER,
 } from './experiments.model';
 import { initialState } from './experiments.reducer';
 import {
@@ -51,6 +52,7 @@ describe('Experiments Selectors', () => {
         startOn: null,
         consistencyRule: CONSISTENCY_RULE.GROUP,
         assignmentUnit: ASSIGNMENT_UNIT.GROUP,
+        conditionOrder: CONDITION_ORDER.RANDOM,
         postExperimentRule: POST_EXPERIMENT_RULE.CONTINUE,
         enrollmentCompleteCondition: null,
         endOn: null,

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.html
@@ -41,7 +41,7 @@
           </mat-select>
         </mat-form-field>
 
-        <mat-form-field class="ft-14-600 group-type" *ngIf="unitOfAssignmentValue">
+        <mat-form-field class="ft-14-600 group-type" *ngIf="unitOfAssignmentValue === ASSIGNMENT_UNIT.GROUP">
           <mat-label>{{ 'home.new-experiment.overview.group-type.placeHolder' | translate }}</mat-label>
           <mat-select class="ft-14-400" formControlName="groupType" [disabled]="!isExperimentEditable">
             <mat-option *ngFor="let group of groupTypes" [value]="group.value">{{ group.value }}</mat-option>
@@ -49,11 +49,26 @@
         </mat-form-field>
       </div>
 
-      <mat-form-field class="ft-14-600 consistency-rule">
+      <mat-form-field
+        class="ft-14-600 consistency-rule"
+        *ngIf="unitOfAssignmentValue !== ASSIGNMENT_UNIT.WITHIN_SUBJECTS"
+      >
         <mat-label>{{ 'home-global.consistency-rule.text' | translate }}</mat-label>
         <mat-select class="ft-14-400" formControlName="consistencyRule">
           <mat-option *ngFor="let consistencyRule of consistencyRules" [value]="consistencyRule.value">
             {{ consistencyRule.value | titlecase }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field
+        class="ft-14-600 condition-order"
+        *ngIf="unitOfAssignmentValue === ASSIGNMENT_UNIT.WITHIN_SUBJECTS"
+      >
+        <mat-label>{{ 'home-global.condition-order.text' | translate }}</mat-label>
+        <mat-select class="ft-14-400" formControlName="conditionOrder">
+          <mat-option *ngFor="let conditionOrder of conditionOrders" [value]="conditionOrder.value">
+            {{ conditionOrder.value | titlecase }}
           </mat-option>
         </mat-select>
       </mat-form-field>
@@ -95,7 +110,7 @@
 
   <section class="shared-modal--buttons-container">
     <span class="shared-modal--buttons-left">
-      <!-- 
+      <!--
         empty left-side spacer for flex-box;
         first modal step has no left side / back btn
       -->

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.scss
@@ -24,11 +24,8 @@
     }
   }
 
+  .condition-order,
   .consistency-rule,
-  .context {
-    width: 230px;
-  }
-
   .chips {
     width: 230px;
   }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, ViewChild, ElementRef, OnChanges } from '@angular/core';
-
+import { ASSIGNMENT_UNIT } from 'upgrade_types';
 import { AbstractControl } from '@angular/forms';
 import { BehaviorSubject } from 'rxjs';
 import {
@@ -73,6 +73,8 @@ export class MonitoredMetricsComponent implements OnInit, OnChanges, OnDestroy {
   queryComparisonStatisticError = [];
   queryMetricDropDownError = [];
 
+  currentAssignmentUnit: ASSIGNMENT_UNIT;
+
   constructor(
     private analysisService: AnalysisService,
     private _formBuilder: UntypedFormBuilder,
@@ -84,11 +86,15 @@ export class MonitoredMetricsComponent implements OnInit, OnChanges, OnDestroy {
   optionsSub() {
     this.allMetricsSub = this.analysisService.allMetrics$.subscribe((metrics) => {
       this.allMetrics = metrics;
-      this.options = this.allMetrics;
+      this.options =
+        this.currentAssignmentUnit === ASSIGNMENT_UNIT.WITHIN_SUBJECTS
+          ? this.allMetrics.filter((metric) => metric.children.length > 0)
+          : this.allMetrics;
     });
   }
 
   ngOnInit() {
+    this.experimentDesignStepperService.currentAssignmentUnit$.subscribe((unit) => (this.currentAssignmentUnit = unit));
     this.optionsSub();
     this.queryForm = this._formBuilder.group({
       queries: this._formBuilder.array([
@@ -208,12 +214,22 @@ export class MonitoredMetricsComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   get ContinuousRepeatedMeasure() {
-    const repeatedMeasure = Object.values(REPEATED_MEASURE);
+    const repeatedMeasure =
+      this.currentAssignmentUnit === ASSIGNMENT_UNIT.WITHIN_SUBJECTS
+        ? Object.values(REPEATED_MEASURE).filter(
+            (value) => value !== REPEATED_MEASURE.earliest && value !== REPEATED_MEASURE.mostRecent
+          )
+        : Object.values(REPEATED_MEASURE);
     return repeatedMeasure;
   }
 
   get CategoricalRepeatedMeasure() {
-    const repeatedMeasure = Object.values(REPEATED_MEASURE);
+    const repeatedMeasure =
+      this.currentAssignmentUnit === ASSIGNMENT_UNIT.WITHIN_SUBJECTS
+        ? Object.values(REPEATED_MEASURE).filter(
+            (value) => value !== REPEATED_MEASURE.earliest && value !== REPEATED_MEASURE.mostRecent
+          )
+        : Object.values(REPEATED_MEASURE);
     repeatedMeasure.shift();
     return repeatedMeasure;
   }

--- a/frontend/projects/upgrade/src/assets/i18n/en.json
+++ b/frontend/projects/upgrade/src/assets/i18n/en.json
@@ -61,6 +61,7 @@
   "home-global.status.text": "STATUS",
   "home-global.unit-of-assignment.text": "Unit of Assignment",
   "home-global.consistency-rule.text": "Consistency Rule",
+  "home-global.condition-order.text": "Condition Order",
   "home-global.design-type.text": "Design Type",
   "home-global.inclusion-criteria.text": "Inclusion Criteria",
   "home-global.post-experiment-rule.text": "Post Rule",
@@ -185,7 +186,7 @@
   "home.new-experiment.metrics.comparison-statistics-exist.validation.text": "Comparison Statistics are required",
   "home.new-experiment.metrics.description-exist.validation.text": "Query Name/Description is required",
   "home.new-experiment.metrics.metric-name-exist.validation.text": "Metric must be selected from the menu. Please choose an option.",
-  "home.new-experiment.metrics.unvalid-metric.text":"Metric must be selected from the menu. Please choose an option.",
+  "home.new-experiment.metrics.unvalid-metric.text": "Metric must be selected from the menu. Please choose an option.",
   "home.new-experiment.metrics.no-available-metrics.text": "Currently no metrics available to select. Metrics can be added later when available. You can continue to next step.",
   "home.new-experiment.schedule.start-automatically.text": "Start Automatically",
   "home.new-experiment.schedule.end-automatically.text": "End Automatically",
@@ -257,7 +258,7 @@
   "home.import-experiment.error.message.text": "Invalid Experiment JSON data",
   "home.import-experiment.old-version-error.message.text": "Warning: this experiment file is incompatible(older) with the current version of UpGrade. Some features may not import or function as intended. Continue with import?",
   "home.import-experiment.new-version-error.message.text": "Warning: this experiment file is incompatible(newer) with the current version of UpGrade. Some features may not import or function as intended. Continue with import?",
-  
+
   "home.import-experiment.missing-properties.message.text": "The document is missing the following properties: ",
   "home.import-experiment.multiple-files-import.warning.message.text": "Non-error experiments will be imported",
   "home.change-experiment-status.title.text": "Change Experiment Status",

--- a/types/src/Experiment/enums.ts
+++ b/types/src/Experiment/enums.ts
@@ -7,13 +7,13 @@ export enum CONSISTENCY_RULE {
 export enum ASSIGNMENT_UNIT {
   INDIVIDUAL = 'individual',
   GROUP = 'group',
-  WITHIN_SUBJECT = 'withinSubject',
+  WITHIN_SUBJECTS = 'within-subjects',
 }
 
-export enum WITHING_SUBJECT_ALGORITHM {
+export enum CONDITION_ORDER {
   RANDOM = 'random',
-  ROUND_ROBIN_RANDOM = 'roundRobinRandom',
-  ROUND_ROBIN_ORDERED = 'roundRobinOrdered',
+  RANDOM_ROUND_ROBIN = 'random round robin',
+  ORDERED_ROUND_ROBIN = 'ordered round robin',
 }
 
 export enum POST_EXPERIMENT_RULE {
@@ -51,7 +51,7 @@ export enum SERVER_ERROR {
   CONDITION_NOT_FOUND = 'Condition not found',
   EXPERIMENT_ID_MISSING_FOR_SHARED_DECISIONPOINT = 'Experiment ID not provided for shared Decision Point',
   INVALID_EXPERIMENT_ID_FOR_SHARED_DECISIONPOINT = 'Experiment ID provided is invalid for shared Decision Point',
-  UNSUPPORTED_CALIPER = 'Caliper profile or event not supported'
+  UNSUPPORTED_CALIPER = 'Caliper profile or event not supported',
 }
 
 export enum MARKED_DECISION_POINT_STATUS {
@@ -185,9 +185,9 @@ export enum PAYLOAD_TYPE {
 }
 
 export enum SUPPORTED_CALIPER_PROFILES {
-  GRADING = "GradingProfile"
+  GRADING = 'GradingProfile',
 }
 
 export enum SUPPORTED_CALIPER_EVENTS {
-  GRADE = "GradeEvent"
+  GRADE = 'GradeEvent',
 }

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -25,7 +25,7 @@ export {
   SUPPORTED_CALIPER_PROFILES,
   SUPPORTED_CALIPER_EVENTS,
   PAYLOAD_TYPE,
-  WITHING_SUBJECT_ALGORITHM,
+  CONDITION_ORDER,
 } from './Experiment/enums';
 export {
   IEnrollmentCompleteCondition,


### PR DESCRIPTION
Changes in the frontend:

1. Updating upgrade types
  a. Adding within subject in Unit of assignment enum
  b. Disable consistency rule
2. Adding new unit of assignment Within Subject with options (lets remove round robin fixed as it can be achieved through round robin ordered)
  a. Random
  b. Round robin random
  c. Round robin ordered
3. Update metrics
  a. hide non-repeatable/simple metrics
  b. For repeatable/group metrics hide Earliest and Most Recent option in Repeated Measure
  
Discussion needed:
  - No Repeated Measure option will appear for categorical metric in within-subjects experiment (after hiding the Earliest and Most Recent options). Should we not support categorical metrics in within-subjects experiments?
  - What should happen if the user creates a non-within-subjects experiment using simple metrics, then later change the Unit of Assignment to "Individual", should we remove only the simple metrics, or clear the whole metrics table?