### PR TITLE
:sparkles: Updated client lib bundler

### DIFF
--- a/clientlibs/js/package-lock.json
+++ b/clientlibs/js/package-lock.json
@@ -18,6 +18,7 @@
         "@types/jest": "^29.2.1",
         "@types/node": "^18.11.9",
         "@types/uuid": "^9.0.1",
+        "dts-bundle-generator": "^8.0.1",
         "jest": "^29.2.2",
         "ts-jest": "^29.1.0",
         "ts-loader": "^9.4.1",
@@ -1953,6 +1954,35 @@
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dts-bundle-generator": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/dts-bundle-generator/-/dts-bundle-generator-8.0.1.tgz",
+      "integrity": "sha512-9JVw78/OXdKfq+RUrmpLm6WAUJp+aOUGEHimVqIlOEH2VugRt1I8CVIoQZlirWZko+/SVZkNgpWCyZubUuzzPA==",
+      "dev": true,
+      "dependencies": {
+        "typescript": ">=5.0.2",
+        "yargs": "^17.6.0"
+      },
+      "bin": {
+        "dts-bundle-generator": "dist/bin/dts-bundle-generator.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/dts-bundle-generator/node_modules/typescript": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -6182,6 +6212,24 @@
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.2.0.tgz",
       "integrity": "sha512-413SY5JpYeSBZxmenGEmCVQ8mCgtFJF0w9PROdaS6z987XC2Pd2GOKqOITLtMftmyFZqgtCOb/QA7/Z3ZXfzIw==",
       "dev": true
+    },
+    "dts-bundle-generator": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/dts-bundle-generator/-/dts-bundle-generator-8.0.1.tgz",
+      "integrity": "sha512-9JVw78/OXdKfq+RUrmpLm6WAUJp+aOUGEHimVqIlOEH2VugRt1I8CVIoQZlirWZko+/SVZkNgpWCyZubUuzzPA==",
+      "dev": true,
+      "requires": {
+        "typescript": ">=5.0.2",
+        "yargs": "^17.6.0"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+          "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+          "dev": true
+        }
+      }
     },
     "electron-to-chromium": {
       "version": "1.4.284",

--- a/clientlibs/js/package.json
+++ b/clientlibs/js/package.json
@@ -2,13 +2,13 @@
   "name": "upgrade_client_lib",
   "version": "4.3.0",
   "description": "Client library to communicate with the Upgrade server",
-  "main": "dist/bundle.js",
-  "types": "dist/clientlibs/js/src/index.d.ts",
   "files": [
     "dist/*"
   ],
   "scripts": {
-    "build": "npm run clean && webpack",
+    "build:bundler": "webpack",
+    "build:types": "./node_modules/.bin/dts-bundle-generator -o dist/browser/index.d.ts src/index.ts && ./node_modules/.bin/dts-bundle-generator -o dist/node/index.d.ts src/index.ts",
+    "build": "npm run clean && npm run build:bundler && npm run build:types",
     "build:watch": "tsc -w",
     "clean": "rm -rf dist",
     "lint": "eslint -c ../../.eslintrc.js --ext .ts './{src, test}/**/*.ts' && npm run prettier:check",
@@ -25,6 +25,7 @@
     "@types/jest": "^29.2.1",
     "@types/node": "^18.11.9",
     "@types/uuid": "^9.0.1",
+    "dts-bundle-generator": "^8.0.1",
     "jest": "^29.2.2",
     "ts-jest": "^29.1.0",
     "ts-loader": "^9.4.1",

--- a/clientlibs/js/src/index.ts
+++ b/clientlibs/js/src/index.ts
@@ -1,1 +1,2 @@
-export { default as UpgradeClient } from './UpgradeClient';
+import UpgradeClient from './UpgradeClient';
+export default UpgradeClient;

--- a/clientlibs/js/webpack.config.ts
+++ b/clientlibs/js/webpack.config.ts
@@ -1,30 +1,44 @@
 const path = require("path");
 
-module.exports = {
-  mode: "production",
-  entry: "./src/index.ts",
+const generalConfiguration = {
+  mode: 'production',
+  entry: './src/index.ts',
   module: {
     rules: [
       {
         test: /\.tsx?$/,
-        use: "ts-loader",
-        exclude: [
-          /node_modules/,
-          /\.spec.ts$/
-        ],
+        use: 'ts-loader',
+        exclude: [/node_modules/, /\.spec.ts$/],
       },
     ],
   },
   resolve: {
     alias: {
-      upgrade_types: path.resolve(__dirname, "../../types/src"),
+      upgrade_types: path.resolve(__dirname, '../../types/src'),
     },
-    extensions: [".tsx", ".ts", ".js"],
-  },
-  output: {
-    filename: "bundle.js",
-    path: path.resolve(__dirname, "dist"),
-    libraryTarget: "umd",
-    library: "upgrade-client-lib",
+    extensions: ['.tsx', '.ts', '.js'],
   },
 };
+
+const browser = {
+  ...generalConfiguration,
+  output: {
+    filename: 'index.js',
+    path: path.resolve(__dirname, 'dist/browser'),
+    libraryTarget: 'umd',
+    library: 'upgrade-client-lib',
+  },
+};
+
+const node = {
+  ...generalConfiguration,
+  target: 'node',
+  output: {
+    filename: 'index.js',
+    path: path.resolve(__dirname, 'dist/node'),
+    libraryTarget: 'umd',
+    library: 'upgrade-client-lib',
+  },
+};
+
+module.exports = [browser, node];


### PR DESCRIPTION
Added separate bundler for browser and node environment
`UpgradeClient` is exported by default not a named export anymore.

# For browser
## Load as script
```
const lib = window["upgrade-client-lib"];
const Upgrade = lib.default;
const client = new Upgrade("user1", "http://localhost:8000", "portal");
```
## Load in typescript/es6 project
```
import UpgradeClient from 'upgrade_client_lib/dist/browser';
const client = new UpgradeClient("vivek", "http://localhost:3030", "math");
```
# For Node
```
import UpgradeClient from 'upgrade_client_lib/dist/node';
const client = new UpgradeClient("vivek", "http://localhost:3030", "math");
```
