### PR TITLE
mark back on client plus renaming and organization

### DIFF
--- a/backend/packages/Upgrade/test/unit/repositories/GroupEnrollmentRepository.test.ts
+++ b/backend/packages/Upgrade/test/unit/repositories/GroupEnrollmentRepository.test.ts
@@ -1,4 +1,4 @@
-import { SelectQueryBuilder } from 'typeorm';
+// import { SelectQueryBuilder } from 'typeorm';
 import * as sinon from 'sinon';
 import { GroupEnrollmentRepository } from '../../../src/api/repositories/GroupEnrollmentRepository';
 import { GroupEnrollment } from '../../../src/api/models/GroupEnrollment';
@@ -6,7 +6,7 @@ import { Experiment } from '../../../src/api/models/Experiment';
 
 let sandbox;
 let createQueryBuilderStub;
-const selectQueryBuilder = new SelectQueryBuilder<GroupEnrollmentRepository>(null);
+// const selectQueryBuilder = new SelectQueryBuilder<GroupEnrollmentRepository>(null);
 const repo = new GroupEnrollmentRepository();
 const err = new Error('test error');
 

--- a/backend/packages/Upgrade/test/unit/services/ExperimentAssignmentService.test.ts
+++ b/backend/packages/Upgrade/test/unit/services/ExperimentAssignmentService.test.ts
@@ -21,7 +21,7 @@ import { ScheduledJobService } from '../../../src/api/services/ScheduledJobServi
 import { SegmentService } from '../../../src/api/services/SegmentService';
 import { SettingService } from '../../../src/api/services/SettingService';
 import { SERVER_ERROR } from 'upgrade_types';
-import { simpleIndividualAssignmentExperiment, simpleGroupAssignmentExperiment, factorialGroupAssignmentExperiment, factorialIndividualAssignmentExperiment, simpleDPExperiment, simpleWithinSubjectOrderedRoundRobinExperiment, simpleWithinSubjectRandomRoundRobinExperiment, withinSubjectDPExperiment } from '../mockdata';
+import { simpleIndividualAssignmentExperiment, simpleGroupAssignmentExperiment, factorialGroupAssignmentExperiment, factorialIndividualAssignmentExperiment, simpleDPExperiment, simpleWithinSubjectOrderedRoundRobinExperiment, withinSubjectDPExperiment } from '../mockdata';
 import { ConditionPayloadRepository } from '../../../src/api/repositories/ConditionPayloadRepository';
 import { GroupEnrollment } from '../../../src/api/models/GroupEnrollment';
 import { MARKED_DECISION_POINT_STATUS } from 'upgrade_types';

--- a/clientlibs/js/src/Assignment.ts
+++ b/clientlibs/js/src/Assignment.ts
@@ -1,11 +1,11 @@
 import markDecisionPoint from "./functions/markDecisionPoint";
 import { IExperimentAssignmentv5, PAYLOAD_TYPE, EXPERIMENT_TYPE, IPayload, MARKED_DECISION_POINT_STATUS } from "../../../types/src";
-import { Interfaces } from "identifiers/Interfaces";
+import { UpGradeClientInterfaces } from "types/Interfaces";
 
 export default class Assignment {
   private _site: string;
   private _target: string;
-  private _clientState: Interfaces.IClientState;
+  private _clientState: UpGradeClientInterfaces.IClientState;
   private _conditionCode: string;
   private _payloadType: PAYLOAD_TYPE;
   private _payloadValue: string | null;
@@ -14,7 +14,7 @@ export default class Assignment {
 
   constructor(
     getAllDataPerDecisionPoint: IExperimentAssignmentv5,
-    clientState: Interfaces.IClientState,
+    clientState: UpGradeClientInterfaces.IClientState,
   ) {
     this._site = getAllDataPerDecisionPoint.site;
     this._target = getAllDataPerDecisionPoint.target;
@@ -63,6 +63,55 @@ export default class Assignment {
       return null;
     }
   }
+
+  /**
+   * Will record ("mark") that a user has "seen" an experiment condition per at the Assignment's decision point location (site + target).
+   * 
+   * Marking the decision point will record the user's condition assignment and the time of the decision point, regardless of whether the user is enrolled in an experiment.
+   * 
+   * @param status `status` signifies a client application's note on what it did in the code with condition assignment that Upgrade provided.
+   *  Status can be one of the following:
+   * 
+   * ```ts
+   * export enum MARKED_DECISION_POINT_STATUS {
+   *   CONDITION_APPLIED = 'condition applied',
+   *   CONDITION_FAILED_TO_APPLY = 'condition not applied',
+   *   NO_CONDITION_ASSIGNED = 'no condition assigned',
+   * }
+   * ```
+   * @param uniquifier A `uniquifier` unique string can be sent along to help tie a user's logged metrics to a specific marked condition.
+   * This identifier will also need to be sent when calling `upgradeClient.log()`
+   * This is required for 'within-subjects' experiments.
+   * 
+   * @param clientError The client can also send along an additional `clientError` string to log context as to why a condition was not applied.
+   * 
+   * @example
+   * ```ts
+   * import { MARKED_DECISION_POINT_STATUS } from 'upgrade_types';
+   * 
+   * const site = 'dashboard';
+   * const target = 'experimental button';
+   * const status: MARKED_DECISION_POINT_STATUS = MARKED_DECISION_POINT_STATUS.CONDITION_FAILED_TO_APPLY
+   * const clientError = 'variant not recognized'; //optional
+   * 
+   *  ```ts
+   * const assignment: Assignment[] = await upgradeClient.getDecisionPointAssignment(site, target);
+   * const markResponse = await assignment.markDecisionPoint(MARKED_DECISION_POINT_STATUS.CONDITION_APPLIED);
+   * ```
+   * 
+   * Note*: mark can also be called via `Client.markDecisionPoint()` without an Assignment object`:
+   * ```ts
+   * import { MARKED_DECISION_POINT_STATUS } from 'upgrade_types';
+   * 
+   * const site = 'dashboard';
+   * const target = 'experimental button';
+   * const condition = 'variant_x'; // send null if no condition / no experiment is running / error
+   * const status: MARKED_DECISION_POINT_STATUS = MARKED_DECISION_POINT_STATUS.CONDITION_FAILED_TO_APPLY
+   * const clientError = 'variant not recognized'; //optional
+   * 
+   * const markResponse = await upgradeClient.markDecisionPoint(site, target, condition, MARKED_DECISION_POINT_STATUS.CONDITION_APPLIED);
+   * ```
+   */
 
   public markDecisionPoint(status: MARKED_DECISION_POINT_STATUS, uniquifier?: string, clientError?: string) {
     return markDecisionPoint(

--- a/clientlibs/js/src/common/fetchDataService.ts
+++ b/clientlibs/js/src/common/fetchDataService.ts
@@ -1,4 +1,4 @@
-import { Interfaces, Types } from '../identifiers';
+import { UpGradeClientInterfaces, UpGradeClientEnums } from '../types';
 import axios, { AxiosRequestConfig } from 'axios';
 import * as uuid from 'uuid';
 
@@ -8,10 +8,10 @@ export default async function fetchDataService(
   token: string,
   clientSessionId: string,
   data: any,
-  requestType: Types.REQUEST_TYPES,
+  requestType: UpGradeClientEnums.REQUEST_TYPES,
   sendAsAnalytics = false,
   skipRetryOnStatusCodes: number[] = []
-): Promise<Interfaces.IResponse> {
+): Promise<UpGradeClientInterfaces.IResponse> {
   return await fetchData(url, token, clientSessionId, data, requestType, sendAsAnalytics, skipRetryOnStatusCodes);
 }
 
@@ -20,12 +20,12 @@ async function fetchData(
   token: string,
   clientSessionId: string,
   data: any,
-  requestType: Types.REQUEST_TYPES,
+  requestType: UpGradeClientEnums.REQUEST_TYPES,
   sendAsAnalytics = false,
   skipRetryOnStatusCodes: number[],
   retries = 3, // Retry request 3 times on failure
   backOff = 300
-): Promise<Interfaces.IResponse> {
+): Promise<UpGradeClientInterfaces.IResponse> {
   try {
     let headers: object = {
       'Content-Type': 'application/json',
@@ -65,7 +65,7 @@ async function fetchData(
       }
     }
 
-    if (requestType === Types.REQUEST_TYPES.POST || requestType === Types.REQUEST_TYPES.PATCH) {
+    if (requestType === UpGradeClientEnums.REQUEST_TYPES.POST || requestType === UpGradeClientEnums.REQUEST_TYPES.PATCH) {
       options = {
         ...options,
         data,

--- a/clientlibs/js/src/common/index.ts
+++ b/clientlibs/js/src/common/index.ts
@@ -1,0 +1,16 @@
+import { IExperimentAssignmentv5 } from "../../../../types/src";
+
+export function rotateAssignmentList(assignment: IExperimentAssignmentv5) {
+  if (assignment.assignedCondition.length > 1) {
+    assignment.assignedCondition.push(assignment.assignedCondition.shift());
+    if (assignment.assignedFactor) {
+      assignment.assignedFactor.push(assignment.assignedFactor.shift());
+    }
+  }
+  return assignment;
+}
+
+export function findExperimentAssignmentBySiteAndTarget(site: string, target: string, experimentAssignmentData: IExperimentAssignmentv5[]): IExperimentAssignmentv5 {
+  const assignment = experimentAssignmentData.find((assignment) => assignment.site === site && assignment.target === target);
+  return assignment;
+};

--- a/clientlibs/js/src/functions/addMetrics.ts
+++ b/clientlibs/js/src/functions/addMetrics.ts
@@ -1,4 +1,4 @@
-import { Types, Interfaces } from '../identifiers';
+import { UpGradeClientEnums, UpGradeClientInterfaces } from '../types';
 import fetchDataService from '../common/fetchDataService';
 import { ISingleMetric, IGroupMetric } from 'upgrade_types';
 
@@ -7,16 +7,16 @@ export default async function addMetrics(
   token: string,
   clientSessionId: string,
   metrics: (ISingleMetric | IGroupMetric)[]
-): Promise<Interfaces.IMetric[]> {
+): Promise<UpGradeClientInterfaces.IMetric[]> {
   const response = await fetchDataService(
     url,
     token,
     clientSessionId,
     { metricUnit: metrics },
-    Types.REQUEST_TYPES.POST
+    UpGradeClientEnums.REQUEST_TYPES.POST
   );
   if (response.status) {
-    response.data = response.data.map((metric: Interfaces.IMetric) => {
+    response.data = response.data.map((metric: UpGradeClientInterfaces.IMetric) => {
       return metric;
     });
     return response.data;

--- a/clientlibs/js/src/functions/getAllExperimentConditions.ts
+++ b/clientlibs/js/src/functions/getAllExperimentConditions.ts
@@ -1,6 +1,6 @@
 import fetchDataService from '../common/fetchDataService';
 import { IExperimentAssignmentv5 } from 'upgrade_types';
-import { Types } from '../identifiers';
+import { UpGradeClientEnums } from '../types';
 
 export default async function getAllExperimentConditions(
   url: string,
@@ -18,7 +18,7 @@ export default async function getAllExperimentConditions(
     token,
     clientSessionId,
     params,
-    Types.REQUEST_TYPES.POST
+    UpGradeClientEnums.REQUEST_TYPES.POST
   );
   if (experimentConditionResponse.status) {
     experimentConditionResponse.data = experimentConditionResponse.data.map((data: IExperimentAssignmentv5) => {

--- a/clientlibs/js/src/functions/getAllfeatureFlags.ts
+++ b/clientlibs/js/src/functions/getAllfeatureFlags.ts
@@ -1,5 +1,5 @@
 import fetchDataService from '../common/fetchDataService';
-import { Types } from '../identifiers';
+import { UpGradeClientEnums } from '../types';
 import { IFeatureFlag, IFlagVariation } from 'upgrade_types';
 
 export default async function getAllFeatureFlags(
@@ -7,7 +7,7 @@ export default async function getAllFeatureFlags(
   token: string,
   clientSessionId: string
 ): Promise<IFeatureFlag[]> {
-  const featureFlagResponse = await fetchDataService(url, token, clientSessionId, {}, Types.REQUEST_TYPES.GET);
+  const featureFlagResponse = await fetchDataService(url, token, clientSessionId, {}, UpGradeClientEnums.REQUEST_TYPES.GET);
   if (featureFlagResponse.status) {
     return featureFlagResponse.data.map((flag: IFeatureFlag) => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/clientlibs/js/src/functions/getDecisionPointAssignment.ts
+++ b/clientlibs/js/src/functions/getDecisionPointAssignment.ts
@@ -1,0 +1,26 @@
+import Assignment from '../Assignment';
+import { findExperimentAssignmentBySiteAndTarget } from '../common';
+import { Interfaces } from 'identifiers/Interfaces';
+
+export default function getDecisionPointAssignment(
+  site: string,
+  target: string,
+  clientState: Interfaces.IClientState
+): Assignment {
+  if (clientState?.allExperimentAssignmentData) {
+    const experimentAssignment = findExperimentAssignmentBySiteAndTarget(site, target, clientState.allExperimentAssignmentData)
+
+    if (experimentAssignment) {
+      const assignment = new Assignment(
+        experimentAssignment,
+        clientState,
+      );
+
+      return assignment;
+    } else {
+      return null;
+    }
+  } else {
+    return null;
+  }
+}

--- a/clientlibs/js/src/functions/getDecisionPointAssignment.ts
+++ b/clientlibs/js/src/functions/getDecisionPointAssignment.ts
@@ -1,11 +1,11 @@
 import Assignment from '../Assignment';
 import { findExperimentAssignmentBySiteAndTarget } from '../common';
-import { Interfaces } from 'identifiers/Interfaces';
+import { UpGradeClientInterfaces } from 'types/Interfaces';
 
 export default function getDecisionPointAssignment(
   site: string,
   target: string,
-  clientState: Interfaces.IClientState
+  clientState: UpGradeClientInterfaces.IClientState
 ): Assignment {
   if (clientState?.allExperimentAssignmentData) {
     const experimentAssignment = findExperimentAssignmentBySiteAndTarget(site, target, clientState.allExperimentAssignmentData)

--- a/clientlibs/js/src/functions/init.ts
+++ b/clientlibs/js/src/functions/init.ts
@@ -1,4 +1,4 @@
-import { Interfaces, Types } from '../identifiers';
+import { UpGradeClientInterfaces, UpGradeClientEnums } from '../types';
 import fetchDataService from '../common/fetchDataService';
 
 export default async function init(
@@ -8,7 +8,7 @@ export default async function init(
   clientSessionId: string,
   group?: Record<string, Array<string>>,
   workingGroup?: Record<string, string>
-): Promise<Interfaces.IUser> {
+): Promise<UpGradeClientInterfaces.IUser> {
   let data: any = {
     id: userId,
   };
@@ -27,7 +27,7 @@ export default async function init(
     };
   }
 
-  const response = await fetchDataService(url, token, clientSessionId, data, Types.REQUEST_TYPES.POST);
+  const response = await fetchDataService(url, token, clientSessionId, data, UpGradeClientEnums.REQUEST_TYPES.POST);
   if (response.status) {
     return response.data;
   } else {

--- a/clientlibs/js/src/functions/log.ts
+++ b/clientlibs/js/src/functions/log.ts
@@ -1,4 +1,4 @@
-import { Types, Interfaces } from '../identifiers';
+import { UpGradeClientEnums, UpGradeClientInterfaces } from '../types';
 import fetchDataService from '../common/fetchDataService';
 import { ILogInput } from 'upgrade_types';
 
@@ -9,7 +9,7 @@ export default async function log(
   clientSessionId: string,
   value: ILogInput[],
   sendAsAnalytics = false
-): Promise<Interfaces.ILog[]> {
+): Promise<UpGradeClientInterfaces.ILog[]> {
   const data = {
     userId,
     value,
@@ -19,7 +19,7 @@ export default async function log(
     token,
     clientSessionId,
     data,
-    Types.REQUEST_TYPES.POST,
+    UpGradeClientEnums.REQUEST_TYPES.POST,
     sendAsAnalytics
   );
   if (logResponse.status) {

--- a/clientlibs/js/src/functions/logCaliper.ts
+++ b/clientlibs/js/src/functions/logCaliper.ts
@@ -1,4 +1,4 @@
-import { Types, Interfaces } from '../identifiers';
+import { UpGradeClientEnums, UpGradeClientInterfaces } from '../types';
 import fetchDataService from '../common/fetchDataService';
 import { CaliperEnvelope } from 'upgrade_types';
 
@@ -9,13 +9,13 @@ export default async function logCaliper(
   clientSessionId: string,
   value: CaliperEnvelope,
   sendAsAnalytics = false
-): Promise<Interfaces.ILog[]> {
+): Promise<UpGradeClientInterfaces.ILog[]> {
     const logResponse = await fetchDataService(
       url,
       token,
       clientSessionId,
       value,
-      Types.REQUEST_TYPES.POST,
+      UpGradeClientEnums.REQUEST_TYPES.POST,
       sendAsAnalytics
     );
     if (logResponse.status) {

--- a/clientlibs/js/src/functions/markDecisionPoint.ts
+++ b/clientlibs/js/src/functions/markDecisionPoint.ts
@@ -1,4 +1,4 @@
-import { Interfaces, Types } from '../identifiers';
+import { UpGradeClientInterfaces, UpGradeClientEnums } from '../types';
 import fetchDataService from '../common/fetchDataService';
 import { IExperimentAssignmentv5, MARKED_DECISION_POINT_STATUS } from 'upgrade_types';
 import { findExperimentAssignmentBySiteAndTarget, rotateAssignmentList } from '../common';
@@ -15,7 +15,7 @@ export default async function markDecisionPoint(
   experimentAssignmentData: IExperimentAssignmentv5[],
   uniquifier?: string,
   clientError?: string
-): Promise<Interfaces.IMarkExperimentPoint> {
+): Promise<UpGradeClientInterfaces.IMarkExperimentPoint> {
   const assignment = findExperimentAssignmentBySiteAndTarget(site, target, experimentAssignmentData)
 
   if (!assignment) {
@@ -26,7 +26,7 @@ export default async function markDecisionPoint(
 
   const data = { ...assignment, assignedCondition: { ...assignment.assignedCondition[0], conditionCode : condition} };
 
-  let requestBody: Interfaces.IMarkDecisionPointRequestBody = {
+  let requestBody: UpGradeClientInterfaces.IMarkDecisionPointRequestBody = {
     userId,
     status,
     data,
@@ -44,7 +44,7 @@ export default async function markDecisionPoint(
       clientError,
     };
   }
-  const response = await fetchDataService(url, token, clientSessionId, requestBody, Types.REQUEST_TYPES.POST);
+  const response = await fetchDataService(url, token, clientSessionId, requestBody, UpGradeClientEnums.REQUEST_TYPES.POST);
   if (response.status) {
     return response.data;
   } else {

--- a/clientlibs/js/src/functions/setAltUserIds.ts
+++ b/clientlibs/js/src/functions/setAltUserIds.ts
@@ -1,4 +1,4 @@
-import { Types, Interfaces } from '../identifiers';
+import { UpGradeClientEnums, UpGradeClientInterfaces } from '../types';
 import fetchDataService from '../common/fetchDataService';
 
 export default async function setAltUserIds(
@@ -7,7 +7,7 @@ export default async function setAltUserIds(
   token: string,
   clientSessionId: string,
   altUserIds: string[]
-): Promise<Interfaces.IExperimentUserAliases[]> {
+): Promise<UpGradeClientInterfaces.IExperimentUserAliases[]> {
   const data = {
     userId,
     aliases: altUserIds,
@@ -18,7 +18,7 @@ export default async function setAltUserIds(
     token,
     clientSessionId,
     data,
-    Types.REQUEST_TYPES.PATCH,
+    UpGradeClientEnums.REQUEST_TYPES.PATCH,
     false,
     skipRetryOnStatusCodes
   );

--- a/clientlibs/js/src/functions/setGroupMembership.ts
+++ b/clientlibs/js/src/functions/setGroupMembership.ts
@@ -1,4 +1,4 @@
-import { Interfaces, Types } from '../identifiers';
+import { UpGradeClientInterfaces, UpGradeClientEnums } from '../types';
 import fetchDataService from '../common/fetchDataService';
 
 export default async function setGroupMembership(
@@ -7,13 +7,13 @@ export default async function setGroupMembership(
   token: string,
   clientSessionId: string,
   group: Record<string, Array<string>>
-): Promise<Interfaces.IUser> {
+): Promise<UpGradeClientInterfaces.IUser> {
   const response = await fetchDataService(
     url,
     token,
     clientSessionId,
     { id: userId, group: group },
-    Types.REQUEST_TYPES.PATCH
+    UpGradeClientEnums.REQUEST_TYPES.PATCH
   );
   if (response.status) {
     return response.data;

--- a/clientlibs/js/src/functions/setWorkingGroup.ts
+++ b/clientlibs/js/src/functions/setWorkingGroup.ts
@@ -1,4 +1,4 @@
-import { Interfaces, Types } from '../identifiers';
+import { UpGradeClientInterfaces, UpGradeClientEnums } from '../types';
 import fetchDataService from '../common/fetchDataService';
 
 export default async function setWorkingGroup(
@@ -7,13 +7,13 @@ export default async function setWorkingGroup(
   token: string,
   clientSessionId: string,
   workingGroup: Record<string, string>
-): Promise<Interfaces.IUser> {
+): Promise<UpGradeClientInterfaces.IUser> {
   const response = await fetchDataService(
     url,
     token,
     clientSessionId,
     { id: userId, workingGroup: workingGroup },
-    Types.REQUEST_TYPES.PATCH
+    UpGradeClientEnums.REQUEST_TYPES.PATCH
   );
   if (response.status) {
     return response.data;

--- a/clientlibs/js/src/identifiers/Interfaces.ts
+++ b/clientlibs/js/src/identifiers/Interfaces.ts
@@ -1,12 +1,32 @@
 /* eslint-disable @typescript-eslint/no-namespace */
-import { SERVER_ERROR, IMetricMetaData } from 'upgrade_types';
+import { SERVER_ERROR, IMetricMetaData, MARKED_DECISION_POINT_STATUS, IExperimentAssignmentv5 } from 'upgrade_types';
 import { Types } from './enums';
 
 export namespace Interfaces {
   export interface IConfig {
     hostURL: string;
     userId: string;
-    api: any;
+    api: IEndpoints;
+    clientSessionId?: string;
+    token?: string;
+  }
+  export interface IEndpoints {
+    init: string;
+    getAllExperimentConditions: string;
+    markDecisionPoint: string;
+    setGroupMemberShip: string;
+    setWorkingGroup: string;
+    failedExperimentPoint: string;
+    getAllFeatureFlag: string;
+    log: string;
+    logCaliper: string;
+    altUserIds: string;
+    addMetrics: string;
+  };
+
+  export interface IClientState {
+    config: IConfig;
+    allExperimentAssignmentData: IExperimentAssignmentv5[];
   }
 
   export interface IResponse {
@@ -31,6 +51,18 @@ export namespace Interfaces {
     id: string;
     group?: Record<string, Array<string>>;
     workingGroup?: Record<string, string>;
+  }
+
+  export interface IMarkDecisionPointRequestBody {
+    userId: string;
+    status: MARKED_DECISION_POINT_STATUS;
+    data: {
+      site: string;
+      target: string;
+      assignedCondition: { conditionCode: string; experimentId?: string };
+    };
+    uniquifier?: string;
+    clientError?: string;
   }
 
   export interface IMarkExperimentPoint {

--- a/clientlibs/js/src/identifiers/index.ts
+++ b/clientlibs/js/src/identifiers/index.ts
@@ -1,2 +1,0 @@
-export { Interfaces } from './Interfaces';
-export { Types } from './enums';

--- a/clientlibs/js/src/index.ts
+++ b/clientlibs/js/src/index.ts
@@ -2,10 +2,5 @@ import UpgradeClient from './UpgradeClient';
 import Assignment from './Assignment';
 import { UpGradeClientEnums, UpGradeClientInterfaces } from './types';
 import { MARKED_DECISION_POINT_STATUS } from '../../../types/src';
-export {
-  UpgradeClient,
-  Assignment,
-  UpGradeClientEnums,
-  UpGradeClientInterfaces,
-  MARKED_DECISION_POINT_STATUS
-};
+export default UpgradeClient;
+export { Assignment, UpGradeClientEnums, UpGradeClientInterfaces, MARKED_DECISION_POINT_STATUS };

--- a/clientlibs/js/src/index.ts
+++ b/clientlibs/js/src/index.ts
@@ -1,2 +1,11 @@
 import UpgradeClient from './UpgradeClient';
-export default UpgradeClient;
+import Assignment from './Assignment';
+import { UpGradeClientEnums, UpGradeClientInterfaces } from './types';
+import { MARKED_DECISION_POINT_STATUS } from '../../../types/src';
+export {
+  UpgradeClient,
+  Assignment,
+  UpGradeClientEnums,
+  UpGradeClientInterfaces,
+  MARKED_DECISION_POINT_STATUS
+};

--- a/clientlibs/js/src/types/Interfaces.ts
+++ b/clientlibs/js/src/types/Interfaces.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 import { SERVER_ERROR, IMetricMetaData, MARKED_DECISION_POINT_STATUS, IExperimentAssignmentv5 } from 'upgrade_types';
-import { Types } from './enums';
+import { UpGradeClientEnums } from './enums';
 
-export namespace Interfaces {
+export namespace UpGradeClientInterfaces {
   export interface IConfig {
     hostURL: string;
     userId: string;
@@ -37,7 +37,7 @@ export namespace Interfaces {
 
   export interface IRequestOptions {
     headers: object;
-    method: Types.REQUEST_TYPES;
+    method: UpGradeClientEnums.REQUEST_TYPES;
     keepalive: boolean;
     body?: string;
   }

--- a/clientlibs/js/src/types/enums.ts
+++ b/clientlibs/js/src/types/enums.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-namespace */
-export namespace Types {
+export namespace UpGradeClientEnums {
   export enum REQUEST_TYPES {
     GET = 'GET',
     POST = 'POST',

--- a/clientlibs/js/src/types/index.ts
+++ b/clientlibs/js/src/types/index.ts
@@ -1,0 +1,2 @@
+export { UpGradeClientInterfaces } from './Interfaces';
+export { UpGradeClientEnums } from './enums';

--- a/clientlibs/js/tsconfig.json
+++ b/clientlibs/js/tsconfig.json
@@ -23,6 +23,7 @@
   },
   "include": [
     "src",
-    ".eslintrc.js"
+    ".eslintrc.js",
+    "webpack.config.js"
   ]
 }

--- a/clientlibs/libTesters/client-lib-tester-frontend/package-lock.json
+++ b/clientlibs/libTesters/client-lib-tester-frontend/package-lock.json
@@ -34,6 +34,7 @@
         "@angular-devkit/build-angular": "^14.1.3",
         "@angular/cli": "~14.1.3",
         "@angular/compiler-cli": "^14.1.0",
+        "@types/webpack": "^5.28.1",
         "concurrently": "^8.2.0",
         "typescript": "~4.7.2"
       }
@@ -3444,6 +3445,17 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/webpack": {
+      "version": "5.28.1",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-5.28.1.tgz",
+      "integrity": "sha512-qw1MqGZclCoBrpiSe/hokSgQM/su8Ocpl3L/YHE0L6moyaypg4+5F7Uzq7NgaPKPxUxUbQ4fLPLpDWdR27bCZw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "tapable": "^2.2.0",
+        "webpack": "^5"
       }
     },
     "node_modules/@types/ws": {
@@ -14815,6 +14827,17 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/webpack": {
+      "version": "5.28.1",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-5.28.1.tgz",
+      "integrity": "sha512-qw1MqGZclCoBrpiSe/hokSgQM/su8Ocpl3L/YHE0L6moyaypg4+5F7Uzq7NgaPKPxUxUbQ4fLPLpDWdR27bCZw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "tapable": "^2.2.0",
+        "webpack": "^5"
       }
     },
     "@types/ws": {

--- a/clientlibs/libTesters/client-lib-tester-frontend/package.json
+++ b/clientlibs/libTesters/client-lib-tester-frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "preinstall": "npm run copy-local-js-build",
+    "postinstall": "npm run copy-local-js-build",
     "start": "ng serve --port 4201",
     "start:install": "npm install && npm run start",
     "start:ts": "concurrently \"npm run start:install\" \"(cd ../ts-lib-tester-backend-server && npm run start:build)\"",

--- a/clientlibs/libTesters/client-lib-tester-frontend/package.json
+++ b/clientlibs/libTesters/client-lib-tester-frontend/package.json
@@ -4,8 +4,7 @@
   "scripts": {
     "ng": "ng",
     "postinstall": "npm run copy-local-js-build",
-    "start": "ng serve --port 4201",
-    "start:install": "npm install && npm run start",
+    "start": "npm install && ng serve --port 4201",
     "start:ts": "concurrently \"npm run start:install\" \"(cd ../ts-lib-tester-backend-server && npm run start:build)\"",
     "copy-local-js-build": "mkdir -p node_modules/upgrade_client_local && cd ../../js/ && npm install && npm run build && cp -r ./{dist,package.json,README.md} ../libTesters/client-lib-tester-frontend/node_modules/upgrade_client_local",
     "watch": "ng build --watch --configuration development",

--- a/clientlibs/libTesters/client-lib-tester-frontend/package.json
+++ b/clientlibs/libTesters/client-lib-tester-frontend/package.json
@@ -37,6 +37,7 @@
     "@angular-devkit/build-angular": "^14.1.3",
     "@angular/cli": "~14.1.3",
     "@angular/compiler-cli": "^14.1.0",
+    "@types/webpack": "^5.28.1",
     "concurrently": "^8.2.0",
     "typescript": "~4.7.2"
   }

--- a/clientlibs/libTesters/client-lib-tester-frontend/src/app/mockFrontendClientAppComponents/general-test-for-version5.service.ts
+++ b/clientlibs/libTesters/client-lib-tester-frontend/src/app/mockFrontendClientAppComponents/general-test-for-version5.service.ts
@@ -10,21 +10,9 @@ import {
 } from '../../../../shared/models';
 import { CaliperEnvelope } from '../../../../../../types/src';
 
-// There's probably a clever way to do this, but getting the right types automatically is tricky
-
-import UpgradeClient from 'upgrade_client_local/dist/browser';
-// import { UpgradeClient } from 'upgrade_client_1_1_7';
-// import * as UpgradeClient_1_1_8 from "upgrade_client_1_1_8/dist/browser"
-// import { UpgradeClient } from 'upgrade_client_3_0_18';
-
+import { UpgradeClient, Assignment, UpGradeClientInterfaces, UpGradeClientEnums, MARKED_DECISION_POINT_STATUS } from 'upgrade_client_local/dist/browser';
 import { AbstractMockAppService } from './abstract-mock-app.service';
 import { MOCK_APP_NAMES } from '../../../../shared/constants';
-
-export enum MARKED_DECISION_POINT_STATUS {
-  CONDITION_APPLIED = 'condition applied',
-  CONDITION_FAILED_TO_APPLY = 'condition not applied',
-  NO_CONDITION_ASSIGNED = 'no condition assigned',
-}
 
 @Injectable({
   providedIn: 'root',
@@ -225,13 +213,13 @@ export class GeneralTestForVersion5Service extends AbstractMockAppService {
     } else if (name === this.HOOKNAMES.DP_ASSIGNMENT_TARGET_2) {
       this.doGetDecisionPointAssignment(this.TARGETS.TARGET_2);
     } else if (name === this.HOOKNAMES.MARK_TARGET_1_CONDITION_1) {
-      this.doMark(this.CONDITIONS.CONDITION_1);
+      this.doClientMark(this.CONDITIONS.CONDITION_1);
     } else if (name === this.HOOKNAMES.MARK_TARGET_1_CONDITION_2) {
-      this.doMark(this.CONDITIONS.CONDITION_2);
+      this.doClientMark(this.CONDITIONS.CONDITION_2);
     } else if (name === this.HOOKNAMES.MARK_TARGET_1_CONDITION_3) {
-      this.doMark(this.CONDITIONS.CONDITION_3);
+      this.doClientMark(this.CONDITIONS.CONDITION_3);
     } else if (name === this.HOOKNAMES.MARK_TARGET_1_CONDITION_4) {
-      this.doMark(this.CONDITIONS.CONDITION_4);
+      this.doClientMark(this.CONDITIONS.CONDITION_4);
     } else if (name === this.HOOKNAMES.SET_ALT_USER_IDS) {
       this.doUserAliases(user);
     } else if (name === this.HOOKNAMES.GROUP_MEMBERSHIP) {
@@ -288,17 +276,33 @@ export class GeneralTestForVersion5Service extends AbstractMockAppService {
     }
   }
 
-  private async doMark(condition: string) {
+  private async doClientMark(condition: string, uniquifier?: string) {
     if (!this.upgradeClient) {
       console.error('No upgradeClient found. Maybe you need to run login hook first?');
     }
     try {
-      const markResponse = await this.upgradeClient.markExperimentPoint(
+      const markResponse = await this.upgradeClient.markDecisionPoint(
         this.SITES.TEST,
         this.TARGETS.TARGET_1,
         condition,
         MARKED_DECISION_POINT_STATUS.CONDITION_APPLIED,
-        String(Math.floor(Math.random() * 1000000)) 
+        uniquifier
+      );
+      console.log({ markResponse });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  private async doAssignmentMark(uniquifier?: string) {
+    if (!this.upgradeClient) {
+      console.error('No upgradeClient found. Maybe you need to run login hook first?');
+    }
+    try {
+      const assignment: Assignment = await this.upgradeClient.getDecisionPointAssignment(this.SITES.TEST, this.TARGETS.TARGET_1);
+      const markResponse = await assignment.markDecisionPoint(
+        MARKED_DECISION_POINT_STATUS.CONDITION_APPLIED,
+        uniquifier
       );
       console.log({ markResponse });
     } catch (err) {

--- a/clientlibs/libTesters/client-lib-tester-frontend/src/app/mockFrontendClientAppComponents/general-test-for-version5.service.ts
+++ b/clientlibs/libTesters/client-lib-tester-frontend/src/app/mockFrontendClientAppComponents/general-test-for-version5.service.ts
@@ -8,9 +8,9 @@ import {
   MockClientAppInterfaceModel,
   MockClientAppUser,
 } from '../../../../shared/models';
-import { CaliperEnvelope } from '../../../../../../types/src';
 
-import { UpgradeClient, Assignment, UpGradeClientInterfaces, UpGradeClientEnums, MARKED_DECISION_POINT_STATUS } from 'upgrade_client_local/dist/browser';
+import UpgradeClient, { Assignment, UpGradeClientInterfaces } from 'upgrade_client_local/dist/browser';
+import { CaliperEnvelope, IExperimentAssignmentv5 } from 'upgrade_client_local/dist/types/src'
 import { AbstractMockAppService } from './abstract-mock-app.service';
 import { MOCK_APP_NAMES } from '../../../../shared/constants';
 
@@ -46,11 +46,11 @@ export class GeneralTestForVersion5Service extends AbstractMockAppService {
     ASSIGN: 'assign',
     DP_ASSIGNMENT_TARGET_1: 'getDecisionPointAssignment1',
     DP_ASSIGNMENT_TARGET_2: 'getDecisionPointAssignment2',
-    MARK_TARGET_1_CONDITION_1: 'markTarget1Condition1',
-    MARK_TARGET_1_CONDITION_2: 'markTarget1Condition2',
-    MARK_TARGET_1_CONDITION_3: 'markTarget1Condition3',
-    MARK_TARGET_1_CONDITION_4: 'markTarget1Condition4',
-    MARK_EXPERIMENT_POINT: 'markExperimentPoint',
+    MARK_ASSIGNMENT_TARGET_1_CONDITION_1: 'doAssignmentMark',
+    MARK_CLIENT_TARGET_1_CONDITION_1: 'doClientMark',
+    // MARK_TARGET_1_CONDITION_3: 'markTarget1Condition3',
+    // MARK_TARGET_1_CONDITION_4: 'markTarget1Condition4',
+    // MARK_EXPERIMENT_POINT: 'markExperimentPoint',
     GROUP_MEMBERSHIP: 'update_group',
     WORKING_GROUPS: 'update_working_group',
     SET_ALT_USER_IDS: 'setAltUserIds',
@@ -96,21 +96,21 @@ export class GeneralTestForVersion5Service extends AbstractMockAppService {
         //   description: 'Dispatches .markExperimentPoint() for target 1, control condition',
         // },
         {
-          name: this.HOOKNAMES.MARK_TARGET_1_CONDITION_1,
+          name: this.HOOKNAMES.MARK_ASSIGNMENT_TARGET_1_CONDITION_1,
           description: 'Dispatches .markExperimentPoint() for target 1, condition 1',
         },
         {
-          name: this.HOOKNAMES.MARK_TARGET_1_CONDITION_2,
+          name: this.HOOKNAMES.MARK_CLIENT_TARGET_1_CONDITION_1,
           description: 'Dispatches .markExperimentPoint() for target 1, condition 2',
         },
-        {
-          name: this.HOOKNAMES.MARK_TARGET_1_CONDITION_3,
-          description: 'Dispatches .markExperimentPoint() for target 1, condition 3',
-        },
-        {
-          name: this.HOOKNAMES.MARK_TARGET_1_CONDITION_4,
-          description: 'Dispatches .markExperimentPoint() for target 1, condition 4',
-        },
+        // {
+        //   name: this.HOOKNAMES.MARK_TARGET_1_CONDITION_3,
+        //   description: 'Dispatches .markExperimentPoint() for target 1, condition 3',
+        // },
+        // {
+        //   name: this.HOOKNAMES.MARK_TARGET_1_CONDITION_4,
+        //   description: 'Dispatches .markExperimentPoint() for target 1, condition 4',
+        // },
         {
           name: this.HOOKNAMES.SET_ALT_USER_IDS,
           description: 'Dispatches .setAltUserIds() for user',
@@ -153,20 +153,20 @@ export class GeneralTestForVersion5Service extends AbstractMockAppService {
         },
         {
           label: 'mark: target1, condition1',
-          hookName: this.HOOKNAMES.MARK_TARGET_1_CONDITION_1,
+          hookName: this.HOOKNAMES.MARK_ASSIGNMENT_TARGET_1_CONDITION_1,
         },
         {
           label: 'mark: target1, condition2',
-          hookName: this.HOOKNAMES.MARK_TARGET_1_CONDITION_2,
+          hookName: this.HOOKNAMES.MARK_CLIENT_TARGET_1_CONDITION_1,
         },
-        {
-          label: 'mark: target1, condition3',
-          hookName: this.HOOKNAMES.MARK_TARGET_1_CONDITION_3,
-        },
-        {
-          label: 'mark: target1, condition4',
-          hookName: this.HOOKNAMES.MARK_TARGET_1_CONDITION_4,
-        },
+        // {
+        //   label: 'mark: target1, condition3',
+        //   hookName: this.HOOKNAMES.MARK_TARGET_1_CONDITION_3,
+        // },
+        // {
+        //   label: 'mark: target1, condition4',
+        //   hookName: this.HOOKNAMES.MARK_TARGET_1_CONDITION_4,
+        // },
         // {
         //   label: 'markExperimentPoint',
         //   hookName: this.HOOKNAMES.MARK_EXPERIMENT_POINT,
@@ -212,14 +212,14 @@ export class GeneralTestForVersion5Service extends AbstractMockAppService {
       this.doGetDecisionPointAssignment(this.TARGETS.TARGET_1);
     } else if (name === this.HOOKNAMES.DP_ASSIGNMENT_TARGET_2) {
       this.doGetDecisionPointAssignment(this.TARGETS.TARGET_2);
-    } else if (name === this.HOOKNAMES.MARK_TARGET_1_CONDITION_1) {
+    } else if (name === this.HOOKNAMES.MARK_ASSIGNMENT_TARGET_1_CONDITION_1) {
+      this.doAssignmentMark();
+    } else if (name === this.HOOKNAMES.MARK_CLIENT_TARGET_1_CONDITION_1) {
       this.doClientMark(this.CONDITIONS.CONDITION_1);
-    } else if (name === this.HOOKNAMES.MARK_TARGET_1_CONDITION_2) {
-      this.doClientMark(this.CONDITIONS.CONDITION_2);
-    } else if (name === this.HOOKNAMES.MARK_TARGET_1_CONDITION_3) {
-      this.doClientMark(this.CONDITIONS.CONDITION_3);
-    } else if (name === this.HOOKNAMES.MARK_TARGET_1_CONDITION_4) {
-      this.doClientMark(this.CONDITIONS.CONDITION_4);
+    // } else if (name === this.HOOKNAMES.MARK_TARGET_1_CONDITION_3) {
+    //   this.doClientMark(this.CONDITIONS.CONDITION_3);
+    // } else if (name === this.HOOKNAMES.MARK_TARGET_1_CONDITION_4) {
+    //   this.doClientMark(this.CONDITIONS.CONDITION_4);
     } else if (name === this.HOOKNAMES.SET_ALT_USER_IDS) {
       this.doUserAliases(user);
     } else if (name === this.HOOKNAMES.GROUP_MEMBERSHIP) {
@@ -255,7 +255,7 @@ export class GeneralTestForVersion5Service extends AbstractMockAppService {
       throw new Error('No upgradeClient found. Maybe you need to run login hook first?');
     }
     try {
-      const assignmentsResponse = await this.upgradeClient.getAllExperimentConditions();
+      const assignmentsResponse: IExperimentAssignmentv5[] = await this.upgradeClient.getAllExperimentConditions();
       console.log({ assignmentsResponse });
     } catch (err) {
       console.error(err);
@@ -267,7 +267,31 @@ export class GeneralTestForVersion5Service extends AbstractMockAppService {
       console.error('No upgradeClient found. Maybe you need to run login hook first?');
     }
     try {
-      const dpAssignmentsResponse = await this.upgradeClient.getDecisionPointAssignment(this.SITES.TEST, target);
+      const dpAssignmentsResponse: Assignment = await this.upgradeClient.getDecisionPointAssignment(this.SITES.TEST, target);
+
+      if (!dpAssignmentsResponse) {
+        console.log({ dpAssignmentsResponse });
+        return;
+      }
+  
+      const condition = dpAssignmentsResponse.getCondition();
+      const payload = dpAssignmentsResponse.getPayload();
+      const getExperimentType = dpAssignmentsResponse.getExperimentType();
+      const factors = dpAssignmentsResponse.factors;
+
+      if (factors) {
+        const factorLevel = dpAssignmentsResponse.getFactorLevel(factors[0]);
+        const getFactorPayload = dpAssignmentsResponse.getFactorPayload(factors[0]);
+        console.log({ factorLevel });
+        console.log({ getFactorPayload });
+      }
+
+      console.log({ condition });
+      console.log({ payload });
+      console.log({ getExperimentType });
+      console.log({ factors });
+    
+
       console.log({ dpAssignmentsResponse });
       console.log('condition:', dpAssignmentsResponse.getCondition());
 
@@ -281,11 +305,11 @@ export class GeneralTestForVersion5Service extends AbstractMockAppService {
       console.error('No upgradeClient found. Maybe you need to run login hook first?');
     }
     try {
-      const markResponse = await this.upgradeClient.markDecisionPoint(
+      const markResponse: UpGradeClientInterfaces.IMarkExperimentPoint = await this.upgradeClient.markDecisionPoint(
         this.SITES.TEST,
         this.TARGETS.TARGET_1,
         condition,
-        MARKED_DECISION_POINT_STATUS.CONDITION_APPLIED,
+        UpgradeClient.MARKED_DECISION_POINT_STATUS.CONDITION_APPLIED,
         uniquifier
       );
       console.log({ markResponse });
@@ -301,7 +325,7 @@ export class GeneralTestForVersion5Service extends AbstractMockAppService {
     try {
       const assignment: Assignment = await this.upgradeClient.getDecisionPointAssignment(this.SITES.TEST, this.TARGETS.TARGET_1);
       const markResponse = await assignment.markDecisionPoint(
-        MARKED_DECISION_POINT_STATUS.CONDITION_APPLIED,
+        UpgradeClient.MARKED_DECISION_POINT_STATUS.CONDITION_APPLIED,
         uniquifier
       );
       console.log({ markResponse });
@@ -318,7 +342,7 @@ export class GeneralTestForVersion5Service extends AbstractMockAppService {
       console.error('User info is missing userAliases:', user);
     }
     try {
-      const useraliasesResponse = await this.upgradeClient.setAltUserIds(user.userAliases);
+      const useraliasesResponse: UpGradeClientInterfaces.IExperimentUserAliases[] = await this.upgradeClient.setAltUserIds(user.userAliases);
       console.log({ useraliasesResponse });
     } catch (err) {
       console.error(err);
@@ -333,7 +357,7 @@ export class GeneralTestForVersion5Service extends AbstractMockAppService {
       console.error('User info is missing groups:', user);
     }
     try {
-      const groupMembershipResponse = await this.upgradeClient.setGroupMembership(user.groups);
+      const groupMembershipResponse: UpGradeClientInterfaces.IUser = await this.upgradeClient.setGroupMembership(user.groups);
       console.log({ groupMembershipResponse });
     } catch (err) {
       console.error(err);
@@ -348,7 +372,7 @@ export class GeneralTestForVersion5Service extends AbstractMockAppService {
       console.error('User info is missing working groups:', user);
     }
     try {
-      const workingGroupMembershipResponse = await this.upgradeClient.setWorkingGroup(user.workingGroup);
+      const workingGroupMembershipResponse: UpGradeClientInterfaces.IUser = await this.upgradeClient.setWorkingGroup(user.workingGroup);
       console.log({ workingGroupMembershipResponse });
     } catch (err) {
       console.error(err);
@@ -394,7 +418,7 @@ export class GeneralTestForVersion5Service extends AbstractMockAppService {
       },
     ];
     try {
-      const logResponse = await this.upgradeClient.log(logRequest);
+      const logResponse: UpGradeClientInterfaces.ILog[] = await this.upgradeClient.log(logRequest);
       console.log({ logResponse });
     } catch (err) {
       console.error(err);

--- a/clientlibs/libTesters/client-lib-tester-frontend/src/app/mockFrontendClientAppComponents/general-test-for-version5.service.ts
+++ b/clientlibs/libTesters/client-lib-tester-frontend/src/app/mockFrontendClientAppComponents/general-test-for-version5.service.ts
@@ -39,15 +39,15 @@ export class GeneralTestForVersion5Service extends AbstractMockAppService {
   public TYPE: MockAppType = 'frontend';
   public LANGUAGE: CodeLanguage = 'ts';
   public SITES = {
-    TEST: 'test',
+    TEST: 'SelectSection',
   };
   public TARGETS = {
-    TARGET_1: 'target_1',
+    TARGET_1: 'targetC',
     TARGET_2: 'target_2',
   };
   public CONDITIONS = {
-    CONDITION_1: 'condition1',
-    CONDITION_2: 'condition2',
+    CONDITION_1: 'control',
+    CONDITION_2: 'variant_X',
     CONDITION_3: 'condition3',
     CONDITION_4: 'condition4',
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "eslint": "^8.26.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.2.1",
+        "eslint-plugin-tsdoc": "^0.2.17",
         "husky": "^8.0.1",
         "is-ci": "^3.0.0",
         "lint-staged": "^13.0.3",
@@ -103,6 +104,24 @@
       "version": "1.2.1",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz",
+      "integrity": "sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==",
+      "dev": true
+    },
+    "node_modules/@microsoft/tsdoc-config": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.16.2.tgz",
+      "integrity": "sha512-OGiIzzoBLgWWR0UdRJX98oYO+XKGf7tiK4Zk6tQ/E4IJqGCe7dvkTvgDZV5cFJUzLGDOjeAXrnZoA6QkVySuxw==",
+      "dev": true,
+      "dependencies": {
+        "@microsoft/tsdoc": "0.14.2",
+        "ajv": "~6.12.6",
+        "jju": "~1.4.0",
+        "resolve": "~1.19.0"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -841,6 +860,16 @@
         }
       }
     },
+    "node_modules/eslint-plugin-tsdoc": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.2.17.tgz",
+      "integrity": "sha512-xRmVi7Zx44lOBuYqG8vzTXuL6IdGOeF9nHX17bjJ8+VE6fsxpdGem0/SBTmAwgYMKYB1WBkqRJVQ+n8GK041pA==",
+      "dev": true,
+      "dependencies": {
+        "@microsoft/tsdoc": "0.14.2",
+        "@microsoft/tsdoc-config": "0.16.2"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "dev": true,
@@ -1111,6 +1140,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "dev": true,
@@ -1189,6 +1224,18 @@
       "version": "1.0.4",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -1284,6 +1331,18 @@
         "is-ci": "bin.js"
       }
     },
+    "node_modules/is-core-module": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
+      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "dev": true,
@@ -1345,6 +1404,12 @@
       "version": "2.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true
     },
     "node_modules/js-sdsl": {
       "version": "4.1.5",
@@ -1821,6 +1886,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "dev": true,
@@ -1920,6 +1991,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.1.0",
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-from": {
@@ -2423,6 +2507,24 @@
       "version": "1.2.1",
       "dev": true
     },
+    "@microsoft/tsdoc": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz",
+      "integrity": "sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==",
+      "dev": true
+    },
+    "@microsoft/tsdoc-config": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.16.2.tgz",
+      "integrity": "sha512-OGiIzzoBLgWWR0UdRJX98oYO+XKGf7tiK4Zk6tQ/E4IJqGCe7dvkTvgDZV5cFJUzLGDOjeAXrnZoA6QkVySuxw==",
+      "dev": true,
+      "requires": {
+        "@microsoft/tsdoc": "0.14.2",
+        "ajv": "~6.12.6",
+        "jju": "~1.4.0",
+        "resolve": "~1.19.0"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -2855,6 +2957,16 @@
         "prettier-linter-helpers": "^1.0.0"
       }
     },
+    "eslint-plugin-tsdoc": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.2.17.tgz",
+      "integrity": "sha512-xRmVi7Zx44lOBuYqG8vzTXuL6IdGOeF9nHX17bjJ8+VE6fsxpdGem0/SBTmAwgYMKYB1WBkqRJVQ+n8GK041pA==",
+      "dev": true,
+      "requires": {
+        "@microsoft/tsdoc": "0.14.2",
+        "@microsoft/tsdoc-config": "0.16.2"
+      }
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "dev": true,
@@ -3019,6 +3131,12 @@
       "version": "1.0.0",
       "dev": true
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
     "get-stream": {
       "version": "6.0.1",
       "dev": true
@@ -3064,6 +3182,15 @@
     "grapheme-splitter": {
       "version": "1.0.4",
       "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
     },
     "has-flag": {
       "version": "4.0.0",
@@ -3116,6 +3243,15 @@
         "ci-info": "^3.2.0"
       }
     },
+    "is-core-module": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
+      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
     "is-extglob": {
       "version": "2.1.1",
       "dev": true
@@ -3145,6 +3281,12 @@
     },
     "isexe": {
       "version": "2.0.0",
+      "dev": true
+    },
+    "jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
       "dev": true
     },
     "js-sdsl": {
@@ -3438,6 +3580,12 @@
       "version": "3.1.1",
       "dev": true
     },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
     "path-type": {
       "version": "4.0.0",
       "dev": true
@@ -3476,6 +3624,16 @@
     "regexpp": {
       "version": "3.2.0",
       "dev": true
+    },
+    "resolve": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.1.0",
+        "path-parse": "^1.0.6"
+      }
     },
     "resolve-from": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "eslint": "^8.26.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-tsdoc": "^0.2.17",
     "husky": "^8.0.1",
     "is-ci": "^3.0.0",
     "lint-staged": "^13.0.3",


### PR DESCRIPTION
This change:

- adds `markDecisionPoint` back to Client object
- changes `markExperimentPoint` to `markDecisionPoint`
- refactor and clean-up
- adds documentation
- improve the exported types so that everything mentioned in documentation is actually accessible as a type when 
- added better tests for within-subjects in client-lib tester