### PR TITLE
resolved issue of zero weight replaced by undefined

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
@@ -758,7 +758,7 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
         this.conditions.controls.forEach((control, index) => {
           const assignmentWeightFormControl = control.get(SIMPLE_EXP_CONSTANTS.FORM_CONTROL_NAMES.ASSIGNMENT_WEIGHT);
           assignmentWeightFormControl.setValue(
-            control.value.assignmentWeight ? control.value.assignmentWeight : this.previousAssignmentWeightValues[index]
+            control.value.assignmentWeight ? control.value.assignmentWeight : 0
           );
           if (this.isExperimentEditable) {
             assignmentWeightFormControl.enable();


### PR DESCRIPTION
This PR resolve issue of zero condition weight converted to undefined, so every time 0 had to get added.  
issue: if weight is 0 then we were getting value from previous weight value but it is only assigned for equal weight in conditions, in other case when equal weight checkout is false it stays as undefined. 