### PR TITLE
upgrade to node 18

### DIFF
--- a/.github/actions/backend-build/action.yml
+++ b/.github/actions/backend-build/action.yml
@@ -24,7 +24,7 @@ runs:
     - name: "[Backend] Install Package Dependencies"
       shell: bash
       working-directory: backend/packages/Upgrade
-      run: npm ci
+      run: npm ci --legacy-peer-deps
     - name: "[Backend] Install Build Dependencies"
       shell: bash
       working-directory: backend

--- a/.github/actions/generic-npm-build/action.yml
+++ b/.github/actions/generic-npm-build/action.yml
@@ -18,7 +18,7 @@ runs:
     - uses: tw3lveparsecs/github-actions-setvars@v0.1
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         check-latest: true
     - name: Set Version
       shell: bash

--- a/.github/actions/generic-npm-build/action.yml
+++ b/.github/actions/generic-npm-build/action.yml
@@ -12,13 +12,17 @@ inputs:
     description: Version to set in package.json
     required: false
     default: ""
+  node_version:
+    description: Version of nodejs to build with
+    required: false
+    default: 18
 runs:
   using: composite
   steps:
     - uses: tw3lveparsecs/github-actions-setvars@v0.1
     - uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: ${{ inputs.node_version }}
         check-latest: true
     - name: Set Version
       shell: bash

--- a/.github/variables/vars.env
+++ b/.github/variables/vars.env
@@ -1,4 +1,4 @@
-NODE_VERSION=16.15.0
+NODE_VERSION=18.17.1
 
 EB_DEV_APP_NAME=upgrade-experiment-app
 EB_DEV_ENV_NAME=dev-cli-upgrade-experiment-app

--- a/.github/workflows/bump-dev-version.yml
+++ b/.github/workflows/bump-dev-version.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '18'
         cache: 'npm'
 
     - name: Install npm packages

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -138,7 +138,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 16
       - name: Build Lambda
         working-directory: backend/packages/Scheduler
         run: |

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - run: npm install semver
       - name: Load Env Vars
         uses: tw3lveparsecs/github-actions-setvars@v0.1
@@ -88,7 +88,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: Set Backend App Version
         working-directory: backend/packages/Upgrade
         run: npm version ${{ needs.init.outputs.version }} --git-tag-version=false
@@ -97,7 +97,7 @@ jobs:
         run: |
           npm version ${{ needs.init.outputs.version }} --git-tag-version=false
           cp -R ../types packages/Upgrade
-          npm ci
+          npm ci --legacy-peer-deps
           zip -qq -r upgrade-backend-${{ needs.init.outputs.version }}.zip node_modules packages/Upgrade Dockerfile Dockerrun.aws.json package.json tsconfig.json
       - uses: actions/upload-artifact@v2
         with:
@@ -113,7 +113,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: Build Frontend
         working-directory: frontend
         run: |
@@ -138,7 +138,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: Build Lambda
         working-directory: backend/packages/Scheduler
         run: |

--- a/.github/workflows/lambda-deploy.yml
+++ b/.github/workflows/lambda-deploy.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           working_directory: backend/packages/Scheduler
           version: ${{ steps.set-vars.outputs.version }}
+          node_version: 16
       - name: Copy Files
         if: steps.check-tag.outputs.exists == 'false'
         working-directory: backend/packages/Scheduler

--- a/.github/workflows/lamdba-build.yml
+++ b/.github/workflows/lamdba-build.yml
@@ -12,3 +12,4 @@ jobs:
         with:
           name: Lambda
           working_directory: backend/packages/Scheduler
+          node_version: 16

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.3.0-alpine
+FROM node:18-alpine
 
 ENV NEW_RELIC_NO_CONFIG_FILE=true
 ENV NR_NATIVE_METRICS_NO_BUILD=true
@@ -8,7 +8,7 @@ WORKDIR /usr/src/app
 
 # Install app dependencies
 COPY . .
-RUN cd packages/Upgrade && npm ci
+RUN cd packages/Upgrade && npm ci --legacy-peer-deps
 ENV NODE_OPTIONS=--max_old_space_size=4096
 RUN ["npm", "run", "build:upgrade"]
 

--- a/backend/buildspec.yml
+++ b/backend/buildspec.yml
@@ -3,7 +3,7 @@ phases:
   install:
     runtime-versions:
       docker: 18
-      nodejs: 16
+      nodejs: 18
     commands:
       - docker pull postgres:latest
   pre_build:

--- a/backend/dev.Dockerfile
+++ b/backend/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.15.0-alpine
+FROM node:18-alpine
 
 ENV NEW_RELIC_NO_CONFIG_FILE=true
 ENV NR_NATIVE_METRICS_NO_BUILD=true

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,7 @@
     "version": "5.0.1",
     "description": "Backend for A/B Testing Project",
     "scripts": {
-        "install:all": "npm ci && cd packages/Scheduler && npm ci && cd ../Upgrade && npm ci",
+        "install:all": "npm ci && cd packages/Scheduler && npm ci && cd ../Upgrade && npm ci --legacy-peer-deps",
         "production:upgrade": "cd packages/Upgrade && npm run production",
         "build:upgrade": "cd packages/Upgrade && npm run build",
         "test:upgrade": "cd packages/Upgrade && npm run test",

--- a/backend/packages/Scheduler/serverless.yml
+++ b/backend/packages/Scheduler/serverless.yml
@@ -15,7 +15,7 @@ plugins:
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
   apiGateway:
     minimumCompressionSize: 1024 # Enable gzip compression for responses > 1 KB
   environment:

--- a/backend/packages/Scheduler/serverless.yml
+++ b/backend/packages/Scheduler/serverless.yml
@@ -15,7 +15,7 @@ plugins:
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs16.x
   apiGateway:
     minimumCompressionSize: 1024 # Enable gzip compression for responses > 1 KB
   environment:

--- a/backend/terraform/aws-lambda/variables.tf
+++ b/backend/terraform/aws-lambda/variables.tf
@@ -52,7 +52,7 @@ variable "function_handler" {
 
 variable "runtime" {
   description = "Lambda function runtime"
-  default     = "nodejs16.x"
+  default     = "nodejs18.x"
 }
 
 variable "TOKEN_SECRET_KEY" { 

--- a/backend/terraform/aws-lambda/variables.tf
+++ b/backend/terraform/aws-lambda/variables.tf
@@ -52,7 +52,7 @@ variable "function_handler" {
 
 variable "runtime" {
   description = "Lambda function runtime"
-  default     = "nodejs18.x"
+  default     = "nodejs16.x"
 }
 
 variable "TOKEN_SECRET_KEY" { 

--- a/backend/terraform/environments/bsnl/main.tf
+++ b/backend/terraform/environments/bsnl/main.tf
@@ -32,7 +32,7 @@ module "aws_lambda_function" {
   output_path           = "../environments/${var.current_directory}/.terraform" 
   function_name         = "Schedule" 
   function_handler      = "schedule.schedule"
-  runtime               =  "nodejs16.x"
+  runtime               =  "nodejs18.x"
 }
 
 output "lambda"{

--- a/backend/terraform/environments/production/main.tf
+++ b/backend/terraform/environments/production/main.tf
@@ -30,7 +30,7 @@ module "aws_lambda_function" {
   output_path           = "../environments/${var.current_directory}/.terraform"  
   function_name         = "Schedule" 
   function_handler      = "schedule.schedule"
-  runtime               =  "nodejs16.x"
+  runtime               =  "nodejs18.x"
   s3_lambda_bucket      = var.s3_lambda_bucket
   s3_lambda_key         = var.s3_lambda_key
 }

--- a/backend/terraform/environments/staging/main.tf
+++ b/backend/terraform/environments/staging/main.tf
@@ -30,7 +30,7 @@ module "aws_lambda_function" {
   output_path           = "../environments/${var.current_directory}/.terraform"  
   function_name         = "Schedule" 
   function_handler      = "schedule.schedule"
-  runtime               =  "nodejs16.x"
+  runtime               =  "nodejs18.x"
   s3_lambda_bucket      = var.s3_lambda_bucket
   s3_lambda_key         = var.s3_lambda_key
 }

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -19,7 +19,7 @@ setuplocal() {
 
     cp -R ../types packages/Upgrade
     cd packages/Upgrade
-    npm ci
+    npm ci --legacy-peer-deps
 
     cd ../../../frontend
     npm ci

--- a/docker.nix
+++ b/docker.nix
@@ -1,12 +1,12 @@
 let
     bootstrapPkgs = import <nixpkgs> {};
 
-    # nixos-21.11 ~ 2021-11-30
+    # nixos-22.11 ~ 2023-06-29
     pinnedPkgs = bootstrapPkgs.pkgs.fetchFromGitHub {
         owner = "NixOS";
         repo = "nixpkgs";
-        rev = "a7ecde854aee5c4c7cd6177f54a99d2c1ff28a31";
-        sha256 = "162dywda2dvfj1248afxc45kcrg83appjd0nmdb541hl7rnncf02";
+        rev = "1732ee9120e43c1df33a33004315741d0173d0b2";
+        sha256 = "sha256-BWXwhyT6a5b+SxnFhB8ktQGwnuDTq2RcKd3oD8SyimU=";
     };
 
     nixpkgs = import pinnedPkgs {};
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
     name = "upgrade-shell";
     buildInputs = 
         # packages everyone gets
-        [ bash nodejs-16_x python38 cacert ]
+        [ bash nodejs-18_x python38 cacert ]
         ++ lib.optional stdenv.isDarwin
         [ darwin.apple_sdk.frameworks.CoreServices ];
 }

--- a/frontend/buildspec.yml
+++ b/frontend/buildspec.yml
@@ -2,7 +2,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      nodejs: 16
+      nodejs: 18
   pre_build:
     commands:
       - npm install

--- a/frontend/dev.Dockerfile
+++ b/frontend/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.15.0-alpine
+FROM node:18-alpine
 
 WORKDIR /usr/src/app
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ab-testing",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ab-testing",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^15.2.8",
@@ -52,7 +52,7 @@
         "@types/jest": "^28.0.0",
         "@types/lodash.find": "^4.6.7",
         "@types/lodash.isequal": "^4.5.6",
-        "@types/node": "^16.0.0",
+        "@types/node": "^18.0.0",
         "@types/uuid": "^8.3.4",
         "codelyzer": "^6.0.2",
         "coverage-badge-creator": "^1.0.11",
@@ -5139,9 +5139,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.18.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.25.tgz",
-      "integrity": "sha512-rUDO6s9Q/El1R1I21HG4qw/LstTHCPO/oQNAwI/4b2f9EWvMnqt4d3HJwPMawfZ3UvodB8516Yg+VAq54YM+eA==",
+      "version": "18.17.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.6.tgz",
+      "integrity": "sha512-fGmT/P7z7ecA6bv/ia5DlaWCH4YeZvAQMNpUhrJjtAhOhZfoxS1VLUgU2pdk63efSjQaOJWdXMuAJsws+8I6dg==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -25699,9 +25699,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.18.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.25.tgz",
-      "integrity": "sha512-rUDO6s9Q/El1R1I21HG4qw/LstTHCPO/oQNAwI/4b2f9EWvMnqt4d3HJwPMawfZ3UvodB8516Yg+VAq54YM+eA==",
+      "version": "18.17.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.6.tgz",
+      "integrity": "sha512-fGmT/P7z7ecA6bv/ia5DlaWCH4YeZvAQMNpUhrJjtAhOhZfoxS1VLUgU2pdk63efSjQaOJWdXMuAJsws+8I6dg==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -78,7 +78,7 @@
     "@types/jest": "^28.0.0",
     "@types/lodash.find": "^4.6.7",
     "@types/lodash.isequal": "^4.5.6",
-    "@types/node": "^16.0.0",
+    "@types/node": "^18.0.0",
     "@types/uuid": "^8.3.4",
     "codelyzer": "^6.0.2",
     "coverage-badge-creator": "^1.0.11",

--- a/regression/tsconfig.json
+++ b/regression/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json.schemastore.org/tsconfig",
-    "display": "Node 16",
+    "display": "Node 18",
     "compilerOptions": {
         "lib": [
             "esnext"


### PR DESCRIPTION
This PR:
- sets all the CI values for node to 18
- updates the nix package to one that's compatible with node 18
- changes install commands to ignore peer dependency errors (npm got stricter about that)