### PR TITLE
🐛 Bugfix for jumbled sorting of experiment list for lower and upper case experiment names

### DIFF
--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -62,7 +62,13 @@ import { Level } from '../models/Level';
 import { LevelRepository } from '../repositories/LevelRepository';
 import { LevelCombinationElement } from '../models/LevelCombinationElement';
 import { LevelCombinationElementRepository } from '../repositories/LevelCombinationElements';
-import { ConditionValidator, ExperimentDTO, FactorValidator, PartitionValidator, ParticipantsValidator } from '../DTO/ExperimentDTO';
+import {
+  ConditionValidator,
+  ExperimentDTO,
+  FactorValidator,
+  PartitionValidator,
+  ParticipantsValidator,
+} from '../DTO/ExperimentDTO';
 import { ConditionPayloadDTO } from '../DTO/ConditionPayloadDTO';
 import { FactorDTO } from '../DTO/FactorDTO';
 import { LevelDTO } from '../DTO/LevelDTO';
@@ -165,7 +171,7 @@ export class ExperimentService {
       .whereInIds(expIds);
 
     if (sortParams) {
-      queryBuilderToReturn = queryBuilderToReturn.addOrderBy(`experiment.${sortParams.key}`, sortParams.sortAs);
+      queryBuilderToReturn = queryBuilderToReturn.addOrderBy(`LOWER(experiment.${sortParams.key})`, sortParams.sortAs);
     }
     const experiments = await queryBuilderToReturn.getMany();
     return experiments.map((experiment) => {
@@ -757,7 +763,7 @@ export class ExperimentService {
         this.checkConditionCodeDefault(conditions);
 
         // creating condition docs
-        const conditionDocToSave: Array<Partial<Omit <ExperimentCondition, 'levelCombinationElements'>>> =
+        const conditionDocToSave: Array<Partial<Omit<ExperimentCondition, 'levelCombinationElements'>>> =
           (conditions &&
             conditions.length > 0 &&
             conditions.map((condition: ConditionValidator) => {
@@ -796,7 +802,7 @@ export class ExperimentService {
                 })
               );
               decisionPoint.id = decisionPoint.id || uuid();
-              return { ...decisionPoint, experiment: experimentDoc }
+              return { ...decisionPoint, experiment: experimentDoc };
             })) ||
           [];
 
@@ -1517,7 +1523,7 @@ export class ExperimentService {
     return { ...experiment, factors: updatedFactors, conditionPayloads: updatedConditionPayloads };
   }
 
-  private includeExcludeSegmentCreation (
+  private includeExcludeSegmentCreation(
     experimentSegment: ParticipantsValidator,
     experimentDocSegmentData: ExperimentSegmentInclusion | ExperimentSegmentExclusion,
     experimentId: string,
@@ -1618,7 +1624,7 @@ export class ExperimentService {
       const array = condition.levelCombinationElements.map((elements) => {
         elements.id = elements.id || uuid();
         // elements.condition = condition;
-        return { ...elements, condition: condition }
+        return { ...elements, condition: condition };
       });
       allLevelCombinationElements.push(...array);
     });

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-list/experiment-list.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-list/experiment-list.component.ts
@@ -64,6 +64,8 @@ export class ExperimentListComponent implements OnInit, OnDestroy, AfterViewInit
     this.allExperimentsSub = this.experimentService.experiments$.subscribe((allExperiments) => {
       this.allExperiments = new MatTableDataSource();
       this.allExperiments.data = [...allExperiments];
+      this.allExperiments.sortingDataAccessor = (item, property) =>
+        property === 'name' ? item.name.toLowerCase() : item[property];
       this.allExperiments.sort = this.sort;
       this.applyFilter(this.searchValue);
     });


### PR DESCRIPTION
When we have experiments with both lowercase and uppercase as first character, the current sorting of experiments on home dashboard is jumbled. This PR has fix for that from both backend and frontend.

Before:
<img width="1280" alt="Screenshot 2023-09-01 at 2 11 31 PM" src="https://github.com/CarnegieLearningWeb/UpGrade/assets/33730817/fe220a77-de55-4876-a2f5-2e0cc830f6e2">
<img width="1277" alt="Screenshot 2023-09-01 at 2 11 37 PM" src="https://github.com/CarnegieLearningWeb/UpGrade/assets/33730817/0cfdbc0d-6a6d-4cbd-8f4e-c5862f87f32d">

After:
<img width="1278" alt="Screenshot 2023-09-01 at 2 10 53 PM" src="https://github.com/CarnegieLearningWeb/UpGrade/assets/33730817/eeaa503d-aa23-4b83-9e18-52d59e991396">
