### PR TITLE
Level elements type error in condition for factorial experiment

### DIFF
--- a/frontend/projects/upgrade/src/app/core/experiment-design-stepper/experiment-design-stepper.service.ts
+++ b/frontend/projects/upgrade/src/app/core/experiment-design-stepper/experiment-design-stepper.service.ts
@@ -49,9 +49,7 @@ import {
   FactorLevelData,
   FactorialFactorTableRowData,
   FactorialLevelTableRowData,
-  ExperimentFactorialFormDesignData,
   ExperimentFactorData,
-  ExperimentLevelData,
 } from './store/experiment-design-stepper.model';
 import {
   actionUpdateFactorialConditionTableData,
@@ -344,18 +342,6 @@ export class ExperimentDesignStepperService {
     });
 
     return conditionPayloads;
-  }
-
-  createFactorialDesignDataFromForm(
-    factorialFormDesignData: ExperimentFactorialFormDesignData
-  ): ExperimentFactorData[] {
-    const factorsData: ExperimentFactorData[] = factorialFormDesignData.factors.map((factor) => {
-      const levelsData: ExperimentLevelData[] = factor.levels.map((level) => {
-        return { ...level, payload: { type: PAYLOAD_TYPE.STRING, value: level.payload } };
-      });
-      return { ...factor, levels: levelsData };
-    });
-    return factorsData;
   }
 
   createNewFactorialConditionTableData(designData: ExperimentFactorialDesignData): FactorialConditionTableRowData[] {

--- a/frontend/projects/upgrade/src/app/core/experiment-design-stepper/store/experiment-design-stepper.model.ts
+++ b/frontend/projects/upgrade/src/app/core/experiment-design-stepper/store/experiment-design-stepper.model.ts
@@ -144,28 +144,6 @@ export interface ExperimentLevelData {
   };
 }
 
-//Form data with payload as string
-export interface ExperimentFactorialFormDesignData {
-  factors: ExperimentFactorFormData[];
-}
-
-export interface ExperimentFactorialLevelDesignData {
-  levels: FactorialLevelTableRowData[];
-}
-
-export interface ExperimentFactorFormData {
-  name: string;
-  description: string;
-  order: number;
-  levels: ExperimentLevelFormData[];
-}
-
-export interface ExperimentLevelFormData {
-  id: string;
-  name: string;
-  payload: string;
-}
-
 export interface ExperimentDesignStepperState {
   hasExperimentStepperDataChanged: boolean;
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/factorial-experiment-design/factorial-experiment-design.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/factorial-experiment-design/factorial-experiment-design.component.html
@@ -480,18 +480,19 @@
                                 [matTooltip]="
                                   factorialExperimentDesignForm.getRawValue('payload')?.factors[factorIndex]?.levels[
                                     levelPayloadIndex
-                                  ]?.payload
+                                  ]?.payload?.value
                                 "
                                 matTooltipPosition="above"
                               >
                                 {{
                                   factorialExperimentDesignForm.getRawValue('payload')?.factors[factorIndex]?.levels[
                                     levelPayloadIndex
-                                  ]?.payload | truncate: 35
+                                  ]?.payload?.value | truncate: 35
                                 }}
                               </span>
                             </ng-container>
                             <ng-container
+                              formGroupName="payload"
                               *ngIf="
                                 (levelsTableEditIndex$ | async) === levelPayloadIndex &&
                                 (factorsTableIndex$ | async) === factorIndex
@@ -502,15 +503,15 @@
                                   [matTooltip]="
                                     factorialExperimentDesignForm.getRawValue('payload')?.factors[factorIndex]?.levels[
                                       levelPayloadIndex
-                                    ]?.payload
+                                    ]?.payload?.value
                                   "
                                   matTooltipPosition="above"
                                 >
                                   <input
                                     matInput
                                     [placeholder]="'home.new-experiment.design.payload.placeholder.text' | translate"
-                                    formControlName="payload"
-                                    [value]="payload"
+                                    formControlName="value"
+                                    [value]="payload?.value"
                                     autocomplete="off"
                                   />
                                 </span>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/factorial-experiment-design/factorial-experiment-design.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/factorial-experiment-design/factorial-experiment-design.component.ts
@@ -31,13 +31,14 @@ import { ExperimentDesignStepperService } from '../../../../../core/experiment-d
 import {
   DecisionPointsTableRowData,
   ExperimentConditionPayloadRequestObject,
-  ExperimentFactorialFormDesignData,
+  ExperimentFactorialDesignData,
   FactorialConditionRequestObject,
   FactorialConditionTableRowData,
   FactorialFactorTableRowData,
   FactorialLevelTableRowData,
 } from '../../../../../core/experiment-design-stepper/store/experiment-design-stepper.model';
 import { FACTORIAL_EXP_CONSTANTS } from './factorial-experiment-design.constants';
+import { PAYLOAD_TYPE } from '../../../../../../../../../../types/src';
 
 @Component({
   selector: 'home-factorial-experiment-design',
@@ -311,7 +312,7 @@ export class FactorialExperimentDesignComponent implements OnInit, OnChanges, On
     return this._formBuilder.group({
       id: [id || uuidv4()],
       name: [name, Validators.required],
-      payload: [payload],
+      payload: this._formBuilder.group({ type: PAYLOAD_TYPE.STRING, value: [payload] }),
     });
   }
 
@@ -495,7 +496,7 @@ export class FactorialExperimentDesignComponent implements OnInit, OnChanges, On
     return !this.levelPointErrors.length;
   }
 
-  validateFactorCount(factorialExperimentDesignFormData: ExperimentFactorialFormDesignData) {
+  validateFactorCount(factorialExperimentDesignFormData: ExperimentFactorialDesignData) {
     this.factorCountError = null;
     this.levelCountError = null;
     this.expandedId = 0;
@@ -524,7 +525,7 @@ export class FactorialExperimentDesignComponent implements OnInit, OnChanges, On
     } else {
       this.factorCountError = factorCountErrorMsg;
     }
-    this.expandedId--;
+    this.expandedId;
   }
 
   validateConditionCount() {
@@ -751,9 +752,7 @@ export class FactorialExperimentDesignComponent implements OnInit, OnChanges, On
       );
 
       order = 1;
-      const factorsDesignFormData = this.experimentDesignStepperService.createFactorialDesignDataFromForm(
-        this.factorialExperimentDesignForm.value
-      );
+      const factorsDesignFormData = this.factorialExperimentDesignForm.value.factors;
       factorialExperimentDesignFormData.factors = factorsDesignFormData.map((factor, index) => {
         return this.experimentInfo
           ? { ...this.experimentInfo.factors[index], ...factor, order: order++ }


### PR DESCRIPTION
Issue was that payload for `levelelements` in condition was expected as `{type: payload type, value: string}` but it was sending it as `string`, we were converting payload from `string` to  `{type: payload type, value: string}` when we go next or save the data but because `conditionTable` was updating live on every change we perform in `factorTable` it was reading it directly from form as `string`. I have changed format in form to `{type: payload type, value: string}` format so this issue is resolved.