### PR TITLE
try using workflow branch input as commit target in release flow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -168,7 +168,7 @@ jobs:
       - uses: ncipollo/release-action@v1
         with:
           artifacts: "**/upgrade-*.zip"
-          commit: main
+          commit: ${{ github.ref }}
           generateReleaseNotes: true
           tag: ${{ needs.init.outputs.version }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
"Create-release" workflow currently hardcodes `main` as the target for tagging a release. We use "Create-release" to deploy what is really a "release-candidate" to staging... the only issue is that when merging bugfixes into the release branch, we would like to just punch the "create-release" button again to redeploy. This all works but it puts the tag on the HEAD of main instead of the release branch (which I only recently realized, we have had some very weird looking tags on main).

This change is an attempt to put the release tag commit on the HEAD of the release branch instead (which will tend to be a squashed bugfix commit), which I believe can be accessed by the `git.ref` input that is indicated by the user when choosing the workflow branch to run the job on.