### PR TITLE
Fix/issue-1000 Updated mark call related changes

### DIFF
--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v4.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v4.ts
@@ -528,7 +528,6 @@ export class ExperimentClientController {
       }
       return {
         ...rest,
-        experimentType: assignedFactor ? EXPERIMENT_TYPE.FACTORIAL : EXPERIMENT_TYPE.SIMPLE,
         assignedCondition: {
           id: assignedCondition[0].id,
           conditionCode: assignedCondition[0].conditionCode,
@@ -663,7 +662,7 @@ export class ExperimentClientController {
     @Req()
     request: AppRequest
   ): Promise<Log[]> {
-    let result = envelope.data.map(async log => {
+    const result = envelope.data.map(async (log) => {
       // getOriginalUserDoc call for alias
       const experimentUserDoc = await this.getUserDoc(log.object.assignee.id, request.logger);
       if (experimentUserDoc) {

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v4.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v4.ts
@@ -23,7 +23,6 @@ import {
   IUserAliases,
   IWorkingGroup,
   PAYLOAD_TYPE,
-  EXPERIMENT_TYPE,
   IPayload,
 } from 'upgrade_types';
 import { FeatureFlag } from '../models/FeatureFlag';

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v5.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v5.ts
@@ -22,7 +22,6 @@ import {
   IGroupMembership,
   IUserAliases,
   IWorkingGroup,
-  EXPERIMENT_TYPE,
   PAYLOAD_TYPE,
   IPayload,
 } from 'upgrade_types';
@@ -540,7 +539,6 @@ export class ExperimentClientController {
       });
       return {
         ...rest,
-        experimentType: assignedFactor ? EXPERIMENT_TYPE.FACTORIAL : EXPERIMENT_TYPE.SIMPLE,
         assignedCondition: finalConditionData,
         assignedFactor: assignedFactor ? finalFactorData : undefined,
       };

--- a/backend/packages/Upgrade/src/api/controllers/validators/MarkExperimentValidator.v4.ts
+++ b/backend/packages/Upgrade/src/api/controllers/validators/MarkExperimentValidator.v4.ts
@@ -1,6 +1,17 @@
 import { Type } from 'class-transformer';
-import { IsNotEmpty, IsDefined, IsString, IsOptional, IsEnum, IsObject, ValidateIf, ValidateNested, ValidationOptions, registerDecorator } from 'class-validator';
-import { EXPERIMENT_TYPE, MARKED_DECISION_POINT_STATUS, PAYLOAD_TYPE } from 'upgrade_types';
+import {
+  IsNotEmpty,
+  IsDefined,
+  IsString,
+  IsOptional,
+  IsEnum,
+  IsObject,
+  ValidateIf,
+  ValidateNested,
+  ValidationOptions,
+  registerDecorator,
+} from 'class-validator';
+import { MARKED_DECISION_POINT_STATUS, PAYLOAD_TYPE } from 'upgrade_types';
 
 const IsAssignedFactorRecord = (validationOptions?: ValidationOptions) => {
   return function (object: unknown, propertyName: string) {
@@ -15,16 +26,14 @@ const IsAssignedFactorRecord = (validationOptions?: ValidationOptions) => {
       },
       validator: {
         validate(value: any) {
-          return validateAssignedFactorData(value)
+          return validateAssignedFactorData(value);
         },
       },
     });
   };
 };
 
-function validateAssignedFactorData(
-  data: any
-): boolean {
+function validateAssignedFactorData(data: any): boolean {
   const keys = Object.keys(data);
   for (const key of keys) {
     const factor = data[key];
@@ -45,9 +54,7 @@ function isValidAssignedFactor(value: any): value is AssignedFactor {
 
 function isValidPayload(value: any): value is Payload {
   return (
-    typeof value === 'object' &&
-    Object.values(PAYLOAD_TYPE).includes(value.type) &&
-    typeof value.value === 'string'
+    typeof value === 'object' && Object.values(PAYLOAD_TYPE).includes(value.type) && typeof value.value === 'string'
   );
 }
 class Payload {
@@ -71,20 +78,13 @@ class AssignedFactor {
 }
 
 class AssignedCondition {
-  @IsNotEmpty()
+  @IsOptional()
   @IsString()
-  id: string;
+  id?: string;
 
-  @IsDefined()
-  @IsNotEmpty()
+  @IsOptional()
   @IsString()
-  conditionCode: string;
-
-  @IsObject()
-  @ValidateNested()
-  @ValidateIf((object, value) => value !== null)
-  @Type(() => Payload)
-  payload: Payload | null;
+  conditionCode?: string;
 
   @IsOptional()
   @IsString()
@@ -99,11 +99,6 @@ class Data {
 
   @IsString()
   target: string;
-
-  @IsEnum(EXPERIMENT_TYPE)
-  @IsDefined()
-  @IsNotEmpty()
-  experimentType: EXPERIMENT_TYPE;
 
   @IsOptional()
   @ValidateNested()

--- a/backend/packages/Upgrade/src/api/controllers/validators/MarkExperimentValidator.v5.ts
+++ b/backend/packages/Upgrade/src/api/controllers/validators/MarkExperimentValidator.v5.ts
@@ -87,12 +87,6 @@ class AssignedCondition {
   @IsString()
   conditionCode?: string;
 
-  @IsObject()
-  @ValidateNested()
-  @ValidateIf((object, value) => value !== null)
-  @Type(() => Payload)
-  payload: Payload | null;
-
   @IsOptional()
   @IsString()
   experimentId?: string;

--- a/backend/packages/Upgrade/src/api/controllers/validators/MarkExperimentValidator.v5.ts
+++ b/backend/packages/Upgrade/src/api/controllers/validators/MarkExperimentValidator.v5.ts
@@ -1,6 +1,17 @@
 import { Type } from 'class-transformer';
-import { IsNotEmpty, IsDefined, IsString, IsOptional, IsEnum, IsObject, ValidateNested, ValidateIf, ValidationOptions, registerDecorator } from 'class-validator';
-import { EXPERIMENT_TYPE, MARKED_DECISION_POINT_STATUS, PAYLOAD_TYPE } from 'upgrade_types';
+import {
+  IsNotEmpty,
+  IsDefined,
+  IsString,
+  IsOptional,
+  IsEnum,
+  IsObject,
+  ValidateNested,
+  ValidateIf,
+  ValidationOptions,
+  registerDecorator,
+} from 'class-validator';
+import { MARKED_DECISION_POINT_STATUS, PAYLOAD_TYPE } from 'upgrade_types';
 
 const IsAssignedFactorRecord = (validationOptions?: ValidationOptions) => {
   return function (object: unknown, propertyName: string) {
@@ -15,16 +26,14 @@ const IsAssignedFactorRecord = (validationOptions?: ValidationOptions) => {
       },
       validator: {
         validate(value: any) {
-          return validateAssignedFactorData(value)
+          return validateAssignedFactorData(value);
         },
       },
     });
   };
 };
 
-function validateAssignedFactorData(
-  data: any
-): boolean {
+function validateAssignedFactorData(data: any): boolean {
   const keys = Object.keys(data);
   for (const key of keys) {
     const factor = data[key];
@@ -45,9 +54,7 @@ function isValidAssignedFactor(value: any): value is AssignedFactor {
 
 function isValidPayload(value: any): value is Payload {
   return (
-    typeof value === 'object' &&
-    Object.values(PAYLOAD_TYPE).includes(value.type) &&
-    typeof value.value === 'string'
+    typeof value === 'object' && Object.values(PAYLOAD_TYPE).includes(value.type) && typeof value.value === 'string'
   );
 }
 
@@ -72,14 +79,13 @@ class AssignedFactor {
 }
 
 class AssignedCondition {
-  @IsNotEmpty()
+  @IsOptional()
   @IsString()
-  id: string;
+  id?: string;
 
-  @IsDefined()
-  @IsNotEmpty()
+  @IsOptional()
   @IsString()
-  conditionCode: string;
+  conditionCode?: string;
 
   @IsObject()
   @ValidateNested()
@@ -100,11 +106,6 @@ class Data {
 
   @IsString()
   target: string;
-
-  @IsEnum(EXPERIMENT_TYPE)
-  @IsDefined()
-  @IsNotEmpty()
-  experimentType: EXPERIMENT_TYPE;
 
   @IsOptional()
   @ValidateNested()

--- a/clientlibs/js/src/common/index.ts
+++ b/clientlibs/js/src/common/index.ts
@@ -1,4 +1,4 @@
-import { IExperimentAssignmentv5 } from "../../../../types/src";
+import { IExperimentAssignmentv5, PAYLOAD_TYPE } from 'upgrade_types';
 
 export function rotateAssignmentList(assignment: IExperimentAssignmentv5) {
   if (assignment.assignedCondition.length > 1) {
@@ -10,7 +10,25 @@ export function rotateAssignmentList(assignment: IExperimentAssignmentv5) {
   return assignment;
 }
 
-export function findExperimentAssignmentBySiteAndTarget(site: string, target: string, experimentAssignmentData: IExperimentAssignmentv5[]): IExperimentAssignmentv5 {
-  const assignment = experimentAssignmentData.find((assignment) => assignment.site === site && assignment.target === target);
-  return assignment;
-};
+export function findExperimentAssignmentBySiteAndTarget(
+  site: string,
+  target: string,
+  experimentAssignmentData: IExperimentAssignmentv5[]
+): IExperimentAssignmentv5 {
+  const assignment = experimentAssignmentData.find(
+    (assignment) => assignment.site === site && assignment.target === target
+  );
+  return (
+    assignment || {
+      site: site,
+      target: target,
+      assignedCondition: [
+        {
+          conditionCode: null,
+          payload: null,
+          id: null,
+        },
+      ],
+    }
+  );
+}

--- a/clientlibs/js/src/functions/getDecisionPointAssignment.ts
+++ b/clientlibs/js/src/functions/getDecisionPointAssignment.ts
@@ -8,18 +8,14 @@ export default function getDecisionPointAssignment(
   clientState: UpGradeClientInterfaces.IClientState
 ): Assignment {
   if (clientState?.allExperimentAssignmentData) {
-    const experimentAssignment = findExperimentAssignmentBySiteAndTarget(site, target, clientState.allExperimentAssignmentData)
+    const experimentAssignment = findExperimentAssignmentBySiteAndTarget(
+      site,
+      target,
+      clientState.allExperimentAssignmentData
+    );
 
-    if (experimentAssignment) {
-      const assignment = new Assignment(
-        experimentAssignment,
-        clientState,
-      );
-
-      return assignment;
-    } else {
-      return null;
-    }
+    const assignment = new Assignment(experimentAssignment, clientState);
+    return assignment;
   } else {
     return null;
   }

--- a/clientlibs/js/src/functions/markDecisionPoint.ts
+++ b/clientlibs/js/src/functions/markDecisionPoint.ts
@@ -16,15 +16,11 @@ export default async function markDecisionPoint(
   uniquifier?: string,
   clientError?: string
 ): Promise<UpGradeClientInterfaces.IMarkExperimentPoint> {
-  const assignment = findExperimentAssignmentBySiteAndTarget(site, target, experimentAssignmentData)
-
-  if (!assignment) {
-    throw new Error('No assignment found');
-  }
+  const assignment = findExperimentAssignmentBySiteAndTarget(site, target, experimentAssignmentData);
 
   rotateAssignmentList(assignment);
 
-  const data = { ...assignment, assignedCondition: { ...assignment.assignedCondition[0], conditionCode : condition} };
+  const data = { ...assignment, assignedCondition: { ...assignment.assignedCondition[0], conditionCode: condition } };
 
   let requestBody: UpGradeClientInterfaces.IMarkDecisionPointRequestBody = {
     userId,
@@ -44,7 +40,13 @@ export default async function markDecisionPoint(
       clientError,
     };
   }
-  const response = await fetchDataService(url, token, clientSessionId, requestBody, UpGradeClientEnums.REQUEST_TYPES.POST);
+  const response = await fetchDataService(
+    url,
+    token,
+    clientSessionId,
+    requestBody,
+    UpGradeClientEnums.REQUEST_TYPES.POST
+  );
   if (response.status) {
     return response.data;
   } else {


### PR DESCRIPTION
Fix/Issue-1000
Remove Assignment if statement which throws Assignment when not found, instead send the Assignment object with no condition details. This way, the user can mark this Assignment.

Fix/Issue-999
Remove unnecessary experimentType property from Assign & Mark call of V5