### PR TITLE
bugfix: send status as string

### DIFF
--- a/clientlibs/java/pom.xml
+++ b/clientlibs/java/pom.xml
@@ -8,8 +8,8 @@
 		changed in the next comment. that increases the likelihood that two PRs in-flight 
 		at the same time that happen to rev to the same new version will be caught 
 		by a merge conflict. -->
-    <!-- 3.1.2 -> 3.1.3: revert apache connector, use method workaround -->
-	<version>3.1.3</version>
+    <!-- 3.1.3 -> 3.1.4: bugfix: send status as string -->
+	<version>3.1.4</version>
 	<build>
 		<plugins>
 			<plugin>

--- a/clientlibs/java/src/main/java/org/upgradeplatform/requestbeans/MarkExperimentRequest.java
+++ b/clientlibs/java/src/main/java/org/upgradeplatform/requestbeans/MarkExperimentRequest.java
@@ -9,7 +9,7 @@ public class MarkExperimentRequest {
 	private String site;
 	private String target;
 	private String condition;
-	private MarkedDecisionPointStatus status;
+	private String status;
 	
 	public MarkExperimentRequest() {}
 
@@ -27,7 +27,7 @@ public class MarkExperimentRequest {
 		this.site = site;
 		this.target = target;
 		this.condition = condition;
-		this.status = status;
+		this.status = status.toString();
 	}
 
 	public String getUserId() {
@@ -62,11 +62,11 @@ public class MarkExperimentRequest {
 		this.condition = condition;
 	}
 
-	public MarkedDecisionPointStatus getStatus() {
+	public String getStatus() {
 		return status;
 	}
 
 	public void setStatus(MarkedDecisionPointStatus status){
-		this.status = status;
+		this.status = status.toString();
 	}
 }


### PR DESCRIPTION
If needed, alternative is to loosen type validation on the optional "status" param in mark.