### PR TITLE
turn off validation for v1 mark endpoint

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ab_testing_backend",
-    "version": "5.0.6",
+    "version": "5.0.7",
     "description": "Backend for A/B Testing Project",
     "scripts": {
         "install:all": "npm ci && cd packages/Scheduler && npm ci && cd ../Upgrade && npm ci --legacy-peer-deps",

--- a/backend/packages/Scheduler/package.json
+++ b/backend/packages/Scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppl-upgrade-serverless",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "description": "Serverless webpack example using Typescript",
   "main": "handler.js",
   "scripts": {

--- a/backend/packages/Upgrade/package.json
+++ b/backend/packages/Upgrade/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ab_testing_backend",
-    "version": "5.0.6",
+    "version": "5.0.7",
     "description": "Backend for A/B Testing Project",
     "main": "index.js",
     "scripts": {

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v1.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v1.ts
@@ -17,12 +17,7 @@ import { ExperimentAssignmentValidator } from './validators/ExperimentAssignment
 import { ExperimentUser } from '../models/ExperimentUser';
 import { ExperimentUserService } from '../services/ExperimentUserService';
 import { UpdateWorkingGroupValidator } from './validators/UpdateWorkingGroupValidator';
-import {
-  SERVER_ERROR,
-  IGroupMembership,
-  IUserAliases,
-  IWorkingGroup,
-} from 'upgrade_types';
+import { SERVER_ERROR, IGroupMembership, IUserAliases, IWorkingGroup } from 'upgrade_types';
 import { FailedParamsValidator } from './validators/FailedParamsValidator.v1';
 import { ExperimentError } from '../models/ExperimentError';
 import { FeatureFlag } from '../models/FeatureFlag';
@@ -420,7 +415,7 @@ export class ExperimentClientController {
   public async markExperimentPoint(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     experiment: MarkExperimentValidator
   ): Promise<IMonitoredDeciosionPoint> {
     request.logger.info({ message: 'Starting the markExperimentPoint call for user' });

--- a/clientlibs/java/pom.xml
+++ b/clientlibs/java/pom.xml
@@ -9,8 +9,9 @@
 		at the same time that happen to rev to the same new version will be caught 
 		by a merge conflict. -->
 
-	<!-- 4.3.0 -> 4.3.1: add javadoc for condition code vs. payload value -->
-	<version>5.0.6</version>
+  <!-- 5.0.6 -> 5.0.7: turn off v1 mark validation -->
+
+	<version>5.0.7</version>
 	<build>
 		<plugins>
 			<plugin>

--- a/clientlibs/java/src/main/java/org/upgradeplatform/client/Main.java
+++ b/clientlibs/java/src/main/java/org/upgradeplatform/client/Main.java
@@ -69,7 +69,9 @@ public class Main {
                                                     System.out.println(prefix() + "success getting condition; marking");
 
                                                     Condition condition = expResult.getAssignedCondition();
-                                                    String code = condition == null ? null : condition.getConditionCode();
+                                                    // String code = condition == null ? null : condition.getConditionCode();
+                                                    String code = null;
+
                                                     System.out.println(condition);
                                                     System.out.println(code);
                                                     expResult.markDecisionPoint(MarkedDecisionPointStatus.CONDITION_APPLIED, new Date().toString(), new ResponseCallback<MarkDecisionPoint>(){

--- a/clientlibs/js/package.json
+++ b/clientlibs/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upgrade_client_lib",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "description": "Client library to communicate with the Upgrade server",
   "files": [
     "dist/*"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ab-testing",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "UpGrade",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "UpGrade",
-      "version": "5.0.6",
+      "version": "5.0.7",
       "license": "ISC",
       "devDependencies": {
         "@angular-eslint/eslint-plugin": "^14.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "UpGrade",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "description": "This is a combined repository for UpGrade, an open-source platform to support large-scale A/B testing in educational applications.  Learn more at www.upgradeplatform.org",
   "main": "index.js",
   "devDependencies": {

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upgrade_types",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "description": "",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
Let me know if this is the right approach. _V1_ mark endpoint is the only one we care about loosening up (I think I misspoke and said v4 endpoint in mtg).

This will allow us to keep using the already deployed v3 Java client version in Mathia if and when we need to promote UpGrade to v5 in prod first.

Once Mathia has deployed a v4+ Java library in prod, the v1 endpoints will no longer be used by anyone in CL, so this is a temporary thing before we officially deprecate the v1 endpoints (and v3 Java library).