### PR TITLE
no retries on 4xx, max_retries=1

### DIFF
--- a/clientlibs/java/pom.xml
+++ b/clientlibs/java/pom.xml
@@ -8,8 +8,8 @@
 		changed in the next comment. that increases the likelihood that two PRs in-flight 
 		at the same time that happen to rev to the same new version will be caught 
 		by a merge conflict. -->
-    <!-- 3.1.3 -> 3.1.4: bugfix: send status as string -->
-	<version>3.1.4</version>
+    <!-- 3.1.4 -> 3.1.5: no retries for 4xx, retry other errors once instead of 3 times -->
+	<version>3.1.5</version>
 	<build>
 		<plugins>
 			<plugin>

--- a/clientlibs/java/src/main/java/org/upgradeplatform/utils/PublishingRetryCallback.java
+++ b/clientlibs/java/src/main/java/org/upgradeplatform/utils/PublishingRetryCallback.java
@@ -7,6 +7,7 @@ import javax.ws.rs.client.InvocationCallback;
 import javax.ws.rs.core.Response;
 
 import static javax.ws.rs.core.Response.Status.Family.SUCCESSFUL;
+import static javax.ws.rs.core.Response.Status.Family.CLIENT_ERROR;
 
 public class PublishingRetryCallback<T> implements InvocationCallback<Response> {
 
@@ -35,7 +36,10 @@ public class PublishingRetryCallback<T> implements InvocationCallback<Response> 
 
 	@Override
 	public void completed(Response response) {
-		if (SUCCESSFUL.equals(response.getStatusInfo().getFamily()) || retries <= 0) {
+    boolean isSuccess = SUCCESSFUL.equals(response.getStatusInfo().getFamily());
+    boolean isClientRequestError = CLIENT_ERROR.equals(response.getStatusInfo().getFamily());
+  
+		if (isSuccess || isClientRequestError || retries <= 0) {
 			callback.completed(response);
 		} else {
 			retry();

--- a/clientlibs/java/src/main/java/org/upgradeplatform/utils/Utils.java
+++ b/clientlibs/java/src/main/java/org/upgradeplatform/utils/Utils.java
@@ -33,7 +33,7 @@ public class Utils
 
 	public static final String PATCH = "PATCH";
 
-	public static final int MAX_RETRIES = 3;
+	public static final int MAX_RETRIES = 1;
 
 
 	public static enum RequestType {


### PR DESCRIPTION
#1047

This will need to get merged down into release/v4.1 then into release/v5.0, with new Java libs published for each.