### PR TITLE
disable experiment client controller validation

### DIFF
--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
@@ -1,13 +1,4 @@
-import {
-  JsonController,
-  Post,
-  Body,
-  UseBefore,
-  Get,
-  Req,
-  InternalServerError,
-  Delete,
-} from 'routing-controllers';
+import { JsonController, Post, Body, UseBefore, Get, Req, InternalServerError, Delete } from 'routing-controllers';
 import { ExperimentService } from '../services/ExperimentService';
 import { ExperimentAssignmentService } from '../services/ExperimentAssignmentService';
 import { MarkExperimentValidator } from './validators/MarkExperimentValidator';
@@ -178,7 +169,7 @@ export class ExperimentClientController {
   public async init(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     experimentUser: ExperimentUserValidator
   ): Promise<Pick<ExperimentUser, 'id' | 'group' | 'workingGroup'>> {
     request.logger.info({ message: 'Starting the init call for user' });
@@ -255,7 +246,7 @@ export class ExperimentClientController {
   public async setGroupMemberShip(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     experimentUser: ExperimentUserValidator
   ): Promise<ExperimentUser> {
     request.logger.info({ message: 'Starting the groupmembership call for user' });
@@ -318,7 +309,7 @@ export class ExperimentClientController {
   public async setWorkingGroup(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     workingGroupParams: UpdateWorkingGroupValidator
   ): Promise<ExperimentUser> {
     request.logger.info({ message: 'Starting the workinggroup call for user' });
@@ -421,7 +412,7 @@ export class ExperimentClientController {
   public async markExperimentPoint(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     experiment: MarkExperimentValidator
   ): Promise<MonitoredDecisionPoint> {
     request.logger.info({ message: 'Starting the markExperimentPoint call for user' });
@@ -542,7 +533,7 @@ export class ExperimentClientController {
   public async getAllExperimentConditions(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     experiment: ExperimentAssignmentValidator
   ): Promise<IExperimentAssignment[]> {
     request.logger.info({ message: 'Starting the getAllExperimentConditions call for user' });
@@ -636,7 +627,7 @@ export class ExperimentClientController {
   public async log(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     logData: LogValidator
   ): Promise<Log[]> {
     request.logger.info({ message: 'Starting the log call for user' });
@@ -679,7 +670,7 @@ export class ExperimentClientController {
   public async caliperLog(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     envelope: CaliperLogEnvelope
   ): Promise<Log[]> {
     const result = envelope.data.map(async (log) => {
@@ -804,7 +795,7 @@ export class ExperimentClientController {
   public async failedExperimentPoint(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     errorBody: FailedParamsValidator
   ): Promise<ExperimentError> {
     const experimentUserDoc = await this.getUserDoc(errorBody.userId, request.logger);
@@ -873,7 +864,7 @@ export class ExperimentClientController {
   public async filterMetrics(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     metric: MetricValidator
   ): Promise<Metric[]> {
     return await this.metricService.saveAllMetrics(metric.metricUnit, request.logger);

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v1.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v1.ts
@@ -175,7 +175,7 @@ export class ExperimentClientController {
   public async init(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     experimentUser: ExperimentUserValidator
   ): Promise<Pick<ExperimentUser, 'id' | 'group' | 'workingGroup'>> {
     request.logger.info({ message: 'Starting the init call for user' });
@@ -252,7 +252,7 @@ export class ExperimentClientController {
   public async setGroupMemberShip(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     experimentUser: ExperimentUserValidator
   ): Promise<IGroupMembership> {
     request.logger.info({ message: 'Starting the groupmembership call for user' });
@@ -320,7 +320,7 @@ export class ExperimentClientController {
   public async setWorkingGroup(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     workingGroupParams: UpdateWorkingGroupValidator
   ): Promise<IWorkingGroup> {
     request.logger.info({ message: 'Starting the workinggroup call for user' });
@@ -499,7 +499,7 @@ export class ExperimentClientController {
   public async getAllExperimentConditions(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     experiment: ExperimentAssignmentValidator
   ): Promise<IExperimentAssignment[]> {
     request.logger.info({ message: 'Starting the getAllExperimentConditions call for user' });
@@ -592,7 +592,7 @@ export class ExperimentClientController {
   public async log(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     logData: LogValidator
   ): Promise<Omit<Log, 'createdAt' | 'updatedAt' | 'versionNumber'>[]> {
     request.logger.info({ message: 'Starting the log call for user' });
@@ -636,7 +636,7 @@ export class ExperimentClientController {
    */
   @Post('log/caliper')
   public async caliperLog(
-    @Body({ validate: true })
+    @Body({ validate: false })
     @Req()
     request: AppRequest,
     envelope: CaliperLogEnvelope
@@ -763,7 +763,7 @@ export class ExperimentClientController {
   public async failedExperimentPoint(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     errorBody: FailedParamsValidator
   ): Promise<ExperimentError> {
     const experimentUserDoc = await this.getUserDoc(errorBody.userId, request.logger);
@@ -832,7 +832,7 @@ export class ExperimentClientController {
   public async filterMetrics(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     metric: MetricValidator
   ): Promise<Metric[]> {
     return await this.metricService.saveAllMetrics(metric.metricUnit, request.logger);

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v4.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v4.ts
@@ -174,7 +174,7 @@ export class ExperimentClientController {
   public async init(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     experimentUser: ExperimentUserValidator
   ): Promise<Pick<ExperimentUser, 'id' | 'group' | 'workingGroup'>> {
     request.logger.info({ message: 'Starting the init call for user' });
@@ -251,7 +251,7 @@ export class ExperimentClientController {
   public async setGroupMemberShip(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     experimentUser: ExperimentUserValidator
   ): Promise<IGroupMembership> {
     request.logger.info({ message: 'Starting the groupmembership call for user' });
@@ -319,7 +319,7 @@ export class ExperimentClientController {
   public async setWorkingGroup(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     workingGroupParams: UpdateWorkingGroupValidator
   ): Promise<IWorkingGroup> {
     request.logger.info({ message: 'Starting the workinggroup call for user' });
@@ -414,7 +414,7 @@ export class ExperimentClientController {
   public async markExperimentPoint(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     experiment: MarkExperimentValidatorv4
   ): Promise<IMonitoredDecisionPoint> {
     request.logger.info({ message: 'Starting the markExperimentPoint call for user' });
@@ -499,7 +499,7 @@ export class ExperimentClientController {
   public async getAllExperimentConditions(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     experiment: ExperimentAssignmentValidator
   ): Promise<IExperimentAssignmentv4[]> {
     request.logger.info({ message: 'Starting the getAllExperimentConditions call for user' });
@@ -612,7 +612,7 @@ export class ExperimentClientController {
   public async log(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     logData: LogValidator
   ): Promise<Omit<Log, 'createdAt' | 'updatedAt' | 'versionNumber'>[]> {
     request.logger.info({ message: 'Starting the log call for user' });
@@ -656,7 +656,7 @@ export class ExperimentClientController {
    */
   @Post('log/caliper')
   public async caliperLog(
-    @Body({ validate: true })
+    @Body({ validate: false })
     envelope: CaliperLogEnvelope,
     @Req()
     request: AppRequest
@@ -794,7 +794,7 @@ export class ExperimentClientController {
   public async filterMetrics(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     metric: MetricValidator
   ): Promise<Metric[]> {
     return await this.metricService.saveAllMetrics(metric.metricUnit, request.logger);

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v5.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v5.ts
@@ -172,7 +172,7 @@ export class ExperimentClientController {
   public async init(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     experimentUser: ExperimentUserValidator
   ): Promise<Pick<ExperimentUser, 'id' | 'group' | 'workingGroup'>> {
     request.logger.info({ message: 'Starting the init call for user' });
@@ -249,7 +249,7 @@ export class ExperimentClientController {
   public async setGroupMemberShip(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     experimentUser: ExperimentUserValidator
   ): Promise<IGroupMembership> {
     request.logger.info({ message: 'Starting the groupmembership call for user' });
@@ -317,7 +317,7 @@ export class ExperimentClientController {
   public async setWorkingGroup(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     workingGroupParams: UpdateWorkingGroupValidator
   ): Promise<IWorkingGroup> {
     request.logger.info({ message: 'Starting the workinggroup call for user' });
@@ -412,7 +412,7 @@ export class ExperimentClientController {
   public async markExperimentPoint(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     experiment: MarkExperimentValidatorv5
   ): Promise<IMonitoredDecisionPoint> {
     request.logger.info({ message: 'Starting the markExperimentPoint call for user' });
@@ -498,7 +498,7 @@ export class ExperimentClientController {
   public async getAllExperimentConditions(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     experiment: ExperimentAssignmentValidator
   ): Promise<IExperimentAssignmentv5[]> {
     request.logger.info({ message: 'Starting the getAllExperimentConditions call for user' });
@@ -616,7 +616,7 @@ export class ExperimentClientController {
   public async log(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     logData: LogValidator
   ): Promise<Omit<Log, 'createdAt' | 'updatedAt' | 'versionNumber'>[]> {
     request.logger.info({ message: 'Starting the log call for user' });
@@ -751,7 +751,7 @@ export class ExperimentClientController {
   public async filterMetrics(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     metric: MetricValidator
   ): Promise<Metric[]> {
     return await this.metricService.saveAllMetrics(metric.metricUnit, request.logger);
@@ -810,7 +810,7 @@ export class ExperimentClientController {
   public async setUserAliases(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: false })
     user: ExperimentUserAliasesValidator
   ): Promise<IUserAliases> {
     const experimentUserDoc = await this.getUserDoc(user.userId, request.logger);


### PR DESCRIPTION
#1043 Please let me know if there are other things to consider. This is a temporary roll-back of these validations, which are working too well... it doesn't appear that things were adequately tested, as valid objects seem to be throwing errors in many places, often at surprising times (production) for requests that have been working in old API and Client versions for months/years.

We will need to re-check the validation objects we are using are really as strict as they need to be and roll these out again in 5.1.