### PR TITLE
cherry-pick java retries hotfix into 4.1

### DIFF
--- a/clientlibs/java/pom.xml
+++ b/clientlibs/java/pom.xml
@@ -9,9 +9,9 @@
 		at the same time that happen to rev to the same new version will be caught 
 		by a merge conflict. -->
 
-	<!-- 4.1.12 -> 4.1.13: make 'status' a string in mark payload  -->
+	<!-- 4.1.13 -> 4.1.14: no retries for 4xx, retry other errors once instead of 3 times  -->
 
-	<version>4.1.13</version>
+	<version>4.1.14</version>
 	<build>
 		<plugins>
 			<plugin>

--- a/clientlibs/java/src/main/java/org/upgradeplatform/utils/PublishingRetryCallback.java
+++ b/clientlibs/java/src/main/java/org/upgradeplatform/utils/PublishingRetryCallback.java
@@ -7,6 +7,7 @@ import javax.ws.rs.client.InvocationCallback;
 import javax.ws.rs.core.Response;
 
 import static javax.ws.rs.core.Response.Status.Family.SUCCESSFUL;
+import static javax.ws.rs.core.Response.Status.Family.CLIENT_ERROR;
 
 public class PublishingRetryCallback<T> implements InvocationCallback<Response> {
 
@@ -35,7 +36,10 @@ public class PublishingRetryCallback<T> implements InvocationCallback<Response> 
 
 	@Override
 	public void completed(Response response) {
-		if (SUCCESSFUL.equals(response.getStatusInfo().getFamily()) || retries <= 0) {
+    boolean isSuccess = SUCCESSFUL.equals(response.getStatusInfo().getFamily());
+    boolean isClientRequestError = CLIENT_ERROR.equals(response.getStatusInfo().getFamily());
+  
+		if (isSuccess || isClientRequestError || retries <= 0) {
 			callback.completed(response);
 		} else {
 			retry();

--- a/clientlibs/java/src/main/java/org/upgradeplatform/utils/Utils.java
+++ b/clientlibs/java/src/main/java/org/upgradeplatform/utils/Utils.java
@@ -33,7 +33,7 @@ public class Utils
 
 	public static final String PATCH = "PATCH";
 
-	public static final int MAX_RETRIES = 3;
+	public static final int MAX_RETRIES = 1;
 
 
 	public static enum RequestType {


### PR DESCRIPTION
Cherry-picking from `release/v3.0.20`, will publish new Java lib for version 4 in Nexus