### PR TITLE
Moving data and query in within subject code block for latency issue in QA

### DIFF
--- a/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
@@ -650,21 +650,23 @@ export class ExperimentAssignmentService {
           );
         })
       );
-
-      const allSites = [],
-        allTargets = [];
-      filteredExperiments.forEach((exp) => {
-        exp.partitions.forEach((partition) => {
-          allSites.push(partition.site);
-          allTargets.push(partition.target);
+      let monitoredLogCounts: any[];
+      if (filteredExperiments.some((e) => e.assignmentUnit === ASSIGNMENT_UNIT.WITHIN_SUBJECTS)) {
+        const allWithinSubjectsSites = [],
+          allWithinSubjectsTargets = [];
+        filteredExperiments.forEach((exp) => {
+          exp.partitions.forEach((partition) => {
+            allWithinSubjectsSites.push(partition.site);
+            allWithinSubjectsTargets.push(partition.target);
+          });
         });
-      });
-      const monitoredLogCounts = await this.monitoredDecisionPointLogRepository.getAllMonitoredDecisionPointLog(
-        userId,
-        allSites,
-        allTargets,
-        logger
-      );
+        monitoredLogCounts = await this.monitoredDecisionPointLogRepository.getAllMonitoredDecisionPointLog(
+          userId,
+          allWithinSubjectsSites,
+          allWithinSubjectsTargets,
+          logger
+        );
+      }
 
       return filteredExperiments.reduce((accumulator, experiment, index) => {
         const assignment = experimentAssignment[index];
@@ -765,7 +767,6 @@ export class ExperimentAssignmentService {
 
   private createExperimentPool(experiments: Experiment[]): Experiment[][] {
     const pool: Experiment[][] = [];
-    // const localExperiment = [...experiments];
 
     const decisionPointExperimentMap: Record<string, Experiment[]> = {};
 
@@ -781,36 +782,6 @@ export class ExperimentAssignmentService {
       const decisionPointToStart = Object.keys(decisionPointExperimentMap)[0];
       pool.push(this.createPool(decisionPointToStart, decisionPointExperimentMap, []));
     }
-
-    // while (localExperiment.length > 0) {
-    //   const poolElements = [];
-    //   const decisionPointHashMap: Record<string, Experiment[]> = {};
-
-    //   for (let i = 0; i < localExperiment.length; i++) {
-    //     // Push single element inside the pool
-    //     const experiment = localExperiment[i];
-    //     if (i === 0) {
-    //       poolElements.push(experiment);
-    //     }
-
-    //     // add to decision point hashmap
-    //     let isIntersecting = false;
-    //     experiment.partitions.forEach((partition) => {
-    //       const partitionId = `${partition.site}_${partition.target}`;
-    //       if (partitionId in decisionPointHashMap) {
-    //         isIntersecting = true;
-    //       }
-    //       decisionPointHashMap[partitionId] = decisionPointHashMap[partitionId] || [];
-    //       decisionPointHashMap[partitionId].push(experiment);
-    //     });
-
-    //     if(isIntersecting) {
-
-    //     }
-    //   }
-
-    //   // remove elements from localExperiment
-    // }
 
     return pool;
   }

--- a/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
@@ -650,10 +650,10 @@ export class ExperimentAssignmentService {
           );
         })
       );
-      let monitoredLogCounts: any[];
+      let monitoredLogCounts = [];
       if (filteredExperiments.some((e) => e.assignmentUnit === ASSIGNMENT_UNIT.WITHIN_SUBJECTS)) {
-        const allWithinSubjectsSites = [],
-          allWithinSubjectsTargets = [];
+        const allWithinSubjectsSites = [];
+        const allWithinSubjectsTargets = [];
         filteredExperiments.forEach((exp) => {
           exp.partitions.forEach((partition) => {
             allWithinSubjectsSites.push(partition.site);

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.ts
@@ -40,7 +40,7 @@ export class ExperimentOverviewComponent implements OnInit, OnDestroy {
   unitOfAssignments = [
     { value: ASSIGNMENT_UNIT.INDIVIDUAL },
     { value: ASSIGNMENT_UNIT.GROUP },
-    { value: ASSIGNMENT_UNIT.WITHIN_SUBJECTS },
+    // { value: ASSIGNMENT_UNIT.WITHIN_SUBJECTS }, // #1063 temporarily removed within-subjects until solved
   ];
   public ASSIGNMENT_UNIT = ASSIGNMENT_UNIT;
 


### PR DESCRIPTION
This PR is a hotfix for the latency issues observed in current QA (v5.0.9) due to the `monitoredLogCounts` query and its required sites and targets data used outside within subjects block, causing unnecessary calls to the query for non-within subjects experiments. 