### PR TITLE
Excluding enrollmentComplete experiments from getValidExperiments query (#909)

### DIFF
--- a/backend/packages/Upgrade/src/api/repositories/ExperimentRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/ExperimentRepository.ts
@@ -76,9 +76,11 @@ export class ExperimentRepository extends Repository<Experiment> {
       .where(
         new Brackets((qb) => {
           qb.where(
-            'experiment.state = :enrolling AND :context ILIKE ANY (ARRAY[experiment.context])',
+            '(experiment.state = :enrolling OR NOT (experiment.state = :enrollmentComplete AND experiment.postExperimentRule = :assign AND experiment.revertTo IS NULL)) AND :context ILIKE ANY (ARRAY[experiment.context])',
             {
               enrolling: 'enrolling',
+              enrollmentComplete: 'enrollmentComplete',
+              assign: 'assign',
               context,
             }
           );
@@ -94,9 +96,11 @@ export class ExperimentRepository extends Repository<Experiment> {
       .where(
         new Brackets((qb) => {
           qb.where(
-            'experiment.state = :enrolling AND :context ILIKE ANY (ARRAY[experiment.context])',
+            '(experiment.state = :enrolling OR NOT (experiment.state = :enrollmentComplete AND experiment.postExperimentRule = :assign AND experiment.revertTo IS NULL)) AND :context ILIKE ANY (ARRAY[experiment.context])',
             {
               enrolling: 'enrolling',
+              enrollmentComplete: 'enrollmentComplete',
+              assign: 'assign',
               context,
             }
           );
@@ -110,9 +114,11 @@ export class ExperimentRepository extends Repository<Experiment> {
       .where(
         new Brackets((qb) => {
           qb.where(
-            'experiment.state = :enrolling AND :context ILIKE ANY (ARRAY[experiment.context])',
+            '(experiment.state = :enrolling OR NOT (experiment.state = :enrollmentComplete AND experiment.postExperimentRule = :assign AND experiment.revertTo IS NULL)) AND :context ILIKE ANY (ARRAY[experiment.context])',
             {
               enrolling: 'enrolling',
+              enrollmentComplete: 'enrollmentComplete',
+              assign: 'assign',
               context,
             }
           );
@@ -135,9 +141,11 @@ export class ExperimentRepository extends Repository<Experiment> {
       .where(
         new Brackets((qb) => {
           qb.where(
-            'experiment.state = :enrolling AND :context ILIKE ANY (ARRAY[experiment.context])',
+            '(experiment.state = :enrolling OR NOT (experiment.state = :enrollmentComplete AND experiment.postExperimentRule = :assign AND experiment.revertTo IS NULL)) AND :context ILIKE ANY (ARRAY[experiment.context])',
             {
               enrolling: 'enrolling',
+              enrollmentComplete: 'enrollmentComplete',
+              assign: 'assign',
               context,
             }
           );
@@ -189,10 +197,12 @@ export class ExperimentRepository extends Repository<Experiment> {
       .where(
         new Brackets((qb) => {
           qb.where(
-            '(experiment.state = :enrolling OR experiment.state = :preview) AND :context ILIKE ANY (ARRAY[experiment.context])',
+            '((experiment.state = :enrolling OR experiment.state = :preview) OR NOT (experiment.state = :enrollmentComplete AND experiment.postExperimentRule = :assign AND experiment.revertTo IS NULL)) AND :context ILIKE ANY (ARRAY[experiment.context])',
             {
               enrolling: 'enrolling',
               preview: 'preview',
+              enrollmentComplete: 'enrollmentComplete',
+              assign: 'assign',
               context,
             }
           );
@@ -208,10 +218,12 @@ export class ExperimentRepository extends Repository<Experiment> {
       .where(
         new Brackets((qb) => {
           qb.where(
-            '(experiment.state = :enrolling OR experiment.state = :preview) AND :context ILIKE ANY (ARRAY[experiment.context])',
+            '((experiment.state = :enrolling OR experiment.state = :preview) OR NOT (experiment.state = :enrollmentComplete AND experiment.postExperimentRule = :assign AND experiment.revertTo IS NULL)) AND :context ILIKE ANY (ARRAY[experiment.context])',
             {
               enrolling: 'enrolling',
               preview: 'preview',
+              enrollmentComplete: 'enrollmentComplete',
+              assign: 'assign',
               context,
             }
           );
@@ -225,10 +237,12 @@ export class ExperimentRepository extends Repository<Experiment> {
       .where(
         new Brackets((qb) => {
           qb.where(
-            '(experiment.state = :enrolling OR experiment.state = :preview) AND :context ILIKE ANY (ARRAY[experiment.context])',
+            '((experiment.state = :enrolling OR experiment.state = :preview) OR NOT (experiment.state = :enrollmentComplete AND experiment.postExperimentRule = :assign AND experiment.revertTo IS NULL)) AND :context ILIKE ANY (ARRAY[experiment.context])',
             {
               enrolling: 'enrolling',
               preview: 'preview',
+              enrollmentComplete: 'enrollmentComplete',
+              assign: 'assign',
               context,
             }
           );
@@ -251,10 +265,12 @@ export class ExperimentRepository extends Repository<Experiment> {
       .where(
         new Brackets((qb) => {
           qb.where(
-            '(experiment.state = :enrolling OR experiment.state = :preview) AND :context ILIKE ANY (ARRAY[experiment.context])',
+            '((experiment.state = :enrolling OR experiment.state = :preview) OR NOT (experiment.state = :enrollmentComplete AND experiment.postExperimentRule = :assign AND experiment.revertTo IS NULL)) AND :context ILIKE ANY (ARRAY[experiment.context])',
             {
               enrolling: 'enrolling',
               preview: 'preview',
+              enrollmentComplete: 'enrollmentComplete',
+              assign: 'assign',
               context,
             }
           );

--- a/backend/packages/Upgrade/src/api/repositories/ExperimentRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/ExperimentRepository.ts
@@ -37,11 +37,21 @@ export class ExperimentRepository extends Repository<Experiment> {
 
     const [experimentData, experimentSegmentData] = await Promise.all([
       experiment.getMany().catch((errorMsg: any) => {
-        const errorMsgString = repositoryError('ExperimentRepository', 'findAllExperiments-experimentData', {}, errorMsg);
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'findAllExperiments-experimentData',
+          {},
+          errorMsg
+        );
         throw errorMsgString;
       }),
       experimentSegment.getMany().catch((errorMsg: any) => {
-        const errorMsgString = repositoryError('ExperimentRepository', 'findAllExperiments-experimentSegmentData', {}, errorMsg);
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'findAllExperiments-experimentSegmentData',
+          {},
+          errorMsg
+        );
         throw errorMsgString;
       }),
     ]);
@@ -68,6 +78,14 @@ export class ExperimentRepository extends Repository<Experiment> {
   }
 
   public async getValidExperiments(context: string): Promise<Experiment[]> {
+    const whereExperimentsClause =
+      '(experiment.state = :enrolling OR experiment.state = :enrollmentComplete) AND NOT (experiment.state = :enrollmentComplete AND experiment.postExperimentRule = :assign AND experiment.revertTo IS NULL) AND :context ILIKE ANY (ARRAY[experiment.context])';
+    const whereClauseParams = {
+      enrolling: 'enrolling',
+      enrollmentComplete: 'enrollmentComplete',
+      assign: 'assign',
+      context,
+    };
     const experimentConditionLevelPayloadQuery = this.createQueryBuilder('experiment')
       .leftJoinAndSelect('experiment.conditions', 'conditions')
       .leftJoinAndSelect('conditions.levelCombinationElements', 'levelCombinationElements')
@@ -75,15 +93,7 @@ export class ExperimentRepository extends Repository<Experiment> {
       .leftJoinAndSelect('conditions.conditionPayloads', 'conditionPayload')
       .where(
         new Brackets((qb) => {
-          qb.where(
-            '(experiment.state = :enrolling OR NOT (experiment.state = :enrollmentComplete AND experiment.postExperimentRule = :assign AND experiment.revertTo IS NULL)) AND :context ILIKE ANY (ARRAY[experiment.context])',
-            {
-              enrolling: 'enrolling',
-              enrollmentComplete: 'enrollmentComplete',
-              assign: 'assign',
-              context,
-            }
-          );
+          qb.where(whereExperimentsClause, whereClauseParams);
         })
       );
 
@@ -95,15 +105,7 @@ export class ExperimentRepository extends Repository<Experiment> {
       .leftJoinAndSelect('factors.levels', 'levels')
       .where(
         new Brackets((qb) => {
-          qb.where(
-            '(experiment.state = :enrolling OR NOT (experiment.state = :enrollmentComplete AND experiment.postExperimentRule = :assign AND experiment.revertTo IS NULL)) AND :context ILIKE ANY (ARRAY[experiment.context])',
-            {
-              enrolling: 'enrolling',
-              enrollmentComplete: 'enrollmentComplete',
-              assign: 'assign',
-              context,
-            }
-          );
+          qb.where(whereExperimentsClause, whereClauseParams);
         })
       );
 
@@ -113,15 +115,7 @@ export class ExperimentRepository extends Repository<Experiment> {
       .leftJoinAndSelect('experiment.stateTimeLogs', 'stateTimeLogs')
       .where(
         new Brackets((qb) => {
-          qb.where(
-            '(experiment.state = :enrolling OR NOT (experiment.state = :enrollmentComplete AND experiment.postExperimentRule = :assign AND experiment.revertTo IS NULL)) AND :context ILIKE ANY (ARRAY[experiment.context])',
-            {
-              enrolling: 'enrolling',
-              enrollmentComplete: 'enrollmentComplete',
-              assign: 'assign',
-              context,
-            }
-          );
+          qb.where(whereExperimentsClause, whereClauseParams);
         })
       );
 
@@ -140,33 +134,50 @@ export class ExperimentRepository extends Repository<Experiment> {
       .leftJoinAndSelect('segmentExclusion.subSegments', 'subSegmentExclusion')
       .where(
         new Brackets((qb) => {
-          qb.where(
-            '(experiment.state = :enrolling OR NOT (experiment.state = :enrollmentComplete AND experiment.postExperimentRule = :assign AND experiment.revertTo IS NULL)) AND :context ILIKE ANY (ARRAY[experiment.context])',
-            {
-              enrolling: 'enrolling',
-              enrollmentComplete: 'enrollmentComplete',
-              assign: 'assign',
-              context,
-            }
-          );
+          qb.where(whereExperimentsClause, whereClauseParams);
         })
       );
 
-    const [experimentConditionLevelPayloadData, experimentFactorPartitionLevelPayloadData, experimentMetricData, experimentSegmentData] = await Promise.all([
+    const [
+      experimentConditionLevelPayloadData,
+      experimentFactorPartitionLevelPayloadData,
+      experimentMetricData,
+      experimentSegmentData,
+    ] = await Promise.all([
       experimentConditionLevelPayloadQuery.getMany().catch((errorMsg: any) => {
-        const errorMsgString = repositoryError('ExperimentRepository', 'getValidExperiments-experimentConditionLevelPayloadQuery', {}, errorMsg);
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'getValidExperiments-experimentConditionLevelPayloadQuery',
+          {},
+          errorMsg
+        );
         throw errorMsgString;
       }),
       experimentFactorPartitionLevelPayloadQuery.getMany().catch((errorMsg: any) => {
-        const errorMsgString = repositoryError('ExperimentRepository', 'getValidExperiments-experimentFactorPartitionLevelPayloadQuery', {}, errorMsg);
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'getValidExperiments-experimentFactorPartitionLevelPayloadQuery',
+          {},
+          errorMsg
+        );
         throw errorMsgString;
       }),
       experimentMetricQuery.getMany().catch((errorMsg: any) => {
-        const errorMsgString = repositoryError('ExperimentRepository', 'getValidExperiments-experimentMetricQuery', {}, errorMsg);
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'getValidExperiments-experimentMetricQuery',
+          {},
+          errorMsg
+        );
         throw errorMsgString;
       }),
       experimentSegmentQuery.getMany().catch((errorMsg: any) => {
-        const errorMsgString = repositoryError('ExperimentRepository', 'getValidExperiments-experimentSegmentQuery', {}, errorMsg);
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'getValidExperiments-experimentSegmentQuery',
+          {},
+          errorMsg
+        );
         throw errorMsgString;
       }),
     ]);
@@ -189,6 +200,15 @@ export class ExperimentRepository extends Repository<Experiment> {
   }
 
   public async getValidExperimentsWithPreview(context: string): Promise<Experiment[]> {
+    const whereExperimentsClause =
+      '(experiment.state = :enrolling OR experiment.state = :enrollmentComplete OR experiment.state = :preview) AND NOT (experiment.state = :enrollmentComplete AND experiment.postExperimentRule = :assign AND experiment.revertTo IS NULL) AND :context ILIKE ANY (ARRAY[experiment.context])';
+    const whereClauseParams = {
+      enrolling: 'enrolling',
+      enrollmentComplete: 'enrollmentComplete',
+      preview: 'preview',
+      assign: 'assign',
+      context,
+    };
     const experimentConditionLevelPayloadQuery = this.createQueryBuilder('experiment')
       .leftJoinAndSelect('experiment.conditions', 'conditions')
       .leftJoinAndSelect('conditions.levelCombinationElements', 'levelCombinationElements')
@@ -196,16 +216,7 @@ export class ExperimentRepository extends Repository<Experiment> {
       .leftJoinAndSelect('conditions.conditionPayloads', 'conditionPayload')
       .where(
         new Brackets((qb) => {
-          qb.where(
-            '((experiment.state = :enrolling OR experiment.state = :preview) OR NOT (experiment.state = :enrollmentComplete AND experiment.postExperimentRule = :assign AND experiment.revertTo IS NULL)) AND :context ILIKE ANY (ARRAY[experiment.context])',
-            {
-              enrolling: 'enrolling',
-              preview: 'preview',
-              enrollmentComplete: 'enrollmentComplete',
-              assign: 'assign',
-              context,
-            }
-          );
+          qb.where(whereExperimentsClause, whereClauseParams);
         })
       );
 
@@ -217,16 +228,7 @@ export class ExperimentRepository extends Repository<Experiment> {
       .leftJoinAndSelect('factors.levels', 'levels')
       .where(
         new Brackets((qb) => {
-          qb.where(
-            '((experiment.state = :enrolling OR experiment.state = :preview) OR NOT (experiment.state = :enrollmentComplete AND experiment.postExperimentRule = :assign AND experiment.revertTo IS NULL)) AND :context ILIKE ANY (ARRAY[experiment.context])',
-            {
-              enrolling: 'enrolling',
-              preview: 'preview',
-              enrollmentComplete: 'enrollmentComplete',
-              assign: 'assign',
-              context,
-            }
-          );
+          qb.where(whereExperimentsClause, whereClauseParams);
         })
       );
 
@@ -236,16 +238,7 @@ export class ExperimentRepository extends Repository<Experiment> {
       .leftJoinAndSelect('experiment.stateTimeLogs', 'stateTimeLogs')
       .where(
         new Brackets((qb) => {
-          qb.where(
-            '((experiment.state = :enrolling OR experiment.state = :preview) OR NOT (experiment.state = :enrollmentComplete AND experiment.postExperimentRule = :assign AND experiment.revertTo IS NULL)) AND :context ILIKE ANY (ARRAY[experiment.context])',
-            {
-              enrolling: 'enrolling',
-              preview: 'preview',
-              enrollmentComplete: 'enrollmentComplete',
-              assign: 'assign',
-              context,
-            }
-          );
+          qb.where(whereExperimentsClause, whereClauseParams);
         })
       );
 
@@ -264,34 +257,50 @@ export class ExperimentRepository extends Repository<Experiment> {
       .leftJoinAndSelect('segmentExclusion.subSegments', 'subSegmentExclusion')
       .where(
         new Brackets((qb) => {
-          qb.where(
-            '((experiment.state = :enrolling OR experiment.state = :preview) OR NOT (experiment.state = :enrollmentComplete AND experiment.postExperimentRule = :assign AND experiment.revertTo IS NULL)) AND :context ILIKE ANY (ARRAY[experiment.context])',
-            {
-              enrolling: 'enrolling',
-              preview: 'preview',
-              enrollmentComplete: 'enrollmentComplete',
-              assign: 'assign',
-              context,
-            }
-          );
+          qb.where(whereExperimentsClause, whereClauseParams);
         })
       );
 
-    const [experimentConditionLevelPayloadData, experimentFactorPartitionLevelPayloadData, experimentMetricData, experimentSegmentData] = await Promise.all([
+    const [
+      experimentConditionLevelPayloadData,
+      experimentFactorPartitionLevelPayloadData,
+      experimentMetricData,
+      experimentSegmentData,
+    ] = await Promise.all([
       experimentConditionLevelPayloadQuery.getMany().catch((errorMsg: any) => {
-        const errorMsgString = repositoryError('ExperimentRepository', 'getValidExperiments-experimentConditionLevelPayloadQuery', {}, errorMsg);
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'getValidExperiments-experimentConditionLevelPayloadQuery',
+          {},
+          errorMsg
+        );
         throw errorMsgString;
       }),
       experimentFactorPartitionLevelPayloadQuery.getMany().catch((errorMsg: any) => {
-        const errorMsgString = repositoryError('ExperimentRepository', 'getValidExperiments-experimentFactorPartitionLevelPayloadQuery', {}, errorMsg);
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'getValidExperiments-experimentFactorPartitionLevelPayloadQuery',
+          {},
+          errorMsg
+        );
         throw errorMsgString;
       }),
       experimentMetricQuery.getMany().catch((errorMsg: any) => {
-        const errorMsgString = repositoryError('ExperimentRepository', 'getValidExperiments-experimentMetricQuery', {}, errorMsg);
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'getValidExperiments-experimentMetricQuery',
+          {},
+          errorMsg
+        );
         throw errorMsgString;
       }),
       experimentSegmentQuery.getMany().catch((errorMsg: any) => {
-        const errorMsgString = repositoryError('ExperimentRepository', 'getValidExperiments-experimentSegmentQuery', {}, errorMsg);
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'getValidExperiments-experimentSegmentQuery',
+          {},
+          errorMsg
+        );
         throw errorMsgString;
       }),
     ]);

--- a/backend/packages/Upgrade/src/api/repositories/ExperimentRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/ExperimentRepository.ts
@@ -76,10 +76,9 @@ export class ExperimentRepository extends Repository<Experiment> {
       .where(
         new Brackets((qb) => {
           qb.where(
-            '(experiment.state = :enrolling OR experiment.state = :enrollmentComplete) AND :context ILIKE ANY (ARRAY[experiment.context])',
+            'experiment.state = :enrolling AND :context ILIKE ANY (ARRAY[experiment.context])',
             {
               enrolling: 'enrolling',
-              enrollmentComplete: 'enrollmentComplete',
               context,
             }
           );
@@ -95,10 +94,9 @@ export class ExperimentRepository extends Repository<Experiment> {
       .where(
         new Brackets((qb) => {
           qb.where(
-            '(experiment.state = :enrolling OR experiment.state = :enrollmentComplete) AND :context ILIKE ANY (ARRAY[experiment.context])',
+            'experiment.state = :enrolling AND :context ILIKE ANY (ARRAY[experiment.context])',
             {
               enrolling: 'enrolling',
-              enrollmentComplete: 'enrollmentComplete',
               context,
             }
           );
@@ -112,10 +110,9 @@ export class ExperimentRepository extends Repository<Experiment> {
       .where(
         new Brackets((qb) => {
           qb.where(
-            '(experiment.state = :enrolling OR experiment.state = :enrollmentComplete) AND :context ILIKE ANY (ARRAY[experiment.context])',
+            'experiment.state = :enrolling AND :context ILIKE ANY (ARRAY[experiment.context])',
             {
               enrolling: 'enrolling',
-              enrollmentComplete: 'enrollmentComplete',
               context,
             }
           );
@@ -138,10 +135,9 @@ export class ExperimentRepository extends Repository<Experiment> {
       .where(
         new Brackets((qb) => {
           qb.where(
-            '(experiment.state = :enrolling OR experiment.state = :enrollmentComplete) AND :context ILIKE ANY (ARRAY[experiment.context])',
+            'experiment.state = :enrolling AND :context ILIKE ANY (ARRAY[experiment.context])',
             {
               enrolling: 'enrolling',
-              enrollmentComplete: 'enrollmentComplete',
               context,
             }
           );
@@ -193,10 +189,9 @@ export class ExperimentRepository extends Repository<Experiment> {
       .where(
         new Brackets((qb) => {
           qb.where(
-            '(experiment.state = :enrolling OR experiment.state = :enrollmentComplete OR experiment.state = :preview) AND :context ILIKE ANY (ARRAY[experiment.context])',
+            '(experiment.state = :enrolling OR experiment.state = :preview) AND :context ILIKE ANY (ARRAY[experiment.context])',
             {
               enrolling: 'enrolling',
-              enrollmentComplete: 'enrollmentComplete',
               preview: 'preview',
               context,
             }
@@ -213,10 +208,9 @@ export class ExperimentRepository extends Repository<Experiment> {
       .where(
         new Brackets((qb) => {
           qb.where(
-            '(experiment.state = :enrolling OR experiment.state = :enrollmentComplete OR experiment.state = :preview) AND :context ILIKE ANY (ARRAY[experiment.context])',
+            '(experiment.state = :enrolling OR experiment.state = :preview) AND :context ILIKE ANY (ARRAY[experiment.context])',
             {
               enrolling: 'enrolling',
-              enrollmentComplete: 'enrollmentComplete',
               preview: 'preview',
               context,
             }
@@ -231,10 +225,9 @@ export class ExperimentRepository extends Repository<Experiment> {
       .where(
         new Brackets((qb) => {
           qb.where(
-            '(experiment.state = :enrolling OR experiment.state = :enrollmentComplete OR experiment.state = :preview) AND :context ILIKE ANY (ARRAY[experiment.context])',
+            '(experiment.state = :enrolling OR experiment.state = :preview) AND :context ILIKE ANY (ARRAY[experiment.context])',
             {
               enrolling: 'enrolling',
-              enrollmentComplete: 'enrollmentComplete',
               preview: 'preview',
               context,
             }
@@ -258,10 +251,9 @@ export class ExperimentRepository extends Repository<Experiment> {
       .where(
         new Brackets((qb) => {
           qb.where(
-            '(experiment.state = :enrolling OR experiment.state = :enrollmentComplete OR experiment.state = :preview) AND :context ILIKE ANY (ARRAY[experiment.context])',
+            '(experiment.state = :enrolling OR experiment.state = :preview) AND :context ILIKE ANY (ARRAY[experiment.context])',
             {
               enrolling: 'enrolling',
-              enrollmentComplete: 'enrollmentComplete',
               preview: 'preview',
               context,
             }

--- a/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario1.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario1.ts
@@ -116,23 +116,6 @@ export default async function testCase(): Promise<void> {
   );
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName, experimentPoint);
 
-  // change experiment status to complete
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
-
-  // fetch experiment
-  experiments = await experimentService.find(new UpgradeLogger());
-  expect(experiments).toEqual(
-    expect.arrayContaining([
-      expect.objectContaining({
-        name: experimentObject.name,
-        state: EXPERIMENT_STATE.ENROLLMENT_COMPLETE,
-        postExperimentRule: experimentObject.postExperimentRule,
-        assignmentUnit: experimentObject.assignmentUnit,
-        consistencyRule: experimentObject.consistencyRule,
-      }),
-    ])
-  );
-
   // get all experiment condition for user 1
   experimentConditionAssignments = await getAllExperimentCondition(experimentUsers[0].id, new UpgradeLogger());
   checkExperimentAssignedIsNull(experimentConditionAssignments, experimentName, experimentPoint);
@@ -188,6 +171,23 @@ export default async function testCase(): Promise<void> {
     new UpgradeLogger()
   );
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[3].id, experimentName, experimentPoint);
+
+  // change experiment status to complete
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
+
+  // fetch experiment
+  experiments = await experimentService.find(new UpgradeLogger());
+  expect(experiments).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: experimentObject.name,
+        state: EXPERIMENT_STATE.ENROLLMENT_COMPLETE,
+        postExperimentRule: experimentObject.postExperimentRule,
+        assignmentUnit: experimentObject.assignmentUnit,
+        consistencyRule: experimentObject.consistencyRule,
+      }),
+    ])
+  );
 
   await checkDeletedExperiment(experimentId, user);
 }

--- a/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario10.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario10.ts
@@ -340,23 +340,6 @@ export default async function testCase(): Promise<void> {
   );
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName, experimentPoint);
 
-  // change experiment status to complete
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
-
-  // fetch experiment
-  experiments = await experimentService.find(new UpgradeLogger());
-  expect(experiments).toEqual(
-    expect.arrayContaining([
-      expect.objectContaining({
-        name: experimentObject.name,
-        state: EXPERIMENT_STATE.ENROLLMENT_COMPLETE,
-        postExperimentRule: experimentObject.postExperimentRule,
-        assignmentUnit: experimentObject.assignmentUnit,
-        consistencyRule: experimentObject.consistencyRule,
-      }),
-    ])
-  );
-
   // get all experiment condition for user 1
   experimentConditionAssignments = await getAllExperimentCondition(experimentUsers[0].id, new UpgradeLogger());
   checkExperimentAssignedIsNotDefault(experimentConditionAssignments, experimentName, experimentPoint);
@@ -437,5 +420,23 @@ export default async function testCase(): Promise<void> {
   );
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[3].id, experimentName, experimentPoint);
 
+  // change experiment status to complete
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
+
+  // fetch experiment
+  experiments = await experimentService.find(new UpgradeLogger());
+  expect(experiments).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: experimentObject.name,
+        state: EXPERIMENT_STATE.ENROLLMENT_COMPLETE,
+        postExperimentRule: experimentObject.postExperimentRule,
+        assignmentUnit: experimentObject.assignmentUnit,
+        consistencyRule: experimentObject.consistencyRule,
+      }),
+    ])
+  );
+
   await checkDeletedExperiment(experimentId, user);
+
 }

--- a/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario2.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario2.ts
@@ -112,23 +112,6 @@ export default async function testCase(): Promise<void> {
   );
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName, experimentPoint);
 
-  // change experiment status to complete
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
-
-  // fetch experiment
-  experiments = await experimentService.find(new UpgradeLogger());
-  expect(experiments).toEqual(
-    expect.arrayContaining([
-      expect.objectContaining({
-        name: experimentObject.name,
-        state: EXPERIMENT_STATE.ENROLLMENT_COMPLETE,
-        postExperimentRule: experimentObject.postExperimentRule,
-        assignmentUnit: experimentObject.assignmentUnit,
-        consistencyRule: experimentObject.consistencyRule,
-      }),
-    ])
-  );
-
   // get all experiment condition for user 1
   experimentConditionAssignments = await getAllExperimentCondition(experimentUsers[0].id, new UpgradeLogger());
   checkExperimentAssignedIsNotDefault(experimentConditionAssignments, experimentName, experimentPoint);
@@ -184,6 +167,23 @@ export default async function testCase(): Promise<void> {
     new UpgradeLogger()
   );
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[3].id, experimentName, experimentPoint);
+  
+  // change experiment status to complete
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
+
+  // fetch experiment
+  experiments = await experimentService.find(new UpgradeLogger());
+  expect(experiments).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: experimentObject.name,
+        state: EXPERIMENT_STATE.ENROLLMENT_COMPLETE,
+        postExperimentRule: experimentObject.postExperimentRule,
+        assignmentUnit: experimentObject.assignmentUnit,
+        consistencyRule: experimentObject.consistencyRule,
+      }),
+    ])
+  );
 
   await checkDeletedExperiment(experimentId, user);
 }

--- a/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario3.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario3.ts
@@ -116,23 +116,6 @@ export default async function testCase(): Promise<void> {
   );
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName, experimentPoint);
 
-  // change experiment status to complete
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
-
-  // fetch experiment
-  experiments = await experimentService.find(new UpgradeLogger());
-  expect(experiments).toEqual(
-    expect.arrayContaining([
-      expect.objectContaining({
-        name: experimentObject.name,
-        state: EXPERIMENT_STATE.ENROLLMENT_COMPLETE,
-        postExperimentRule: experimentObject.postExperimentRule,
-        assignmentUnit: experimentObject.assignmentUnit,
-        consistencyRule: experimentObject.consistencyRule,
-      }),
-    ])
-  );
-
   // get all experiment condition for user 1
   experimentConditionAssignments = await getAllExperimentCondition(experimentUsers[0].id, new UpgradeLogger());
   checkExperimentAssignedIsNull(experimentConditionAssignments, experimentName, experimentPoint);
@@ -189,5 +172,23 @@ export default async function testCase(): Promise<void> {
   );
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[3].id, experimentName, experimentPoint);
 
+  // change experiment status to complete
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
+
+  // fetch experiment
+  experiments = await experimentService.find(new UpgradeLogger());
+  expect(experiments).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: experimentObject.name,
+        state: EXPERIMENT_STATE.ENROLLMENT_COMPLETE,
+        postExperimentRule: experimentObject.postExperimentRule,
+        assignmentUnit: experimentObject.assignmentUnit,
+        consistencyRule: experimentObject.consistencyRule,
+      }),
+    ])
+  );
+
   await checkDeletedExperiment(experimentId, user);
+
 }

--- a/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario4.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario4.ts
@@ -116,23 +116,6 @@ export default async function testCase(): Promise<void> {
   );
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName, experimentPoint);
 
-  // change experiment status to complete
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
-
-  // fetch experiment
-  experiments = await experimentService.find(new UpgradeLogger());
-  expect(experiments).toEqual(
-    expect.arrayContaining([
-      expect.objectContaining({
-        name: experimentObject.name,
-        state: EXPERIMENT_STATE.ENROLLMENT_COMPLETE,
-        postExperimentRule: experimentObject.postExperimentRule,
-        assignmentUnit: experimentObject.assignmentUnit,
-        consistencyRule: experimentObject.consistencyRule,
-      }),
-    ])
-  );
-
   // get all experiment condition for user 1
   experimentConditionAssignments = await getAllExperimentCondition(experimentUsers[0].id, new UpgradeLogger());
   checkExperimentAssignedIsNull(experimentConditionAssignments, experimentName, experimentPoint);
@@ -189,5 +172,23 @@ export default async function testCase(): Promise<void> {
   );
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[3].id, experimentName, experimentPoint);
 
+  // change experiment status to complete
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
+
+  // fetch experiment
+  experiments = await experimentService.find(new UpgradeLogger());
+  expect(experiments).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: experimentObject.name,
+        state: EXPERIMENT_STATE.ENROLLMENT_COMPLETE,
+        postExperimentRule: experimentObject.postExperimentRule,
+        assignmentUnit: experimentObject.assignmentUnit,
+        consistencyRule: experimentObject.consistencyRule,
+      }),
+    ])
+  );
+
   await checkDeletedExperiment(experimentId, user);
+
 }

--- a/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario5.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario5.ts
@@ -111,23 +111,6 @@ export default async function testCase(): Promise<void> {
   );
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName, experimentPoint);
 
-  // change experiment status to complete
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
-
-  // fetch experiment
-  experiments = await experimentService.find(new UpgradeLogger());
-  expect(experiments).toEqual(
-    expect.arrayContaining([
-      expect.objectContaining({
-        name: experimentObject.name,
-        state: EXPERIMENT_STATE.ENROLLMENT_COMPLETE,
-        postExperimentRule: experimentObject.postExperimentRule,
-        assignmentUnit: experimentObject.assignmentUnit,
-        consistencyRule: experimentObject.consistencyRule,
-      }),
-    ])
-  );
-
   // get all experiment condition for user 1
   experimentConditionAssignments = await getAllExperimentCondition(experimentUsers[0].id, new UpgradeLogger());
   checkExperimentAssignedIsNotDefault(experimentConditionAssignments, experimentName, experimentPoint);
@@ -184,5 +167,23 @@ export default async function testCase(): Promise<void> {
   );
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[3].id, experimentName, experimentPoint);
 
+  // change experiment status to complete
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
+
+  // fetch experiment
+  experiments = await experimentService.find(new UpgradeLogger());
+  expect(experiments).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: experimentObject.name,
+        state: EXPERIMENT_STATE.ENROLLMENT_COMPLETE,
+        postExperimentRule: experimentObject.postExperimentRule,
+        assignmentUnit: experimentObject.assignmentUnit,
+        consistencyRule: experimentObject.consistencyRule,
+      }),
+    ])
+  );
+
   await checkDeletedExperiment(experimentId, user);
+
 }

--- a/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario6.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario6.ts
@@ -227,23 +227,6 @@ export default async function testCase(): Promise<void> {
   );
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName, experimentPoint);
 
-  // change experiment status to complete
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
-
-  // fetch experiment
-  experiments = await experimentService.find(new UpgradeLogger());
-  expect(experiments).toEqual(
-    expect.arrayContaining([
-      expect.objectContaining({
-        name: experimentObject.name,
-        state: EXPERIMENT_STATE.ENROLLMENT_COMPLETE,
-        postExperimentRule: experimentObject.postExperimentRule,
-        assignmentUnit: experimentObject.assignmentUnit,
-        consistencyRule: experimentObject.consistencyRule,
-      }),
-    ])
-  );
-
   // get all experiment condition for user 1
   experimentConditionAssignments = await getAllExperimentCondition(experimentUsers[0].id, new UpgradeLogger());
   checkExperimentAssignedIsNull(experimentConditionAssignments, experimentName, experimentPoint);
@@ -300,5 +283,23 @@ export default async function testCase(): Promise<void> {
   );
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[3].id, experimentName, experimentPoint);
 
+  // change experiment status to complete
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
+
+  // fetch experiment
+  experiments = await experimentService.find(new UpgradeLogger());
+  expect(experiments).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: experimentObject.name,
+        state: EXPERIMENT_STATE.ENROLLMENT_COMPLETE,
+        postExperimentRule: experimentObject.postExperimentRule,
+        assignmentUnit: experimentObject.assignmentUnit,
+        consistencyRule: experimentObject.consistencyRule,
+      }),
+    ])
+  );
+
   await checkDeletedExperiment(experimentId, user);
+
 }

--- a/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario8.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario8.ts
@@ -319,23 +319,6 @@ export default async function testCase(): Promise<void> {
   );
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName, experimentPoint);
 
-  // change experiment status to complete
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
-
-  // fetch experiment
-  experiments = await experimentService.find(new UpgradeLogger());
-  expect(experiments).toEqual(
-    expect.arrayContaining([
-      expect.objectContaining({
-        name: experimentObject.name,
-        state: EXPERIMENT_STATE.ENROLLMENT_COMPLETE,
-        postExperimentRule: experimentObject.postExperimentRule,
-        assignmentUnit: experimentObject.assignmentUnit,
-        consistencyRule: experimentObject.consistencyRule,
-      }),
-    ])
-  );
-
   // get all experiment condition for user 1
   experimentConditionAssignments = await getAllExperimentCondition(experimentUsers[0].id, new UpgradeLogger());
   checkExperimentAssignedIsNotDefault(experimentConditionAssignments, experimentName, experimentPoint);
@@ -416,5 +399,23 @@ export default async function testCase(): Promise<void> {
   );
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[3].id, experimentName, experimentPoint);
 
+  // change experiment status to complete
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
+
+  // fetch experiment
+  experiments = await experimentService.find(new UpgradeLogger());
+  expect(experiments).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: experimentObject.name,
+        state: EXPERIMENT_STATE.ENROLLMENT_COMPLETE,
+        postExperimentRule: experimentObject.postExperimentRule,
+        assignmentUnit: experimentObject.assignmentUnit,
+        consistencyRule: experimentObject.consistencyRule,
+      }),
+    ])
+  );
+
   await checkDeletedExperiment(experimentId, user);
+
 }

--- a/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario9.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario9.ts
@@ -326,23 +326,6 @@ export default async function testCase(): Promise<void> {
   );
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[2].id, experimentName, experimentPoint);
 
-  // change experiment status to complete
-  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
-
-  // fetch experiment
-  experiments = await experimentService.find(new UpgradeLogger());
-  expect(experiments).toEqual(
-    expect.arrayContaining([
-      expect.objectContaining({
-        name: experimentObject.name,
-        state: EXPERIMENT_STATE.ENROLLMENT_COMPLETE,
-        postExperimentRule: experimentObject.postExperimentRule,
-        assignmentUnit: experimentObject.assignmentUnit,
-        consistencyRule: experimentObject.consistencyRule,
-      }),
-    ])
-  );
-
   // get all experiment condition for user 1
   experimentConditionAssignments = await getAllExperimentCondition(experimentUsers[0].id, new UpgradeLogger());
   checkExperimentAssignedIsNotDefault(experimentConditionAssignments, experimentName, experimentPoint);
@@ -423,5 +406,23 @@ export default async function testCase(): Promise<void> {
   );
   checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[3].id, experimentName, experimentPoint);
 
+  // change experiment status to complete
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.ENROLLMENT_COMPLETE, user, new UpgradeLogger());
+
+  // fetch experiment
+  experiments = await experimentService.find(new UpgradeLogger());
+  expect(experiments).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: experimentObject.name,
+        state: EXPERIMENT_STATE.ENROLLMENT_COMPLETE,
+        postExperimentRule: experimentObject.postExperimentRule,
+        assignmentUnit: experimentObject.assignmentUnit,
+        consistencyRule: experimentObject.consistencyRule,
+      }),
+    ])
+  );
+
   await checkDeletedExperiment(experimentId, user);
+
 }


### PR DESCRIPTION
This PR contains changes to improve the PROD latency issues due to enrolmentComplete experiments for post-experiment rule set to default condition. We are now excluding enrollmentComplete experiments from getValidExperiments and getValidExperimentsWithPreview queries.

This gives an optimization of 62% in terms of average api response time for 600 concurrent users. With Splitting of queries into 3 and Caching, the time is reduced by 91% in terms of average api response time for 600 concurrent users. Please find the detailed Load Testing Analysis in this [document](https://docs.google.com/document/d/1hsQpcF3ptcYaHfUaw_iqPrCv0AK4hx4YVJrdfYclNlM/edit?usp=sharing). Here is the Response Time Comparison table:
<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-a12e0a09-7fff-7017-ecb6-b4e70c70c1ba"><div dir="ltr" style="margin-left:0pt;" align="center">

Test Case | Concurrent Users | Trial 1 (Median Response Time) | Trial 2 (Median Response Time) | Avg of (Median Response Time)
-- | -- | -- | -- | --
No enrollmentComplete experiments (Total 8 experiments) | 600 | 5700 ms | 4300 ms | 5000 ms
All post-exp rule default experiments set to enrollmentComplete (5 out of 8 experiments) | 600 | 7300 ms | 7800 ms | 7500 ms
Exclude enrollmentComplete experiments from getValidExperiments(5 out of 8 experiments) | 600 | 3100 ms | 2600 ms | 2850 ms
Split queries into 3 + Exclude enrollmentComplete experiments from getValidExperiments(5 out of 8 experiments) | 600 | 2300 ms | 1800 ms | 2050 ms
Split queries into 3 + Caching + Exclude enrollmentComplete experiments from getValidExperiments(5 out of 8 experiments) | 600 | 850 ms | 550 ms | 700 ms

</div></b>

Outcome (For 600 concurrent users): 

- So, there is a 62% improvement when the time is reduced from 7500 ms to 2850 ms for excluding enrollmentComplete experiments from getValidExperiments

- So, there is a 91% improvement when the time is reduced from 7500 ms to 700 ms for (Split queries into 3 + Caching + excluding enrollmentComplete experiments) from getValidExperiments


<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-87030005-7fff-5804-3917-b12cb6662fdc"><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:700;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Observation: Due to load on my machine, I tried with lesser concurrent users (200/400) as well, below are the results:</span></p><br /><div dir="ltr" style="margin-left:0pt;" align="center">

Test Case | Concurrent Users | Trail 1 (Median Response Time) | Trail 2 (Median Response Time) | Avg of (Median Response Time)
-- | -- | -- | -- | --
Split queries into 3 + Caching + Exclude enrollmentComplete experiments from getValidExperiments(5 out of 8 experiments) | 400 | 88 ms | 91 ms | 89.5 ms
Split queries into 3 + Caching + Exclude enrollmentComplete experiments from getValidExperiments(5 out of 8 experiments) | 200 | 30 ms | 37 ms | 33.5 ms

</div></b>