### PR TITLE
Hotfix/optimize findallexperiments query

### DIFF
--- a/backend/packages/Upgrade/src/api/repositories/ExperimentRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/ExperimentRepository.ts
@@ -37,11 +37,21 @@ export class ExperimentRepository extends Repository<Experiment> {
 
     const [experimentData, experimentSegmentData] = await Promise.all([
       experiment.getMany().catch((errorMsg: any) => {
-        const errorMsgString = repositoryError('ExperimentRepository', 'findAllExperiments-experimentData', {}, errorMsg);
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'findAllExperiments-experimentData',
+          {},
+          errorMsg
+        );
         throw errorMsgString;
       }),
       experimentSegment.getMany().catch((errorMsg: any) => {
-        const errorMsgString = repositoryError('ExperimentRepository', 'findAllExperiments-experimentSegmentData', {}, errorMsg);
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'findAllExperiments-experimentSegmentData',
+          {},
+          errorMsg
+        );
         throw errorMsgString;
       }),
     ]);
@@ -68,6 +78,14 @@ export class ExperimentRepository extends Repository<Experiment> {
   }
 
   public async getValidExperiments(context: string): Promise<Experiment[]> {
+    const whereExperimentsClause =
+      '(experiment.state = :enrolling OR experiment.state = :enrollmentComplete) AND NOT (experiment.state = :enrollmentComplete AND experiment.postExperimentRule = :assign AND experiment.revertTo IS NULL) AND :context ILIKE ANY (ARRAY[experiment.context])';
+    const whereClauseParams = {
+      enrolling: 'enrolling',
+      enrollmentComplete: 'enrollmentComplete',
+      assign: 'assign',
+      context,
+    };
     const experimentConditionLevelPayloadQuery = this.createQueryBuilder('experiment')
       .leftJoinAndSelect('experiment.conditions', 'conditions')
       .leftJoinAndSelect('conditions.levelCombinationElements', 'levelCombinationElements')
@@ -75,14 +93,7 @@ export class ExperimentRepository extends Repository<Experiment> {
       .leftJoinAndSelect('conditions.conditionPayloads', 'conditionPayload')
       .where(
         new Brackets((qb) => {
-          qb.where(
-            '(experiment.state = :enrolling OR experiment.state = :enrollmentComplete) AND :context ILIKE ANY (ARRAY[experiment.context])',
-            {
-              enrolling: 'enrolling',
-              enrollmentComplete: 'enrollmentComplete',
-              context,
-            }
-          );
+          qb.where(whereExperimentsClause, whereClauseParams);
         })
       );
 
@@ -94,14 +105,7 @@ export class ExperimentRepository extends Repository<Experiment> {
       .leftJoinAndSelect('factors.levels', 'levels')
       .where(
         new Brackets((qb) => {
-          qb.where(
-            '(experiment.state = :enrolling OR experiment.state = :enrollmentComplete) AND :context ILIKE ANY (ARRAY[experiment.context])',
-            {
-              enrolling: 'enrolling',
-              enrollmentComplete: 'enrollmentComplete',
-              context,
-            }
-          );
+          qb.where(whereExperimentsClause, whereClauseParams);
         })
       );
 
@@ -111,14 +115,7 @@ export class ExperimentRepository extends Repository<Experiment> {
       .leftJoinAndSelect('experiment.stateTimeLogs', 'stateTimeLogs')
       .where(
         new Brackets((qb) => {
-          qb.where(
-            '(experiment.state = :enrolling OR experiment.state = :enrollmentComplete) AND :context ILIKE ANY (ARRAY[experiment.context])',
-            {
-              enrolling: 'enrolling',
-              enrollmentComplete: 'enrollmentComplete',
-              context,
-            }
-          );
+          qb.where(whereExperimentsClause, whereClauseParams);
         })
       );
 
@@ -137,32 +134,50 @@ export class ExperimentRepository extends Repository<Experiment> {
       .leftJoinAndSelect('segmentExclusion.subSegments', 'subSegmentExclusion')
       .where(
         new Brackets((qb) => {
-          qb.where(
-            '(experiment.state = :enrolling OR experiment.state = :enrollmentComplete) AND :context ILIKE ANY (ARRAY[experiment.context])',
-            {
-              enrolling: 'enrolling',
-              enrollmentComplete: 'enrollmentComplete',
-              context,
-            }
-          );
+          qb.where(whereExperimentsClause, whereClauseParams);
         })
       );
 
-    const [experimentConditionLevelPayloadData, experimentFactorPartitionLevelPayloadData, experimentMetricData, experimentSegmentData] = await Promise.all([
+    const [
+      experimentConditionLevelPayloadData,
+      experimentFactorPartitionLevelPayloadData,
+      experimentMetricData,
+      experimentSegmentData,
+    ] = await Promise.all([
       experimentConditionLevelPayloadQuery.getMany().catch((errorMsg: any) => {
-        const errorMsgString = repositoryError('ExperimentRepository', 'getValidExperiments-experimentConditionLevelPayloadQuery', {}, errorMsg);
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'getValidExperiments-experimentConditionLevelPayloadQuery',
+          {},
+          errorMsg
+        );
         throw errorMsgString;
       }),
       experimentFactorPartitionLevelPayloadQuery.getMany().catch((errorMsg: any) => {
-        const errorMsgString = repositoryError('ExperimentRepository', 'getValidExperiments-experimentFactorPartitionLevelPayloadQuery', {}, errorMsg);
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'getValidExperiments-experimentFactorPartitionLevelPayloadQuery',
+          {},
+          errorMsg
+        );
         throw errorMsgString;
       }),
       experimentMetricQuery.getMany().catch((errorMsg: any) => {
-        const errorMsgString = repositoryError('ExperimentRepository', 'getValidExperiments-experimentMetricQuery', {}, errorMsg);
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'getValidExperiments-experimentMetricQuery',
+          {},
+          errorMsg
+        );
         throw errorMsgString;
       }),
       experimentSegmentQuery.getMany().catch((errorMsg: any) => {
-        const errorMsgString = repositoryError('ExperimentRepository', 'getValidExperiments-experimentSegmentQuery', {}, errorMsg);
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'getValidExperiments-experimentSegmentQuery',
+          {},
+          errorMsg
+        );
         throw errorMsgString;
       }),
     ]);
@@ -185,6 +200,15 @@ export class ExperimentRepository extends Repository<Experiment> {
   }
 
   public async getValidExperimentsWithPreview(context: string): Promise<Experiment[]> {
+    const whereExperimentsClause =
+      '(experiment.state = :enrolling OR experiment.state = :enrollmentComplete OR experiment.state = :preview) AND NOT (experiment.state = :enrollmentComplete AND experiment.postExperimentRule = :assign AND experiment.revertTo IS NULL) AND :context ILIKE ANY (ARRAY[experiment.context])';
+    const whereClauseParams = {
+      enrolling: 'enrolling',
+      enrollmentComplete: 'enrollmentComplete',
+      preview: 'preview',
+      assign: 'assign',
+      context,
+    };
     const experimentConditionLevelPayloadQuery = this.createQueryBuilder('experiment')
       .leftJoinAndSelect('experiment.conditions', 'conditions')
       .leftJoinAndSelect('conditions.levelCombinationElements', 'levelCombinationElements')
@@ -192,15 +216,7 @@ export class ExperimentRepository extends Repository<Experiment> {
       .leftJoinAndSelect('conditions.conditionPayloads', 'conditionPayload')
       .where(
         new Brackets((qb) => {
-          qb.where(
-            '(experiment.state = :enrolling OR experiment.state = :enrollmentComplete OR experiment.state = :preview) AND :context ILIKE ANY (ARRAY[experiment.context])',
-            {
-              enrolling: 'enrolling',
-              enrollmentComplete: 'enrollmentComplete',
-              preview: 'preview',
-              context,
-            }
-          );
+          qb.where(whereExperimentsClause, whereClauseParams);
         })
       );
 
@@ -212,15 +228,7 @@ export class ExperimentRepository extends Repository<Experiment> {
       .leftJoinAndSelect('factors.levels', 'levels')
       .where(
         new Brackets((qb) => {
-          qb.where(
-            '(experiment.state = :enrolling OR experiment.state = :enrollmentComplete OR experiment.state = :preview) AND :context ILIKE ANY (ARRAY[experiment.context])',
-            {
-              enrolling: 'enrolling',
-              enrollmentComplete: 'enrollmentComplete',
-              preview: 'preview',
-              context,
-            }
-          );
+          qb.where(whereExperimentsClause, whereClauseParams);
         })
       );
 
@@ -230,15 +238,7 @@ export class ExperimentRepository extends Repository<Experiment> {
       .leftJoinAndSelect('experiment.stateTimeLogs', 'stateTimeLogs')
       .where(
         new Brackets((qb) => {
-          qb.where(
-            '(experiment.state = :enrolling OR experiment.state = :enrollmentComplete OR experiment.state = :preview) AND :context ILIKE ANY (ARRAY[experiment.context])',
-            {
-              enrolling: 'enrolling',
-              enrollmentComplete: 'enrollmentComplete',
-              preview: 'preview',
-              context,
-            }
-          );
+          qb.where(whereExperimentsClause, whereClauseParams);
         })
       );
 
@@ -257,33 +257,50 @@ export class ExperimentRepository extends Repository<Experiment> {
       .leftJoinAndSelect('segmentExclusion.subSegments', 'subSegmentExclusion')
       .where(
         new Brackets((qb) => {
-          qb.where(
-            '(experiment.state = :enrolling OR experiment.state = :enrollmentComplete OR experiment.state = :preview) AND :context ILIKE ANY (ARRAY[experiment.context])',
-            {
-              enrolling: 'enrolling',
-              enrollmentComplete: 'enrollmentComplete',
-              preview: 'preview',
-              context,
-            }
-          );
+          qb.where(whereExperimentsClause, whereClauseParams);
         })
       );
 
-    const [experimentConditionLevelPayloadData, experimentFactorPartitionLevelPayloadData, experimentMetricData, experimentSegmentData] = await Promise.all([
+    const [
+      experimentConditionLevelPayloadData,
+      experimentFactorPartitionLevelPayloadData,
+      experimentMetricData,
+      experimentSegmentData,
+    ] = await Promise.all([
       experimentConditionLevelPayloadQuery.getMany().catch((errorMsg: any) => {
-        const errorMsgString = repositoryError('ExperimentRepository', 'getValidExperiments-experimentConditionLevelPayloadQuery', {}, errorMsg);
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'getValidExperiments-experimentConditionLevelPayloadQuery',
+          {},
+          errorMsg
+        );
         throw errorMsgString;
       }),
       experimentFactorPartitionLevelPayloadQuery.getMany().catch((errorMsg: any) => {
-        const errorMsgString = repositoryError('ExperimentRepository', 'getValidExperiments-experimentFactorPartitionLevelPayloadQuery', {}, errorMsg);
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'getValidExperiments-experimentFactorPartitionLevelPayloadQuery',
+          {},
+          errorMsg
+        );
         throw errorMsgString;
       }),
       experimentMetricQuery.getMany().catch((errorMsg: any) => {
-        const errorMsgString = repositoryError('ExperimentRepository', 'getValidExperiments-experimentMetricQuery', {}, errorMsg);
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'getValidExperiments-experimentMetricQuery',
+          {},
+          errorMsg
+        );
         throw errorMsgString;
       }),
       experimentSegmentQuery.getMany().catch((errorMsg: any) => {
-        const errorMsgString = repositoryError('ExperimentRepository', 'getValidExperiments-experimentSegmentQuery', {}, errorMsg);
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'getValidExperiments-experimentSegmentQuery',
+          {},
+          errorMsg
+        );
         throw errorMsgString;
       }),
     ]);

--- a/backend/packages/Upgrade/src/api/repositories/ExperimentRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/ExperimentRepository.ts
@@ -8,19 +8,23 @@ import { createGlobalExcludeSegment } from '../../../src/init/seed/globalExclude
 @EntityRepository(Experiment)
 export class ExperimentRepository extends Repository<Experiment> {
   public async findAllExperiments(): Promise<Experiment[]> {
-    const experiment = this.createQueryBuilder('experiment')
+    const experimentConditionLevelPayloadQuery = this.createQueryBuilder('experiment')
       .leftJoinAndSelect('experiment.conditions', 'conditions')
+      .leftJoinAndSelect('conditions.levelCombinationElements', 'levelCombinationElements')
+      .leftJoinAndSelect('levelCombinationElements.level', 'level')
+      .leftJoinAndSelect('conditions.conditionPayloads', 'conditionPayload');
+
+    const experimentFactorPartitionLevelPayloadQuery = this.createQueryBuilder('experiment')
       .leftJoinAndSelect('experiment.partitions', 'partitions')
-      .leftJoinAndSelect('experiment.queries', 'queries')
-      .leftJoinAndSelect('experiment.stateTimeLogs', 'stateTimeLogs')
-      .leftJoinAndSelect('experiment.factors', 'factors')
-      .leftJoinAndSelect('factors.levels', 'levels')
-      .leftJoinAndSelect('queries.metric', 'metric')
       .leftJoinAndSelect('partitions.conditionPayloads', 'conditionPayloads')
       .leftJoinAndSelect('conditionPayloads.parentCondition', 'parentCondition')
-      .leftJoinAndSelect('conditions.levelCombinationElements', 'levelCombinationElements')
-      .leftJoinAndSelect('conditions.conditionPayloads', 'conditionPayload')
-      .leftJoinAndSelect('levelCombinationElements.level', 'level');
+      .leftJoinAndSelect('experiment.factors', 'factors')
+      .leftJoinAndSelect('factors.levels', 'levels');
+
+    const experimentMetricQuery = this.createQueryBuilder('experiment')
+    .leftJoinAndSelect('experiment.queries', 'queries')
+    .leftJoinAndSelect('queries.metric', 'metric')
+    .leftJoinAndSelect('experiment.stateTimeLogs', 'stateTimeLogs');
 
     const experimentSegment = this.createQueryBuilder('experiment')
       .select('experiment.id')
@@ -35,11 +39,29 @@ export class ExperimentRepository extends Repository<Experiment> {
       .leftJoinAndSelect('segmentExclusion.groupForSegment', 'groupForSegmentExclusion')
       .leftJoinAndSelect('segmentExclusion.subSegments', 'subSegmentExclusion');
 
-    const [experimentData, experimentSegmentData] = await Promise.all([
-      experiment.getMany().catch((errorMsg: any) => {
+    const [experimentConditionLevelPayloadData, experimentFactorPartitionLevelPayloadData, experimentMetricData, experimentSegmentData] = await Promise.all([
+      experimentConditionLevelPayloadQuery.getMany().catch((errorMsg: any) => {
         const errorMsgString = repositoryError(
           'ExperimentRepository',
-          'findAllExperiments-experimentData',
+          'findAllExperiments-experimentConditionLevelPayloadData',
+          {},
+          errorMsg
+        );
+        throw errorMsgString;
+      }),
+      experimentFactorPartitionLevelPayloadQuery.getMany().catch((errorMsg: any) => {
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'findAllExperiments-experimentFactorPartitionLevelPayloadData',
+          {},
+          errorMsg
+        );
+        throw errorMsgString;
+      }),
+      experimentMetricQuery.getMany().catch((errorMsg: any) => {
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'findAllExperiments-experimentMetricData',
           {},
           errorMsg
         );
@@ -55,6 +77,12 @@ export class ExperimentRepository extends Repository<Experiment> {
         throw errorMsgString;
       }),
     ]);
+
+    const experimentData = experimentConditionLevelPayloadData.map((data) => {
+      const data2 = experimentFactorPartitionLevelPayloadData.find((i) => i.id === data.id);
+      const data3 = experimentMetricData.find((i) => i.id === data.id);
+      return { ...data, ...data2, ...data3 };
+    });
 
     const mergedData = experimentData.map((data) => {
       const { id } = data;

--- a/backend/packages/Upgrade/test/unit/repositories/ExperimentRepository.test.ts
+++ b/backend/packages/Upgrade/test/unit/repositories/ExperimentRepository.test.ts
@@ -176,14 +176,12 @@ describe('ExperimentRepository Testing', () => {
       .returns(selectQueryBuilder);
     const result = [experiment];
 
-    selectMock.expects('leftJoinAndSelect').exactly(12).returns(selectQueryBuilder);
-    selectMock.expects('leftJoinAndSelect').exactly(10).returns(selectQueryBuilder);
-    selectMock.expects('getMany').once().returns(Promise.resolve(result));
-    selectMock.expects('getMany').once().returns(Promise.resolve(result));
+    selectMock.expects('leftJoinAndSelect').exactly(22).returns(selectQueryBuilder);
+    selectMock.expects('getMany').exactly(4).returns(Promise.resolve(result));
 
     const res = await repo.findAllExperiments();
 
-    sinon.assert.calledTwice(createQueryBuilderStub);
+    expect(createQueryBuilderStub.callCount).toBe(4);
     selectMock.verify();
 
     expect(res).toEqual(result);
@@ -195,13 +193,13 @@ describe('ExperimentRepository Testing', () => {
       .returns(selectQueryBuilder);
 
     selectMock.expects('leftJoinAndSelect').exactly(22).returns(selectQueryBuilder);
-    selectMock.expects('getMany').twice().returns(Promise.reject(err));
+    selectMock.expects('getMany').exactly(4).returns(Promise.reject(err));
 
     expect(async () => {
       await repo.findAllExperiments();
     }).rejects.toThrow(err);
 
-    sinon.assert.calledTwice(createQueryBuilderStub);
+    expect(createQueryBuilderStub.callCount).toBe(4);
     selectMock.verify();
   });
 


### PR DESCRIPTION
This PR contains optimization of findallexperiments query which is used in an api find experiments, which is not actually used in the frontend as we use paginated api. Probably devs use this for testing stuff. This findallexperiments query is mostly used in integration test cases.