### PR TITLE
Clear previously uploaded files when importing an experiment

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/import-experiment/import-experiment.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/import-experiment/import-experiment.component.ts
@@ -586,6 +586,7 @@ export class ImportExperimentComponent implements OnInit {
     const reader = new FileReader();
     this.uploadedFileCount = event.target.files.length;
     this.importFileErrors = [];
+    this.allExperiments = [];
 
     readFile(index);
     function readFile(fileIndex: number) {


### PR DESCRIPTION
Resolves #1114

This issue was caused by the `validateExperiment()` function, which pushes the `experimentInfo` into the `this.allExperiments` array whenever the user uploads new file(s). The simple solution is to clear the `this.allExperiments` array whenever a new file(s) has been uploaded by the user.

After this change, the previously uploaded files will not be imported.

https://github.com/CarnegieLearningWeb/UpGrade/assets/90279765/4f6ef77c-35ad-46a1-a86f-f441fb2c72d5

