### PR TITLE
🐛 Fix for archive state not working in QA testing #30

### DIFF
--- a/backend/packages/Upgrade/src/api/services/QueryService.ts
+++ b/backend/packages/Upgrade/src/api/services/QueryService.ts
@@ -68,8 +68,12 @@ export class QueryService {
     const experiments: Experiment[] = [];
 
     // checks for archieve state experiment
-    if (promiseResult[0].experiment?.state === EXPERIMENT_STATE.ARCHIVED) {
-      return this.getArchivedStats(queryIds, logger);
+    if (queryIds.length !== 0) {
+      if (promiseResult[0].experiment?.state === EXPERIMENT_STATE.ARCHIVED) {
+        return this.getArchivedStats(queryIds, logger);
+      }
+    } else {
+      return [];
     }
 
     const analyzePromise = promiseResult.map((query) => {

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/experiment-status/experiment-status.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/experiment-status/experiment-status.component.ts
@@ -118,6 +118,6 @@ export class ExperimentStatusComponent implements OnInit {
   }
 
   setArchivedStatusAgreement() {
-    this.archivedStatusAgreement = true;
+    this.archivedStatusAgreement = !this.archivedStatusAgreement;
   }
 }


### PR DESCRIPTION
This PR contains the below fixes:

1. Now, the `Save` button on the experiment status change modal will be disabled on unchecking the archived status confirmation checkbox again.
2. Fixes the error when we used to change the experiment status to archived state. This was in case of experiments not containing any metric queries. So, handled that case for analyze() function.