### PR TITLE
Fix QueryFailedError when sorting experiments by status

### DIFF
--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -177,7 +177,10 @@ export class ExperimentService {
       .whereInIds(expIds);
 
     if (sortParams) {
-      queryBuilderToReturn = queryBuilderToReturn.addOrderBy(`LOWER(experiment.${sortParams.key})`, sortParams.sortAs);
+      queryBuilderToReturn = queryBuilderToReturn.addOrderBy(
+        `LOWER(CAST(experiment.${sortParams.key} AS TEXT))`,
+        sortParams.sortAs
+      );
     }
     const experiments = await queryBuilderToReturn.getMany();
     return experiments.map((experiment) => {


### PR DESCRIPTION
Resolves #1128

This issue was caused by applying the `LOWER()` function to an enum type when sorting the experiments by status. We can fix this by casting the enum type to a text type with `LOWER(CAST(experiment.${sortParams.key} AS TEXT))`.
