### PR TITLE
Enable the archivedStatusAgreement for non-Archived statuses

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/experiment-status/experiment-status.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/experiment-status/experiment-status.component.ts
@@ -99,9 +99,7 @@ export class ExperimentStatusComponent implements OnInit {
         // allow cancelled status for even less than 2 conditions:
         this.showConditionCountErrorMsg = false;
       }
-      if (status.value === EXPERIMENT_STATE.ARCHIVED) {
-        this.archivedStatusAgreement = false;
-      }
+      this.archivedStatusAgreement = status.value !== EXPERIMENT_STATE.ARCHIVED;
     });
   }
 


### PR DESCRIPTION
Resolves #1130 

This change sets the `this.archivedStatusAgreement` to true for non-Archived statuses when the "newStatus" dropdown's value changes. 