### PR TITLE
Original url destinations like experiment detail page will not redirect to home after login

### DIFF
--- a/frontend/projects/upgrade/src/app/core/auth/auth.service.ts
+++ b/frontend/projects/upgrade/src/app/core/auth/auth.service.ts
@@ -154,7 +154,6 @@ export class AuthService {
   }
 
   setRedirectionUrl(redirectUrl: string): void {
-    console.log({ redirectUrl });
     this.store$.dispatch(AuthActions.actionSetRedirectUrl({ redirectUrl }));
   }
 

--- a/frontend/projects/upgrade/src/app/core/auth/auth.service.ts
+++ b/frontend/projects/upgrade/src/app/core/auth/auth.service.ts
@@ -36,6 +36,8 @@ export class AuthService {
 
   initializeUserSession(): void {
     const currentUser = this.getUserFromBrowserStorage();
+    this.setRedirectionUrl(window.location.pathname);
+
     if (currentUser) {
       this.handleAutomaticLogin(currentUser);
     } else {
@@ -106,6 +108,7 @@ export class AuthService {
       .login(user)
       .pipe(
         tap((res: User) => {
+          console.log(`^^^ Do Login: ${window.location.href}`);
           this.store$.dispatch(AuthActions.actionLoginSuccess());
           this.deferSetUserInfoAfterNavigateEnd(res, googleCredential);
         }),
@@ -152,6 +155,7 @@ export class AuthService {
   }
 
   setRedirectionUrl(redirectUrl: string): void {
+    console.log({ redirectUrl });
     this.store$.dispatch(AuthActions.actionSetRedirectUrl({ redirectUrl }));
   }
 

--- a/frontend/projects/upgrade/src/app/core/auth/auth.service.ts
+++ b/frontend/projects/upgrade/src/app/core/auth/auth.service.ts
@@ -108,7 +108,6 @@ export class AuthService {
       .login(user)
       .pipe(
         tap((res: User) => {
-          console.log(`^^^ Do Login: ${window.location.href}`);
           this.store$.dispatch(AuthActions.actionLoginSuccess());
           this.deferSetUserInfoAfterNavigateEnd(res, googleCredential);
         }),

--- a/frontend/projects/upgrade/src/app/core/auth/auth.service.ts
+++ b/frontend/projects/upgrade/src/app/core/auth/auth.service.ts
@@ -36,13 +36,26 @@ export class AuthService {
 
   initializeUserSession(): void {
     const currentUser = this.getUserFromBrowserStorage();
-    this.setRedirectionUrl(window.location.pathname);
+    this.determinePostLoginDestinationUrl();
 
     if (currentUser) {
       this.handleAutomaticLogin(currentUser);
     } else {
       this.authLogout();
     }
+  }
+
+  /**
+   * determinePostLoginDestinationUrl
+   *
+   * - navigate to /home if user started from login or if no path is present
+   * - otherwise, navigate to the path they started from after google login does its thing
+   */
+
+  determinePostLoginDestinationUrl(): void {
+    const originalDestinationUrl = window.location.pathname?.endsWith('login') ? 'home' : window.location.pathname;
+
+    this.setRedirectionUrl(originalDestinationUrl);
   }
 
   initializeGoogleSignInButton(btnRef: ElementRef): void {

--- a/frontend/projects/upgrade/src/app/core/auth/store/auth.models.ts
+++ b/frontend/projects/upgrade/src/app/core/auth/store/auth.models.ts
@@ -21,7 +21,7 @@ export interface UserPermission {
 export interface AuthState {
   isLoggedIn: boolean;
   isAuthenticating: boolean;
-  redirectUrl?: string;
+  redirectUrl: string;
   user: User;
   googleCredential: string;
 }

--- a/frontend/projects/upgrade/src/app/core/auth/store/auth.reducer.ts
+++ b/frontend/projects/upgrade/src/app/core/auth/store/auth.reducer.ts
@@ -7,6 +7,7 @@ export const initialState: AuthState = {
   isAuthenticating: false,
   user: null,
   googleCredential: null,
+  redirectUrl: '/home',
 };
 
 const reducer = createReducer(

--- a/frontend/projects/upgrade/src/app/core/meta-reducers/clear-state.reducer.spec.ts
+++ b/frontend/projects/upgrade/src/app/core/meta-reducers/clear-state.reducer.spec.ts
@@ -1,5 +1,5 @@
 import { createReducer } from '@ngrx/store';
-import { actionLogoutSuccess } from '../auth/store/auth.actions';
+import { actionLogoutSuccess, actionLoginStart } from '../auth/store/auth.actions';
 import { LocalStorageService } from '../local-storage/local-storage.service';
 import { ThemeOptions } from '../settings/store/settings.model';
 import { clearState } from './clear-state.reducer';
@@ -11,11 +11,7 @@ describe('clearState', () => {
       theme: ThemeOptions.DARK_THEME,
     },
     auth: {
-      isLoggedIn: false,
-      isAuthenticating: false,
-      user: null,
-      googleCredential: null,
-      redirectUrl: '/home',
+      redirectUrl: '/test',
     },
   };
 
@@ -23,7 +19,7 @@ describe('clearState', () => {
     LocalStorageService.prototype.removeItem = jest.fn();
   });
 
-  it('should reset settings state and clear localStorage settings', () => {
+  it('should reset settings and auth state except for theme and redirectUrl on actionLogoutSuccess, and also clear localStorage settings', () => {
     const reducer = createReducer(mockState);
     const metaReducer = clearState(reducer);
     const expectedResetState = {
@@ -37,7 +33,7 @@ describe('clearState', () => {
         isAuthenticating: false,
         user: null,
         googleCredential: null,
-        redirectUrl: '/home',
+        redirectUrl: '/test',
       },
     };
 
@@ -47,5 +43,38 @@ describe('clearState', () => {
       Object.keys(ExperimentLocalStorageKeys).length
     );
     expect(newState).toEqual(expectedResetState);
+  });
+
+  it('should NOT reset anything or clear localStorage if action is anything but actionLogoutSuccess', () => {
+    const mockWithNonDefaultState = {
+      ...mockState,
+      auth: {
+        ...mockState.auth,
+        isLoggedIn: true,
+      },
+    };
+    const reducer = createReducer(mockState);
+    const metaReducer = clearState(reducer);
+    const expectedResetState = {
+      settings: {
+        theme: ThemeOptions.DARK_THEME,
+        toCheckAuth: null,
+        toFilterMetric: null,
+      },
+      auth: {
+        isLoggedIn: true,
+        isAuthenticating: false,
+        user: null,
+        googleCredential: null,
+        redirectUrl: '/test',
+      },
+    };
+
+    const newState = metaReducer(mockWithNonDefaultState, actionLoginStart());
+
+    expect(LocalStorageService.prototype.removeItem).not.toHaveBeenCalledTimes(
+      Object.keys(ExperimentLocalStorageKeys).length
+    );
+    expect(newState).not.toEqual(expectedResetState);
   });
 });

--- a/frontend/projects/upgrade/src/app/core/meta-reducers/clear-state.reducer.spec.ts
+++ b/frontend/projects/upgrade/src/app/core/meta-reducers/clear-state.reducer.spec.ts
@@ -10,6 +10,13 @@ describe('clearState', () => {
     settings: {
       theme: ThemeOptions.DARK_THEME,
     },
+    auth: {
+      isLoggedIn: false,
+      isAuthenticating: false,
+      user: null,
+      googleCredential: null,
+      redirectUrl: '/home',
+    },
   };
 
   beforeEach(() => {
@@ -24,6 +31,13 @@ describe('clearState', () => {
         theme: ThemeOptions.DARK_THEME,
         toCheckAuth: null,
         toFilterMetric: null,
+      },
+      auth: {
+        isLoggedIn: false,
+        isAuthenticating: false,
+        user: null,
+        googleCredential: null,
+        redirectUrl: '/home',
       },
     };
 

--- a/frontend/projects/upgrade/src/app/core/meta-reducers/clear-state.reducer.ts
+++ b/frontend/projects/upgrade/src/app/core/meta-reducers/clear-state.reducer.ts
@@ -3,6 +3,7 @@ import * as AuthActions from '../auth/store/auth.actions';
 import { ExperimentLocalStorageKeys } from '../experiments/store/experiments.model';
 import { LocalStorageService } from '../local-storage/local-storage.service';
 import { SettingsState } from '../settings/store/settings.model';
+import { AuthState } from '../auth/store/auth.models';
 
 export function clearState(reducer) {
   return (state, action: Action) => {
@@ -12,10 +13,18 @@ export function clearState(reducer) {
         toCheckAuth: null,
         toFilterMetric: null,
       };
+      const authState: AuthState = {
+        isLoggedIn: false,
+        isAuthenticating: false,
+        user: null,
+        googleCredential: null,
+        redirectUrl: state.auth.redirectUrl,
+      };
       const localStorageService = new LocalStorageService();
 
       state = {
         settings: settingState, // Used to persist theme,
+        auth: authState, // Used to persist redirectUrl
       };
 
       Object.values(ExperimentLocalStorageKeys).forEach((key) => {


### PR DESCRIPTION
#1137

Most routes will redirect to `/home` if you click on a shared url such as an experiment detail page like `/home/detail/abc123...` because the original destination url gets lost after navigating to `/login`.

This should allow one to open up a shared link, login if needed, and return to the intended destination page.