### PR TITLE
🐛 Resolving bug for null partitionId stored in enrolment docs resulting in wrong enrolment counts

### DIFF
--- a/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
@@ -329,7 +329,7 @@ export class ExperimentAssignmentService {
           await this.updateEnrollmentExclusion(
             userDoc,
             experiment,
-            selectedExperimentDP[0],
+            selectedExperimentDP,
             {
               individualEnrollment: individualEnrollments,
               individualExclusion: individualExclusions,


### PR DESCRIPTION
This PR resolves #1180 

Now the experiment CSV data export should have non-empty data rows for logged users data.
The enrolment counts on Data Tab would be reflected properly.
<img width="1263" alt="Screenshot 2023-12-13 at 7 26 29 PM" src="https://github.com/CarnegieLearningWeb/UpGrade/assets/33730817/ea0612b6-1dce-449c-baa8-12a25015fa89">
