### PR TITLE
mdc migration: Card (use raised instead of outlined)

### DIFF
--- a/frontend/projects/upgrade/src/app/features/auth/login/login.component.html
+++ b/frontend/projects/upgrade/src/app/features/auth/login/login.component.html
@@ -1,6 +1,6 @@
 <div class="light-theme login-theme">
   <div class="login-container">
-    <mat-card class="login">
+    <mat-card appearance="raised" class="login">
       <div class="login-info-container">
         <app-shared-icons [iconType]="'login-light'"></app-shared-icons>
         <div class="login-info">

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiment-users/experiment-users-root/experiment-users-root.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiment-users/experiment-users-root/experiment-users-root.component.html
@@ -1,8 +1,8 @@
-<mat-card class="tabs-container users-container">
+<mat-card appearance="raised" class="tabs-container users-container">
   <h1 class="ft-32-700 title">{{ 'users.main-heading.text' | translate }}</h1>
   <span class="ft-16-400 subtitle" [innerHTML]="'users.sub-heading.text' | translate"></span>
 
-  <mat-card class="tabs-wrapper">
+  <mat-card appearance="raised" class="tabs-wrapper">
     <mat-tab-group disableRipple="true" (selectedTabChange)="selectedTabChange($event)">
       <!-- <mat-tab [label]="'users.experiment-users-title.text' | translate">
         <users-experiment-users></users-experiment-users>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-list/experiment-list.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-list/experiment-list.component.html
@@ -1,4 +1,4 @@
-<mat-card class="experiments-list-container">
+<mat-card appearance="raised" class="experiments-list-container">
   <div class="header">
     <div>
       <mat-form-field class="filter-options">

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
@@ -1,11 +1,11 @@
-<mat-card class="experiment-container" *ngIf="experiment">
+<mat-card appearance="raised" class="experiment-container" *ngIf="experiment">
   <span class="ft-16-400">
     <a [routerLink]="['/home']" class="ft-16-400 experiment-link"
       >{{ 'home.view-experiment.experiments.text' | translate }}
     </a>
     <b> {{ experiment?.name }} </b>
   </span>
-  <mat-card class="experiment">
+  <mat-card appearance="raised" class="experiment">
     <div class="experiment-info">
       <div class="experiment-overview">
         <span class="ft-32-700 experiment-overview-title">

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/root/home.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/root/home.component.html
@@ -1,13 +1,13 @@
-<mat-card class="experiments-container">
+<mat-card appearance="raised" class="experiments-container">
   <h1 class="title ft-32-700">{{ 'global.experiment.title' | translate }}</h1>
   <span class="subtitle ft-16-400" [innerHTML]="'home.experiment.text.subtitle' | translate"></span>
 
   <ng-container *ngIf="isLoadingExperiments$ | async; else loadingExperimentState">
-    <mat-card class="experiment-table" *ngIf="(experiments$ | async).length; else noExperimentTemplate">
+    <mat-card appearance="raised" class="experiment-table" *ngIf="(experiments$ | async).length; else noExperimentTemplate">
       <home-experiment-list></home-experiment-list>
     </mat-card>
     <ng-template #noExperimentTemplate>
-      <mat-card class="no-experiment-container">
+      <mat-card appearance="raised" class="no-experiment-container">
         <span class="text ft-24-600" [innerHTML]="'home.no-experiment.text' | translate"></span>
         <button
           mat-flat-button

--- a/frontend/projects/upgrade/src/app/features/dashboard/logs/root/logs.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/logs/root/logs.component.html
@@ -1,8 +1,8 @@
-<mat-card class="tabs-container logs-container">
+<mat-card appearance="raised" class="tabs-container logs-container">
   <h1 class="ft-32-700 title">{{ 'logs.main-heading.text' | translate }}</h1>
   <span class="ft-16-400 subtitle" [innerHTML]="'logs.sub-heading.text' | translate"></span>
 
-  <mat-card class="tabs-wrapper">
+  <mat-card appearance="raised" class="tabs-wrapper">
     <mat-tab-group disableRipple="true" (selectedIndexChange)="selectedIndexChange($event)">
       <mat-tab [label]="'logs.audit-logs-tab.text' | translate">
         <audit-logs></audit-logs>

--- a/frontend/projects/upgrade/src/app/features/dashboard/profile/components/metrics/metrics.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/profile/components/metrics/metrics.component.html
@@ -1,4 +1,4 @@
-<mat-card class="metrics-container">
+<mat-card appearance="raised" class="metrics-container">
   <div class="header">
     <mat-form-field>
       <input

--- a/frontend/projects/upgrade/src/app/features/dashboard/profile/profile-root/profile-root.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/profile/profile-root/profile-root.component.html
@@ -1,8 +1,8 @@
-<mat-card class="tabs-container profile-container">
+<mat-card appearance="raised" class="tabs-container profile-container">
   <h1 class="ft-32-700 title">{{ 'profile.heading.text' | translate }}</h1>
   <span class="ft-16-400 subtitle" [innerHTML]="'profile.sub-heading.text' | translate"></span>
 
-  <mat-card class="tabs-wrapper">
+  <mat-card appearance="raised" class="tabs-wrapper">
     <mat-tab-group disableRipple="true">
       <mat-tab [label]="'profile.heading.text' | translate">
         <profile-info></profile-info>

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/components/segments-list/segments-list.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/components/segments-list/segments-list.component.html
@@ -1,4 +1,4 @@
-<mat-card class="segments-list-container">
+<mat-card appearance="raised" class="segments-list-container">
   <div class="header">
     <div>
       <mat-form-field class="filter-options">

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/view-segment/view-segment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/view-segment/view-segment.component.html
@@ -1,9 +1,9 @@
-<mat-card class="segment-container" *ngIf="segment">
+<mat-card appearance="raised" class="segment-container" *ngIf="segment">
   <span class="ft-16-400">
     <a [routerLink]="['/segments']" class="ft-16-400 segment-link">{{ 'segments.title.text' | translate }} </a>
     > <b> {{ segment?.name }} </b>
   </span>
-  <mat-card class="segment">
+  <mat-card appearance="raised" class="segment">
     <div class="segment-info">
       <div class="segment-overview">
         <span class="ft-32-700 segment-overview-title">

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/segments-root/segments-root.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/segments-root/segments-root.component.html
@@ -1,12 +1,12 @@
-<mat-card class="segments-container">
+<mat-card appearance="raised" class="segments-container">
   <h1 class="title ft-32-700">{{ 'segments.title.text' | translate }}</h1>
   <span class="subtitle ft-16-400" [innerHTML]="'segments.subtitle.text' | translate"></span>
   <ng-container *ngIf="isLoadingSegments$ | async; else loadingSegmentState">
-    <mat-card class="segments-table" *ngIf="(segments$ | async).length; else noSegmentsTemplate">
+    <mat-card appearance="raised" class="segments-table" *ngIf="(segments$ | async).length; else noSegmentsTemplate">
       <segments-list></segments-list>
     </mat-card>
     <ng-template #noSegmentsTemplate>
-      <mat-card class="no-segments-container">
+      <mat-card appearance="raised" class="no-segments-container">
         <span class="text ft-24-600" [innerHTML]="'segments.no-segments.text' | translate"></span>
         <button
           mat-flat-button

--- a/frontend/projects/upgrade/src/app/shared/shared.module.ts
+++ b/frontend/projects/upgrade/src/app/shared/shared.module.ts
@@ -14,7 +14,7 @@ import { MatLegacyProgressSpinnerModule as MatProgressSpinnerModule } from '@ang
 import { MatLegacyChipsModule as MatChipsModule } from '@angular/material/legacy-chips';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatLegacyCheckboxModule as MatCheckboxModule } from '@angular/material/legacy-checkbox';
-import { MatLegacyCardModule as MatCardModule } from '@angular/material/legacy-card';
+import { MatCardModule } from '@angular/material/card';
 import { MatLegacyListModule as MatListModule } from '@angular/material/legacy-list';
 import { MatIconModule } from '@angular/material/icon';
 import { MatLegacyTooltipModule as MatTooltipModule } from '@angular/material/legacy-tooltip';

--- a/frontend/projects/upgrade/src/styles.scss
+++ b/frontend/projects/upgrade/src/styles.scss
@@ -11,9 +11,13 @@
 //  If you specify typography styles for the components you use elsewhere, you should delete this line.
 //  If you don't need the default component typographies but still want the hierarchy styles,
 //  you can delete this line and instead use:
-//    `@include mat.legacy-typography-hierarchy(mat.define-legacy-typography-config());
+//    `@include mat.legacy-typography-hierarchy(mat.define-typography-config());
+/* TODO(mdc-migration): Remove all-legacy-component-typographies once all legacy components are migrated*/
 @include mat.all-legacy-component-typographies();
+@include mat.all-component-typographies();
+/* TODO(mdc-migration): Remove legacy-core once all legacy components are migrated*/
 @include mat.legacy-core();
+@include mat.core();
 
 @import './styles/variables.css';
 @import './themes/light-theme';
@@ -100,7 +104,9 @@
 }
 
 .light-theme {
+  /* TODO(mdc-migration): Remove all-legacy-component-themes once all legacy components are migrated*/
   @include mat.all-legacy-component-themes($light-theme);
+  @include mat.all-component-themes($light-theme);
   @include custom-components-theme($light-theme);
 }
 

--- a/frontend/projects/upgrade/src/themes/light-theme.scss
+++ b/frontend/projects/upgrade/src/themes/light-theme.scss
@@ -6,9 +6,13 @@
 //  If you specify typography styles for the components you use elsewhere, you should delete this line.
 //  If you don't need the default component typographies but still want the hierarchy styles,
 //  you can delete this line and instead use:
-//    `@include mat.legacy-typography-hierarchy(mat.define-legacy-typography-config());`
+//    `@include mat.legacy-typography-hierarchy(mat.define-typography-config());`
+/* TODO(mdc-migration): Remove all-legacy-component-typographies once all legacy components are migrated*/
 @include mat.all-legacy-component-typographies();
+@include mat.all-component-typographies();
+/* TODO(mdc-migration): Remove legacy-core once all legacy components are migrated*/
 @include mat.legacy-core();
+@include mat.core();
 
 mat.$blue-palette: (
   50: #e7edff,


### PR DESCRIPTION
This just updates the "mat-card" components (and the initial changes in `styles.scss` to prepare migration); this one is fairly straightforward, the migration script introduces `appearance: "outlined" to the html templates, which looked wrong, but switching it to "raised" looked like the way we have styled it previously.

Please make sure everything looks normal!

https://material.angular.io/components/card/api

#1196 