### PR TITLE
Add ft-16-600 to list-item-label elements

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/dashboard-root/dashboard-root.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/dashboard-root/dashboard-root.component.html
@@ -11,32 +11,32 @@
         <mat-list class="list">
           <mat-list-item *ngFor="let link of routeLinks">
             <a
-              class="nav-item ft-16-600"
+              class="nav-item"
               routerLinkActive="selected"
               [routerLink]="link.path"
               #linkInfo="routerLinkActive"
             >
               <mat-icon class="icon">{{ link.iconType }}</mat-icon>
-              <span class="list-item-label">{{ link.text | translate }}</span>
+              <span class="ft-16-600 list-item-label">{{ link.text | translate }}</span>
             </a>
           </mat-list-item>
         </mat-list>
         <div class="user">
           <mat-list class="user-list">
             <mat-list-item
-              class="user-list--item ft-16-600"
+              class="user-list--item"
               *ngIf="currentUser$ | async as user"
               routerLinkActive="user-list--item-selected"
             >
               <a class="profile" [routerLink]="['/profile']">
                 <img src="{{ user?.imageUrl }}" class="user-pic" referrerpolicy="no-referrer" />
-                <span class="list-item-label">{{ (user?.firstName || '') + ' ' + (user?.lastName || '') }}</span>
+                <span class="ft-16-600 list-item-label">{{ (user?.firstName || '') + ' ' + (user?.lastName || '') }}</span>
               </a>
             </mat-list-item>
-            <mat-list-item class="user-list--item ft-16-600">
+            <mat-list-item class="user-list--item">
               <a role="presentation" class="logout-link" (click)="logout()">
                 <mat-icon class="icon">exit_to_app</mat-icon>
-                <span class="list-item-label">{{ 'home-global.sign-out.text' | translate }}</span>
+                <span class="ft-16-600 list-item-label">{{ 'home-global.sign-out.text' | translate }}</span>
               </a>
             </mat-list-item>
           </mat-list>

--- a/frontend/projects/upgrade/src/styles.scss
+++ b/frontend/projects/upgrade/src/styles.scss
@@ -280,8 +280,6 @@ button[mat-button], button[mat-raised-button], button[mat-flat-button], button[m
 .mat-mdc-list-item {
   .list-item-label {
     color: var(--black-2);
-    font-family: 'Open Sans';
-    font-weight: 600;
     letter-spacing: normal;
   }
 }


### PR DESCRIPTION
This PR provides additional updates to the already merged PR (https://github.com/CarnegieLearningWeb/UpGrade/pull/1217). It adds the `ft-16-600` class to the `list-item-label` elements, which simplifies the global style in the `styles.scss` file.