### PR TITLE
Add tab-label class for styling the tab labels

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/experiment-users/experiment-users-root/experiment-users-root.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiment-users/experiment-users-root/experiment-users-root.component.html
@@ -10,13 +10,28 @@
       disableRipple
       (selectedTabChange)="selectedTabChange($event)"
     >
-      <!-- <mat-tab [label]="'users.experiment-users-title.text' | translate">
+      <!-- <mat-tab>
+        <ng-template mat-tab-label>
+          <span class="ft-22-600 tab-label">
+              {{ 'users.experiment-users-title.text' | translate }}
+          </span>
+        </ng-template>
         <users-experiment-users></users-experiment-users>
       </mat-tab> -->
-      <mat-tab [label]="'users.preview-users-title.text' | translate">
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <span class="ft-22-600 tab-label">
+              {{ 'users.preview-users-title.text' | translate }}
+          </span>
+        </ng-template>
         <users-preview-user></users-preview-user>
       </mat-tab>
-      <mat-tab [label]="'users.stratification.text' | translate">
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <span class="ft-22-600 tab-label">
+              {{ 'users.stratification.text' | translate }}
+          </span>
+        </ng-template>
         <users-stratification-factor-list></users-stratification-factor-list>
       </mat-tab>
     </mat-tab-group>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/create-query/create-query.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/create-query/create-query.component.html
@@ -6,10 +6,20 @@
     disableRipple
     (selectedIndexChange)="selectedIndexChange($event)"
   >
-    <mat-tab [label]="'monitor.simple-metric.text' | translate">
+    <mat-tab>
+      <ng-template mat-tab-label>
+        <span class="ft-22-600 tab-label">
+            {{ 'monitor.simple-metric.text' | translate }}
+        </span>
+      </ng-template>
       <ng-container *ngTemplateOutlet="queryTemplate; context: { tabIndex: 0 }"></ng-container>
     </mat-tab>
-    <mat-tab [label]="'monitor.grouped-metric.text' | translate">
+    <mat-tab>
+      <ng-template mat-tab-label>
+        <span class="ft-22-600 tab-label">
+            {{ 'monitor.grouped-metric.text' | translate }}
+        </span>
+      </ng-template>
       <ng-container *ngTemplateOutlet="queryTemplate"></ng-container>
     </mat-tab>
   </mat-tab-group>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
@@ -86,7 +86,12 @@
       [dynamicHeight]="true"
       disableRipple
     >
-      <mat-tab label="{{ 'home.view-experiment.mattab.overview.text' | translate }}">
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <span class="ft-22-600 tab-label">
+              {{ 'home.view-experiment.mattab.overview.text' | translate }}
+          </span>
+        </ng-template>
         <div class="experiment-secondary-info tab-body-container">
           <div class="experiment-secondary-info-container">
             <div class="experiment-info-section">
@@ -441,7 +446,12 @@
         </div>
       </mat-tab>
 
-      <mat-tab label="{{ 'home.view-experiment.mattab.design.text' | translate }}">
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <span class="ft-22-600 tab-label">
+              {{ 'home.view-experiment.mattab.design.text' | translate }}
+          </span>
+        </ng-template>
         <div class="tab-body-container tab-table-body-container">
           <!-- Experiment Decision Points Table -->
           <div class="table-container table-container-partition">
@@ -754,7 +764,12 @@
         </div>
       </mat-tab>
 
-      <mat-tab label="{{ 'home.view-experiment.mattab.participants.text' | translate }}">
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <span class="ft-22-600 tab-label">
+              {{ 'home.view-experiment.mattab.participants.text' | translate }}
+          </span>
+        </ng-template>
         <div class="tab-body-container tab-table-body-container">
           <!-- Participants to include table -->
           <div class="table-container table-container-participants">
@@ -844,7 +859,12 @@
         </div>
       </mat-tab>
 
-      <mat-tab label="{{ 'home.view-experiment.mattab.metrics.text' | translate }}">
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <span class="ft-22-600 tab-label">
+              {{ 'home.view-experiment.mattab.metrics.text' | translate }}
+          </span>
+        </ng-template>
         <div class="tab-body-container tab-table-body-container">
           <!-- Experiment metrics table -->
           <div class="table-container table-container-metrics">
@@ -902,7 +922,12 @@
         </div>
       </mat-tab>
 
-      <mat-tab label="{{ 'home.view-experiment.mattab.data.text' | translate }}">
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <span class="ft-22-600 tab-label">
+              {{ 'home.view-experiment.mattab.data.text' | translate }}
+          </span>
+        </ng-template>
         <div class="tab-body-container">
           <div class="ft-24-700 enrollment-text">
             {{ 'home.view-experiment.mattab.data.enrollment.text' | translate }}

--- a/frontend/projects/upgrade/src/app/features/dashboard/logs/root/logs.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/logs/root/logs.component.html
@@ -10,11 +10,21 @@
       disableRipple
       (selectedIndexChange)="selectedIndexChange($event)"
     >
-      <mat-tab [label]="'logs.audit-logs-tab.text' | translate">
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <span class="ft-22-600 tab-label">
+              {{ 'logs.audit-logs-tab.text' | translate }}
+          </span>
+        </ng-template>
         <audit-logs></audit-logs>
       </mat-tab>
       <!-- #1080 temporarily disable -->
-      <!-- <mat-tab [label]="'logs.error-logs-tab.text' | translate">
+      <!-- <mat-tab>
+        <ng-template mat-tab-label>
+          <span class="ft-22-600 tab-label">
+              {{ 'logs.error-logs-tab.text' | translate }}
+          </span>
+        </ng-template>
         <error-logs></error-logs>
       </mat-tab> -->
     </mat-tab-group>

--- a/frontend/projects/upgrade/src/app/features/dashboard/profile/profile-root/profile-root.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/profile/profile-root/profile-root.component.html
@@ -9,10 +9,20 @@
       [dynamicHeight]="true"
       disableRipple
     >
-      <mat-tab [label]="'profile.heading.text' | translate">
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <span class="ft-22-600 tab-label">
+              {{ 'profile.heading.text' | translate }}
+          </span>
+        </ng-template>
         <profile-info></profile-info>
       </mat-tab>
-      <mat-tab [label]="'global.metrics.text' | translate">
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <span class="ft-22-600 tab-label">
+              {{ 'global.metrics.text' | translate }}
+          </span>
+        </ng-template>
         <profile-metrics></profile-metrics>
       </mat-tab>
     </mat-tab-group>

--- a/frontend/projects/upgrade/src/styles.scss
+++ b/frontend/projects/upgrade/src/styles.scss
@@ -363,10 +363,7 @@ button[mat-button], button[mat-raised-button], button[mat-flat-button], button[m
         margin-left: 34px;
       }
 
-      .mdc-tab__text-label {
-        font-family: 'Open Sans';
-        font-weight: 600;
-        font-size: var(--text-size-xx-large);
+      .tab-label {
         letter-spacing: normal;
         color: var(--grey-2);
         user-select: none;
@@ -377,7 +374,7 @@ button[mat-button], button[mat-raised-button], button[mat-flat-button], button[m
       &.mdc-tab--active {
         opacity: 1;
 
-        .mdc-tab__text-label {
+        .tab-label {
           color: var(--blue);
         }
       }

--- a/frontend/projects/upgrade/src/styles/utility.scss
+++ b/frontend/projects/upgrade/src/styles/utility.scss
@@ -176,6 +176,10 @@ button,
   @include set-font(20, 700);
 }
 
+.ft-22-600 {
+  @include set-font(22, 600);
+}
+
 .ft-22-700 {
   @include set-font(22, 700);
 }


### PR DESCRIPTION
This PR provides additional updates to the already merged PR (https://github.com/CarnegieLearningWeb/UpGrade/pull/1261). It adds a template with the `mat-tab-label` directive inside the `mat-tab`, allowing us to place the label text inside a `span` element. This approach enables us to use `ft-22-600` and `tab-label` classes to style the label, just like how we styled labels for checkbox, chip, radio-button, etc. (reference: https://material.angular.io/components/tabs/overview#labels).

This change is not really necessary, but it is aimed at making the mat elements work consistently.

For example, I've rewritten the code below:

```
<mat-tab [label]="'users.stratification.text' | translate">
    <users-stratification-factor-list></users-stratification-factor-list>
</mat-tab>
```
to be like the following:

```
<mat-tab>
    <ng-template mat-tab-label>
        <span class="ft-22-600 tab-label">
            {{ 'users.stratification.text' | translate }}
        </span>
    </ng-template>
    <users-stratification-factor-list></users-stratification-factor-list>
</mat-tab>
```
And then removed the `font-family`, `font-weight`, and `font-size` from the global styling in `styles.scss`:
```
.tab-label {
    letter-spacing: normal;
    color: var(--grey-2);
    user-select: none;
}
```