### PR TITLE
Remove header-cell border-bottom

### DIFF
--- a/frontend/projects/upgrade/src/styles.scss
+++ b/frontend/projects/upgrade/src/styles.scss
@@ -331,7 +331,7 @@ button[mat-button], button[mat-raised-button], button[mat-flat-button], button[m
       overflow: hidden;
     }
 
-    .mat-mdc-cell {
+    .mat-mdc-cell, .mat-mdc-header-cell {
       background-color: transparent;
       border-bottom: none;
       letter-spacing: normal;


### PR DESCRIPTION
This PR provides additional updates to the already merged PR (https://github.com/CarnegieLearningWeb/UpGrade/pull/1253). It removes the border below the `mat-mdc-header-cell` so that only the border below the `mat-mdc-header-row` is visible.

Currently, the 2 borders below the header row is visible in upgrade.qa-cli.net like the following (but not in the local dev environment for some reason):
<img width="1000" alt="Screenshot 2024-01-26 at 2 19 24 PM" src="https://github.com/CarnegieLearningWeb/UpGrade/assets/90279765/937a8afd-76f2-4f0d-85a8-2e7c2a6aec50">

The change will remove the border below the header cell so that only a single border is visible: 
<img width="1000" alt="Screenshot 2024-01-26 at 2 26 50 PM" src="https://github.com/CarnegieLearningWeb/UpGrade/assets/90279765/2f04e280-2179-4a55-b589-512c91e68322">
