### PR TITLE
Set max-height for decision points table row

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.scss
@@ -274,6 +274,12 @@ $font-size-small: 15px;
     &-partition {
       margin-bottom: 24px;
 
+      .table {
+        mat-row {
+          max-height: 50px;
+        }
+      }
+
       .factor-table {
         overflow: auto;
 
@@ -285,6 +291,10 @@ $font-size-small: 15px;
         mat-header-cell,
         mat-cell {
           justify-content: left;
+        }
+
+        mat-header-cell {
+          color: var(--grey-2);
         }
 
         mat-icon {


### PR DESCRIPTION
This PR offers further updates to the previously merged PR (https://github.com/CarnegieLearningWeb/UpGrade/pull/1253). It addresses the issue where the height of the Decision Points table row increases due to the 'Exclude If Reached' checkbox, by setting the `max-height` to `50px`.