### PR TITLE
Bugfix/1252 auth refresh fix

### DIFF
--- a/frontend/projects/upgrade/src/app/core/auth/auth.service.ts
+++ b/frontend/projects/upgrade/src/app/core/auth/auth.service.ts
@@ -13,7 +13,6 @@ import { BehaviorSubject, filter, take } from 'rxjs';
 import { AUTH_CONSTANTS, GoogleAuthJWTPayload, User, UserRole } from '../users/store/users.model';
 import { ENV, Environment } from '../../../environments/environment-types';
 import jwt_decode from 'jwt-decode';
-import { AuthDataService } from './auth.data.service';
 import { NavigationEnd, NavigationSkipped, Router } from '@angular/router';
 
 @Injectable()
@@ -26,7 +25,6 @@ export class AuthService {
 
   constructor(
     private store$: Store<AppState>,
-    private authDataService: AuthDataService,
     private router: Router,
     private ngZone: NgZone,
     private localStorageService: LocalStorageService,

--- a/frontend/projects/upgrade/src/app/core/auth/store/auth.effects.ts
+++ b/frontend/projects/upgrade/src/app/core/auth/store/auth.effects.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import * as authActions from './auth.actions';
 import * as experimentUserActions from '../../experiment-users/store/experiment-users.actions';
@@ -14,8 +14,6 @@ import { selectRedirectUrl } from './auth.selectors';
 import { AuthDataService } from '../auth.data.service';
 import { AuthService } from '../auth.service';
 import { User } from '../../users/store/users.model';
-import { SettingsService } from '../../settings/settings.service';
-import { ENV, Environment } from '../../../../environments/environment-types';
 
 @Injectable()
 export class AuthEffects {
@@ -24,9 +22,7 @@ export class AuthEffects {
     private store$: Store<AppState>,
     private router: Router,
     private authDataService: AuthDataService,
-    private authService: AuthService,
-    private settingsService: SettingsService,
-    @Inject(ENV) private environment: Environment
+    private authService: AuthService
   ) {}
 
   fetchUserExperimentData$ = createEffect(() =>


### PR DESCRIPTION
This PR fixes issues with buttons "disappearing" on refresh in some routes: #1252. There is logic that waits until a "NavigationEnd" event is emitted from router before setting the user's role / permissions, but that isn't always the only router event type that signals the end of navigation. I found that "NavigationSkipped" is also necessary for when the router doesn't need to redirect anywhere.