### PR TITLE
Bugfix/1270 docker build failure

### DIFF
--- a/backend/packages/Upgrade/commands/tsconfig.ts
+++ b/backend/packages/Upgrade/commands/tsconfig.ts
@@ -3,10 +3,11 @@ import * as path from 'path';
 
 import * as tsconfig from '../tsconfig.json';
 
-const content: any = tsconfig;
+const content: any = JSON.parse(JSON.stringify(tsconfig)); // Clone tsconfig.json
 content.compilerOptions.outDir = 'dist';
 content.include = ['src/**/*', 'custom.d.ts'];
 content.compilerOptions.paths.upgrade_types = ['./types'];
+delete content.references;
 
 const filePath = path.join(process.cwd(), 'tsconfig.build.json');
 jsonfile.writeFile(filePath, content, { spaces: 2 }, (err) => {

--- a/backend/packages/Upgrade/commands/tsconfig.ts
+++ b/backend/packages/Upgrade/commands/tsconfig.ts
@@ -1,13 +1,15 @@
-import * as jsonfile from 'jsonfile';
-import * as path from 'path';
-
-import * as tsconfig from '../tsconfig.json';
+import jsonfile from 'jsonfile';
+import path from 'path';
+import tsconfig from '../tsconfig.json';
+import baseConfig from '../../../tsconfig.json';
 
 const content: any = JSON.parse(JSON.stringify(tsconfig)); // Clone tsconfig.json
+content.compilerOptions = { ...baseConfig.compilerOptions, ...content.compilerOptions };
 content.compilerOptions.outDir = 'dist';
 content.include = ['src/**/*', 'custom.d.ts'];
 content.compilerOptions.paths.upgrade_types = ['./types'];
 delete content.references;
+delete content.extends;
 
 const filePath = path.join(process.cwd(), 'tsconfig.build.json');
 jsonfile.writeFile(filePath, content, { spaces: 2 }, (err) => {

--- a/backend/packages/Upgrade/package-scripts.js
+++ b/backend/packages/Upgrade/package-scripts.js
@@ -72,7 +72,7 @@ module.exports = {
       },
       production: {
         script:
-          'cross-env NODE_ENV=production ts-node --esm --project tsconfig.build.json -r tsconfig-paths/register dist/src/app.js',
+          'cross-env NODE_ENV=production TS_NODE_PROJECT=tsconfig.build.json ts-node --esm -r tsconfig-paths/register dist/src/app.js',
       },
       development: {
         script: 'cross-env NODE_ENV=development node dist/src/app.js',


### PR DESCRIPTION
In the upgraded `ts-node` and `tsconfig-paths`, `tsconfig-paths` is not using the typescript configuration file loaded by `ts-node` through `--project` flag. But passing it through the environment variable does the trick.