### PR TITLE
remaining mdc and final removal of legacy stuff

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/experiment-users/components/experiment-users/experiment-users.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiment-users/components/experiment-users/experiment-users.component.ts
@@ -9,7 +9,7 @@ import { AuthService } from '../../../../../core/auth/auth.service';
 import { UserRole } from 'upgrade_types';
 import { ExperimentService } from '../../../../../core/experiments/experiments.service';
 import { MatSort } from '@angular/material/sort';
-import { MatLegacyPaginator as MatPaginator } from '@angular/material/legacy-paginator';
+import { MatPaginator } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
 
 @Component({

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/components/feature-flags-list/feature-flags-list.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/components/feature-flags-list/feature-flags-list.component.scss
@@ -15,11 +15,6 @@
     .filter-options {
       margin-right: 10px;
       width: 80px;
-      /* TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-      ::ng-deep .mat-form-field-underline,
-      ::ng-deep .mat-form-field-ripple {
-        background-color: unset;
-      }
     }
 
     .search-input {
@@ -31,10 +26,6 @@
       height: 40px;
       color: var(--white);
     }
-  }
-  /* TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-  ::ng-deep .mat-form-field-suffix {
-    top: 5px;
   }
 
   .flags-list-table-container {

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/components/flag-variations/flag-variations.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/components/flag-variations/flag-variations.component.scss
@@ -88,13 +88,4 @@
       margin-left: 0 !important;
     }
   }
-  /* TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-  ::ng-deep .form-control .mat-form-field-underline {
-    bottom: unset;
-    background-color: unset !important;
-  }
-  /* TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-  ::ng-deep .mat-form-field-appearance-legacy.mat-form-field-invalid:not(.mat-focused) .mat-form-field-ripple {
-    display: none;
-  }
 }

--- a/frontend/projects/upgrade/src/app/shared/shared.module.ts
+++ b/frontend/projects/upgrade/src/app/shared/shared.module.ts
@@ -6,11 +6,9 @@ import { TranslateModule } from '@ngx-translate/core';
 
 import { MatButtonModule } from '@angular/material/button';
 import { MatToolbarModule } from '@angular/material/toolbar';
-import { MatLegacyMenuModule as MatMenuModule } from '@angular/material/legacy-menu';
 import { MatSelectModule } from '@angular/material/select';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatInputModule } from '@angular/material/input';
-import { MatLegacyProgressSpinnerModule as MatProgressSpinnerModule } from '@angular/material/legacy-progress-spinner';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatCheckboxModule } from '@angular/material/checkbox';
@@ -18,15 +16,14 @@ import { MatCardModule } from '@angular/material/card';
 import { MatListModule } from '@angular/material/list';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { MatLegacySnackBarModule as MatSnackBarModule } from '@angular/material/legacy-snack-bar';
-import { MatLegacySlideToggleModule as MatSlideToggleModule } from '@angular/material/legacy-slide-toggle';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatTreeModule } from '@angular/material/tree';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
-import { MatLegacySliderModule as MatSliderModule } from '@angular/material/legacy-slider';
 import { MatTableModule } from '@angular/material/table';
-import { MatLegacyPaginatorModule as MatPaginatorModule } from '@angular/material/legacy-paginator';
-import { MatLegacyProgressBarModule as MatProgressBarModule } from '@angular/material/legacy-progress-bar';
+import { MatPaginatorModule } from '@angular/material/paginator';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatSortModule } from '@angular/material/sort';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatStepperModule } from '@angular/material/stepper';
@@ -57,13 +54,11 @@ import { environment } from '../../environments/environment';
     MatSelectModule,
     MatTabsModule,
     MatInputModule,
-    MatProgressSpinnerModule,
     MatChipsModule,
     MatCardModule,
     MatSidenavModule,
     MatCheckboxModule,
     MatListModule,
-    MatMenuModule,
     MatIconModule,
     MatTooltipModule,
     MatSnackBarModule,
@@ -99,11 +94,9 @@ import { environment } from '../../environments/environment';
     ReactiveFormsModule,
     TranslateModule,
     MatButtonModule,
-    MatMenuModule,
     MatTabsModule,
     MatChipsModule,
     MatInputModule,
-    MatProgressSpinnerModule,
     MatCheckboxModule,
     MatCardModule,
     MatSidenavModule,
@@ -115,7 +108,6 @@ import { environment } from '../../environments/environment';
     MatSnackBarModule,
     MatSlideToggleModule,
     MatDividerModule,
-    MatSliderModule,
     MatTableModule,
     MatPaginatorModule,
     MatSortModule,

--- a/frontend/projects/upgrade/src/styles.scss
+++ b/frontend/projects/upgrade/src/styles.scss
@@ -4,19 +4,7 @@
 @import url('https://fonts.googleapis.com/css?family=Roboto:400,700|Material+Icons');
 @import url('https://fonts.googleapis.com/css?family=Open+Sans:400,600,700,800&display=swap');
 
-// TODO(v15): As of v15 mat.legacy-core no longer includes default typography styles.
-//  The following line adds:
-//    1. Default typography styles for all components
-//    2. Styles for typography hierarchy classes (e.g. .mat-headline-1)
-//  If you specify typography styles for the components you use elsewhere, you should delete this line.
-//  If you don't need the default component typographies but still want the hierarchy styles,
-//  you can delete this line and instead use:
-//    `@include mat.legacy-typography-hierarchy(mat.define-typography-config());
-/* TODO(mdc-migration): Remove all-legacy-component-typographies once all legacy components are migrated*/
-@include mat.all-legacy-component-typographies();
 @include mat.all-component-typographies();
-/* TODO(mdc-migration): Remove legacy-core once all legacy components are migrated*/
-@include mat.legacy-core();
 @include mat.core();
 
 @import './styles/variables.css';
@@ -104,8 +92,6 @@
 }
 
 .light-theme {
-  /* TODO(mdc-migration): Remove all-legacy-component-themes once all legacy components are migrated*/
-  @include mat.all-legacy-component-themes($light-theme);
   @include mat.all-component-themes($light-theme);
   @include custom-components-theme($light-theme);
 }

--- a/frontend/projects/upgrade/src/themes/light-theme.scss
+++ b/frontend/projects/upgrade/src/themes/light-theme.scss
@@ -1,17 +1,7 @@
 @use '@angular/material' as mat;
-// TODO(v15): As of v15 mat.legacy-core no longer includes default typography styles.
-//  The following line adds:
-//    1. Default typography styles for all components
-//    2. Styles for typography hierarchy classes (e.g. .mat-headline-1)
-//  If you specify typography styles for the components you use elsewhere, you should delete this line.
-//  If you don't need the default component typographies but still want the hierarchy styles,
-//  you can delete this line and instead use:
-//    `@include mat.legacy-typography-hierarchy(mat.define-typography-config());`
-/* TODO(mdc-migration): Remove all-legacy-component-typographies once all legacy components are migrated*/
-@include mat.all-legacy-component-typographies();
+
 @include mat.all-component-typographies();
-/* TODO(mdc-migration): Remove legacy-core once all legacy components are migrated*/
-@include mat.legacy-core();
+
 @include mat.core();
 
 mat.$blue-palette: (


### PR DESCRIPTION
Last one! Please double-check a few components, the migration script doesn't do a lot with them and they looked fine to me:

`mat-slider-toggle`
`mat-progress-bar`
and the snackbar notifications

Ignore `mat-paginator`, it is only used in a dead component that should itself be removed in a different tech debt story.

The other components like `mat-menu` removed from the "shared.module" have no actual implementations in the html but probably lead to larger build-size.