### PR TITLE
Refine table styles

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/experiment-users/components/preview-user/preview-user.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiment-users/components/preview-user/preview-user.component.scss
@@ -45,6 +45,8 @@
       }
 
       .mat-mdc-header-cell {
+        background-color: var(--white);
+
         &.mat-column-totalAssignedConditions {
           text-align: center;
         }

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiment-users/components/stratification-factor-list/stratification-factor-list.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiment-users/components/stratification-factor-list/stratification-factor-list.component.html
@@ -89,7 +89,7 @@
         </mat-cell>
       </ng-container>
 
-      <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+      <mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></mat-header-row>
       <mat-row *matRowDef="let row; columns: displayedColumns"></mat-row>
     </mat-table>
   </div>

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiment-users/components/stratification-factor-list/stratification-factor-list.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiment-users/components/stratification-factor-list/stratification-factor-list.component.scss
@@ -23,8 +23,9 @@
 
   .table-container {
     position: relative;
-    margin-top: 8px;
+    margin-top: 16px;
     overflow: auto;
+    max-height: 450px;
 
     .spinner {
       position: sticky;
@@ -36,8 +37,8 @@
       width: 100%;
 
       .mat-mdc-header-row {
-        min-height: 35px;
-        max-height: 35px;
+        min-height: 56px;
+        max-height: 56px;
         justify-content: space-between;
       }
 
@@ -48,7 +49,7 @@
 
       .mat-mdc-header-cell {
         justify-content: left;
-        color: var(--grey-6);
+        color: var(--grey-2);
       }
 
       .mat-mdc-cell {

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-list/experiment-list.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-list/experiment-list.component.scss
@@ -78,6 +78,7 @@ $experiment-state-light-color: #8f9bb3;
     .mat-mdc-header-cell {
       padding: 10px 5px;
       word-break: break-word;
+      background-color: var(--white);
 
       &.cdk-column-name {
         width: 15%;

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
@@ -512,7 +512,7 @@
               <mat-table class="factor-table" [dataSource]="factorsDataSource" multiTemplateDataRows>
                 <!-- Expand Icon Column -->
                 <ng-container matColumnDef="expandIcon">
-                  <mat-header-cell class="ft-14-700" *matHeaderCellDef></mat-header-cell>
+                  <mat-header-cell class="ft-12-700" *matHeaderCellDef></mat-header-cell>
                   <mat-cell *matCellDef="let data; let factorIndex = dataIndex" style="justify-content: flex-start">
                     <mat-icon [class.active]="factorIndex === expandedId" (click)="expandFactor(factorIndex)"
                       >play_arrow</mat-icon
@@ -561,20 +561,20 @@
                       <mat-table class="table level-table" [dataSource]="data.levels">
                         <!-- Level Column -->
                         <ng-container matColumnDef="level">
-                          <mat-header-cell class="ft-14-700" *matHeaderCellDef>
+                          <mat-header-cell class="ft-12-700" *matHeaderCellDef>
                             {{ 'home.new-experiment.design.level-name.text' | translate }}
                           </mat-header-cell>
-                          <mat-cell *matCellDef="let data; let levelIndex = index">
+                          <mat-cell class="ft-12-600" *matCellDef="let data; let levelIndex = index">
                             <span>{{ data.name }}</span>
                           </mat-cell>
                         </ng-container>
 
                         <!-- Payload Column -->
                         <ng-container matColumnDef="payload">
-                          <mat-header-cell class="ft-14-700" *matHeaderCellDef>
+                          <mat-header-cell class="ft-12-700" *matHeaderCellDef>
                             {{ 'home.new-experiment.design.payloads.column-header.payload.text' | translate }}
                           </mat-header-cell>
-                          <mat-cell *matCellDef="let data; let levelIndex = index">
+                          <mat-cell class="ft-12-600" *matCellDef="let data; let levelIndex = index">
                             <span>{{ data.payload?.value }}</span>
                           </mat-cell>
                         </ng-container>

--- a/frontend/projects/upgrade/src/app/features/dashboard/profile/components/metrics/metrics.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/profile/components/metrics/metrics.component.scss
@@ -56,6 +56,8 @@
       }
 
       .mat-mdc-header-cell {
+        color: var(--grey-2);
+
         &.mat-column-metric {
           padding-left: 20px;
         }

--- a/frontend/projects/upgrade/src/app/features/dashboard/profile/components/profile-info/profile-info.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/profile/components/profile-info/profile-info.component.scss
@@ -100,6 +100,10 @@ $role-text-color: #0a7319;
           color: var(--grey-2);
         }
 
+        .mat-mdc-header-cell {
+          background-color: var(--white);
+        }
+
         tr.mat-mdc-footer-row,
         tr.mat-mdc-row {
           height: 55px;

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/components/segments-list/segments-list.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/components/segments-list/segments-list.component.scss
@@ -71,6 +71,7 @@
       padding: 10px 5px;
       width: 20%;
       word-break: break-word;
+      background-color: var(--white);
     }
 
     .mat-mdc-header-cell {


### PR DESCRIPTION
This PR provides additional updates to the already merged PR (https://github.com/CarnegieLearningWeb/UpGrade/pull/1253). This PR makes the sticky headers have white background color so that the text doesn't overlap when scrolled. Also, updates some font sizes and colors to make them consistent.