### PR TITLE
Replace skip/take with offset/limit which is relevant for sql based query.

### DIFF
--- a/backend/packages/Upgrade/src/api/repositories/AnalyticsRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/AnalyticsRepository.ts
@@ -439,8 +439,8 @@ export class AnalyticsRepository {
       .addGroupBy('"individualEnrollment"."groupId"')
       .addGroupBy('condition."conditionCode"')
       .orderBy('"individualEnrollment"."userId"', 'ASC')
-      .skip(skip)
-      .take(take)
+      .offset(skip)
+      .limit(take)
       .where('"individualEnrollment"."experimentId" = :experimentId', { experimentId })
       .execute();
   }
@@ -486,8 +486,8 @@ export class AnalyticsRepository {
       .addGroupBy('"individualEnrollment"."groupId"')
       .addGroupBy('"monitoredPointLogs"."condition"')
       .orderBy('"individualEnrollment"."userId"', 'ASC')
-      .skip(skip)
-      .take(take)
+      .offset(skip)
+      .limit(take)
       .where('"individualEnrollment"."experimentId" = :experimentId', { experimentId })
       .execute();
   }

--- a/backend/packages/Upgrade/src/api/repositories/ErrorRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/ErrorRepository.ts
@@ -20,7 +20,7 @@ export class ErrorRepository extends Repository<ExperimentError> {
   }
 
   public async paginatedFind(limit: number, offset: number, filter: SERVER_ERROR): Promise<ExperimentError[]> {
-    let queryBuilder = this.createQueryBuilder('error').skip(offset).take(limit).orderBy('error.createdAt', 'DESC');
+    let queryBuilder = this.createQueryBuilder('error').offset(offset).limit(limit).orderBy('error.createdAt', 'DESC');
     if (filter) {
       queryBuilder = queryBuilder.where('error.type = :filter', { filter });
     }
@@ -45,7 +45,7 @@ export class ErrorRepository extends Repository<ExperimentError> {
     const errorLogOffset = await this.createQueryBuilder('error')
       .select('error.id')
       .orderBy('error.createdAt', 'DESC')
-      .take(limit);
+      .limit(limit);
 
     const result = await this.createQueryBuilder()
       .delete()

--- a/backend/packages/Upgrade/src/api/repositories/ExperimentAuditLogRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/ExperimentAuditLogRepository.ts
@@ -12,8 +12,8 @@ export class ExperimentAuditLogRepository extends Repository<ExperimentAuditLog>
     filter: EXPERIMENT_LOG_TYPE
   ): Promise<ExperimentAuditLog[]> {
     let queryBuilder = this.createQueryBuilder('audit')
-      .skip(offset)
-      .take(limit)
+      .offset(offset)
+      .limit(limit)
       .leftJoinAndSelect('audit.user', 'user')
       .orderBy('audit.createdAt', 'DESC');
 
@@ -63,7 +63,7 @@ export class ExperimentAuditLogRepository extends Repository<ExperimentAuditLog>
     const auditLogOffset = await this.createQueryBuilder('audit')
       .select('audit.id')
       .orderBy('audit.createdAt', 'DESC')
-      .take(limit);
+      .limit(limit);
 
     const result = await this.createQueryBuilder()
       .delete()

--- a/backend/packages/Upgrade/src/api/repositories/MonitoredDecisionPointRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/MonitoredDecisionPointRepository.ts
@@ -88,8 +88,8 @@ export class MonitoredDecisionPointRepository extends Repository<MonitoredDecisi
   //         .select('*')
   //         .from(MonitoredExperimentPoint, 'monitoredExperiment')
   //         .where('"monitoredExperiment"."experimentId" IN (:...ids)', { ids: monitorPointIds })
-  //         .skip(offset)
-  //         .take(limit);
+  //         .offset(offset)
+  //         .limit(limit);
   //     }, 'monitoredExperiment')
   //     .leftJoin(ExperimentUser, 'user', 'user.id = "monitoredExperiment"."userId"')
   //     .leftJoin(IndividualAssignment, 'individualAssignment', 'user.id = "individualAssignment"."userId"')

--- a/backend/packages/Upgrade/src/api/repositories/PreviewUserRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/PreviewUserRepository.ts
@@ -67,8 +67,8 @@ export class PreviewUserRepository extends Repository<PreviewUser> {
 
   public async findPaginated(skip: number, take: number): Promise<PreviewUser[] | undefined> {
     return this.createQueryBuilder('user')
-      .skip(skip)
-      .take(take)
+      .offset(skip)
+      .limit(take)
       .orderBy('user.createdAt', 'DESC')
       .getMany()
       .catch((errorMsg: any) => {

--- a/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
+++ b/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
@@ -61,7 +61,7 @@ export class FeatureFlagService {
       queryBuilder = queryBuilder.addOrderBy(`feature_flag.${sortParams.key}`, sortParams.sortAs);
     }
 
-    queryBuilder = queryBuilder.skip(skip).take(take);
+    queryBuilder = queryBuilder.offset(skip).limit(take);
     return queryBuilder.getMany();
   }
 

--- a/backend/packages/Upgrade/src/api/services/UserService.ts
+++ b/backend/packages/Upgrade/src/api/services/UserService.ts
@@ -95,7 +95,7 @@ export class UserService {
       queryBuilder = queryBuilder.addOrderBy(`users.${sortParams.key}`, sortParams.sortAs);
     }
     const systemEmail = systemUserDoc.email;
-    queryBuilder = queryBuilder.where('users.email != :email', { email: systemEmail }).skip(skip).take(take);
+    queryBuilder = queryBuilder.where('users.email != :email', { email: systemEmail }).offset(skip).limit(take);
 
     return queryBuilder.getMany();
   }

--- a/backend/packages/Upgrade/test/unit/repositories/ErrorRepository.test.ts
+++ b/backend/packages/Upgrade/test/unit/repositories/ErrorRepository.test.ts
@@ -81,7 +81,7 @@ describe('ErrorRepository Testing', () => {
 
     selectMock.expects('select').once().returns(selectQueryBuilder);
     selectMock.expects('orderBy').once().returns(selectQueryBuilder);
-    selectMock.expects('take').once().returns(selectQueryBuilder);
+    selectMock.expects('limit').once().returns(selectQueryBuilder);
     selectMock.expects('getQuery').once().returns(experiment.id);
     deleteMock.expects('delete').once().returns(deleteQueryBuilder);
     deleteMock.expects('from').once().returns(deleteQueryBuilder);
@@ -105,7 +105,7 @@ describe('ErrorRepository Testing', () => {
 
     selectMock.expects('select').once().returns(selectQueryBuilder);
     selectMock.expects('orderBy').once().returns(selectQueryBuilder);
-    selectMock.expects('take').once().returns(selectQueryBuilder);
+    selectMock.expects('limit').once().returns(selectQueryBuilder);
     selectMock.expects('getQuery').once().returns(experiment.id);
     deleteMock.expects('delete').once().returns(deleteQueryBuilder);
     deleteMock.expects('from').once().returns(deleteQueryBuilder);
@@ -151,8 +151,8 @@ describe('ErrorRepository Testing', () => {
   it('should find paginated', async () => {
     createQueryBuilderStub = sandbox.stub(ErrorRepository.prototype, 'createQueryBuilder').returns(selectQueryBuilder);
 
-    selectMock.expects('skip').once().returns(selectQueryBuilder);
-    selectMock.expects('take').once().returns(selectQueryBuilder);
+    selectMock.expects('offset').once().returns(selectQueryBuilder);
+    selectMock.expects('limit').once().returns(selectQueryBuilder);
     selectMock.expects('orderBy').once().returns(selectQueryBuilder);
     selectMock.expects('where').once().returns(selectQueryBuilder);
     selectMock.expects('getMany').once().returns(Promise.resolve(result));
@@ -168,8 +168,8 @@ describe('ErrorRepository Testing', () => {
   it('should find paginated with no filter', async () => {
     createQueryBuilderStub = sandbox.stub(ErrorRepository.prototype, 'createQueryBuilder').returns(selectQueryBuilder);
 
-    selectMock.expects('skip').once().returns(selectQueryBuilder);
-    selectMock.expects('take').once().returns(selectQueryBuilder);
+    selectMock.expects('offset').once().returns(selectQueryBuilder);
+    selectMock.expects('limit').once().returns(selectQueryBuilder);
     selectMock.expects('orderBy').once().returns(selectQueryBuilder);
     selectMock.expects('where').never().returns(selectQueryBuilder);
     selectMock.expects('getMany').once().returns(Promise.resolve(result));
@@ -185,8 +185,8 @@ describe('ErrorRepository Testing', () => {
   it('should throw an error when find paginated fails', async () => {
     createQueryBuilderStub = sandbox.stub(ErrorRepository.prototype, 'createQueryBuilder').returns(selectQueryBuilder);
 
-    selectMock.expects('skip').once().returns(selectQueryBuilder);
-    selectMock.expects('take').once().returns(selectQueryBuilder);
+    selectMock.expects('offset').once().returns(selectQueryBuilder);
+    selectMock.expects('limit').once().returns(selectQueryBuilder);
     selectMock.expects('orderBy').once().returns(selectQueryBuilder);
     selectMock.expects('where').once().returns(selectQueryBuilder);
     selectMock.expects('getMany').once().returns(Promise.reject(err));

--- a/backend/packages/Upgrade/test/unit/repositories/ExperimentAuditLogRepository.test.ts
+++ b/backend/packages/Upgrade/test/unit/repositories/ExperimentAuditLogRepository.test.ts
@@ -115,7 +115,7 @@ describe('ExperimentAuditLogRepository Testing', () => {
 
     selectMock.expects('select').once().returns(selectQueryBuilder);
     selectMock.expects('orderBy').once().returns(selectQueryBuilder);
-    selectMock.expects('take').once().returns(selectQueryBuilder);
+    selectMock.expects('limit').once().returns(selectQueryBuilder);
     selectMock.expects('getQuery').once().returns(experiment.id);
     deleteMock.expects('delete').once().returns(deleteQueryBuilder);
     deleteMock.expects('from').once().returns(deleteQueryBuilder);
@@ -139,7 +139,7 @@ describe('ExperimentAuditLogRepository Testing', () => {
 
     selectMock.expects('select').once().returns(selectQueryBuilder);
     selectMock.expects('orderBy').once().returns(selectQueryBuilder);
-    selectMock.expects('take').once().returns(selectQueryBuilder);
+    selectMock.expects('limit').once().returns(selectQueryBuilder);
     selectMock.expects('getQuery').once().returns(experiment.id);
     deleteMock.expects('delete').once().returns(deleteQueryBuilder);
     deleteMock.expects('from').once().returns(deleteQueryBuilder);
@@ -191,8 +191,8 @@ describe('ExperimentAuditLogRepository Testing', () => {
       .stub(ExperimentAuditLogRepository.prototype, 'createQueryBuilder')
       .returns(selectQueryBuilder);
 
-    selectMock.expects('skip').once().returns(selectQueryBuilder);
-    selectMock.expects('take').once().returns(selectQueryBuilder);
+    selectMock.expects('offset').once().returns(selectQueryBuilder);
+    selectMock.expects('limit').once().returns(selectQueryBuilder);
     selectMock.expects('leftJoinAndSelect').once().returns(selectQueryBuilder);
     selectMock.expects('orderBy').once().returns(selectQueryBuilder);
     selectMock.expects('where').once().returns(selectQueryBuilder);
@@ -211,8 +211,8 @@ describe('ExperimentAuditLogRepository Testing', () => {
       .stub(ExperimentAuditLogRepository.prototype, 'createQueryBuilder')
       .returns(selectQueryBuilder);
 
-    selectMock.expects('skip').once().returns(selectQueryBuilder);
-    selectMock.expects('take').once().returns(selectQueryBuilder);
+    selectMock.expects('offset').once().returns(selectQueryBuilder);
+    selectMock.expects('limit').once().returns(selectQueryBuilder);
     selectMock.expects('leftJoinAndSelect').once().returns(selectQueryBuilder);
     selectMock.expects('orderBy').once().returns(selectQueryBuilder);
     selectMock.expects('where').never().returns(selectQueryBuilder);
@@ -231,8 +231,8 @@ describe('ExperimentAuditLogRepository Testing', () => {
       .stub(ExperimentAuditLogRepository.prototype, 'createQueryBuilder')
       .returns(selectQueryBuilder);
 
-    selectMock.expects('skip').once().returns(selectQueryBuilder);
-    selectMock.expects('take').once().returns(selectQueryBuilder);
+    selectMock.expects('offset').once().returns(selectQueryBuilder);
+    selectMock.expects('limit').once().returns(selectQueryBuilder);
     selectMock.expects('leftJoinAndSelect').once().returns(selectQueryBuilder);
     selectMock.expects('orderBy').once().returns(selectQueryBuilder);
     selectMock.expects('where').once().returns(selectQueryBuilder);

--- a/backend/packages/Upgrade/test/unit/repositories/PreviewUserRepository.test.ts
+++ b/backend/packages/Upgrade/test/unit/repositories/PreviewUserRepository.test.ts
@@ -212,8 +212,8 @@ describe('PreviewUserRepository Testing', () => {
       raw: [user],
     };
 
-    selectMock.expects('skip').once().returns(selectQueryBuilder);
-    selectMock.expects('take').once().returns(selectQueryBuilder);
+    selectMock.expects('offset').once().returns(selectQueryBuilder);
+    selectMock.expects('limit').once().returns(selectQueryBuilder);
     selectMock.expects('orderBy').once().returns(selectQueryBuilder);
     selectMock.expects('getMany').once().returns(Promise.resolve(result));
 
@@ -231,8 +231,8 @@ describe('PreviewUserRepository Testing', () => {
       .withArgs('user')
       .returns(selectQueryBuilder);
 
-    selectMock.expects('skip').once().returns(selectQueryBuilder);
-    selectMock.expects('take').once().returns(selectQueryBuilder);
+    selectMock.expects('offset').once().returns(selectQueryBuilder);
+    selectMock.expects('limit').once().returns(selectQueryBuilder);
     selectMock.expects('orderBy').once().returns(selectQueryBuilder);
     selectMock.expects('getMany').once().returns(Promise.reject(err));
 

--- a/backend/packages/Upgrade/test/unit/services/FeatureFlagService.test.ts
+++ b/backend/packages/Upgrade/test/unit/services/FeatureFlagService.test.ts
@@ -52,8 +52,8 @@ describe('Feature Flag Service Testing', () => {
 
   const mockFlagArr = [mockFlag1, mockFlag2, mockFlag3];
 
-  const takeSpy = jest.fn().mockReturnThis();
-  const skipSpy = jest.fn().mockReturnThis();
+  const limitSpy = jest.fn().mockReturnThis();
+  const offsetSpy = jest.fn().mockReturnThis();
   const addSelectSpy = jest.fn().mockReturnThis();
   const setParamaterSpy = jest.fn().mockReturnThis();
   const addOrderBySpy = jest.fn().mockReturnThis();
@@ -63,8 +63,8 @@ describe('Feature Flag Service Testing', () => {
     addOrderBy: addOrderBySpy,
     setParameter: setParamaterSpy,
     where: jest.fn().mockReturnThis(),
-    skip: skipSpy,
-    take: takeSpy,
+    offset: offsetSpy,
+    limit: limitSpy,
     innerJoinAndSelect: jest.fn().mockReturnThis(),
     getMany: jest.fn().mockResolvedValue(mockFlagArr),
   };
@@ -104,8 +104,8 @@ describe('Feature Flag Service Testing', () => {
               addOrderBy: addOrderBySpy,
               setParameter: setParamaterSpy,
               where: jest.fn().mockReturnThis(),
-              skip: skipSpy,
-              take: takeSpy,
+              offset: offsetSpy,
+              limit: limitSpy,
               innerJoinAndSelect: jest.fn().mockReturnThis(),
               getMany: jest.fn().mockResolvedValue(mockFlagArr),
             })),

--- a/backend/packages/Upgrade/test/unit/services/UserService.test.ts
+++ b/backend/packages/Upgrade/test/unit/services/UserService.test.ts
@@ -35,8 +35,8 @@ describe('User Service Testing', () => {
 
   const userArr = [mockUser1, mockUser2, mockUser3];
 
-  const takeSpy = jest.fn().mockReturnThis();
-  const skipSpy = jest.fn().mockReturnThis();
+  const limitSpy = jest.fn().mockReturnThis();
+  const offsetSpy = jest.fn().mockReturnThis();
   const addSelectSpy = jest.fn().mockReturnThis();
   const setParamaterSpy = jest.fn().mockReturnThis();
   const addOrderBySpy = jest.fn().mockReturnThis();
@@ -63,8 +63,8 @@ describe('User Service Testing', () => {
               addOrderBy: addOrderBySpy,
               setParameter: setParamaterSpy,
               where: jest.fn().mockReturnThis(),
-              skip: skipSpy,
-              take: takeSpy,
+              offset: offsetSpy,
+              limit: limitSpy,
               getMany: jest.fn().mockResolvedValue(userArr),
             })),
           },
@@ -109,8 +109,8 @@ describe('User Service Testing', () => {
   it('should return paginated users', async () => {
     const users = await service.findPaginated(1, 2, logger);
     expect(repo.createQueryBuilder).toBeCalledWith('users');
-    expect(skipSpy).toBeCalledWith(1);
-    expect(takeSpy).toBeCalledWith(2);
+    expect(offsetSpy).toBeCalledWith(1);
+    expect(limitSpy).toBeCalledWith(2);
     expect(users).toEqual(userArr);
   });
 
@@ -121,8 +121,8 @@ describe('User Service Testing', () => {
     };
     const users = await service.findPaginated(0, 0, logger, params);
     expect(repo.createQueryBuilder).toBeCalledWith('users');
-    expect(skipSpy).toBeCalledWith(0);
-    expect(takeSpy).toBeCalledWith(0);
+    expect(offsetSpy).toBeCalledWith(0);
+    expect(limitSpy).toBeCalledWith(0);
     expect(addSelectSpy).toBeCalledWith(
       `ts_rank_cd(to_tsvector('english',concat_ws(' ', coalesce(users."firstName"::TEXT,''))), to_tsquery(:query))`,
       'rank'
@@ -142,8 +142,8 @@ describe('User Service Testing', () => {
     };
     const users = await service.findPaginated(0, 0, logger, searchParams, sortParams);
     expect(repo.createQueryBuilder).toBeCalledWith('users');
-    expect(skipSpy).toBeCalledWith(0);
-    expect(takeSpy).toBeCalledWith(0);
+    expect(offsetSpy).toBeCalledWith(0);
+    expect(limitSpy).toBeCalledWith(0);
     expect(addSelectSpy).toBeCalledWith(
       `ts_rank_cd(to_tsvector('english',concat_ws(' ', coalesce(users."lastName"::TEXT,''))), to_tsquery(:query))`,
       'rank'


### PR DESCRIPTION
This PR replaces the skip/take with offset/limit in mostly all the typeorm queries. So, basically skip/take is typeorm based and was not reflected back in the converted SQL query and we were not getting 50 user set for log query, which gave the 64k user limit issue #1286. This PR should resolve that as well. I tested the experiment list skip/take query after the update, but seems to not load the next set of experiments in paginated query at few times. Not sure why, might need to dig deeper. So, I have kept that skip/take for now in this query.

@bcb37 Meanwhile you can test the 64k issue by replicating it in your K6 test suite.