### PR TITLE
use upsert() on user creation

### DIFF
--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v1.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v1.ts
@@ -181,26 +181,30 @@ export class ExperimentClientController {
     request.logger.info({ message: 'Starting the init call for user' });
     // getOriginalUserDoc call for alias
     const experimentUserDoc = await this.experimentUserService.getUserDoc(experimentUser.id, request.logger);
+    // if reinit call is made with any of the below fields not included in the call,
+    // then we will fetch the stored values of the field and return them in the response
+    // for consistent init response with 3 fields ['userId', 'group', 'workingGroup']
+    const { id, group, workingGroup } = { ...experimentUserDoc, ...experimentUser };
+
     if (experimentUserDoc) {
       // append userDoc in logger
       request.logger.child({ userDoc: experimentUserDoc });
       request.logger.info({ message: 'Got the original user doc' });
     }
-    const userDocument = await this.experimentUserService.upsertOnChange(
+
+    const upsertResult = await this.experimentUserService.upsertOnChange(
       experimentUserDoc,
       experimentUser,
       request.logger
     );
-    if (!userDocument || !userDocument[0]) {
+
+    if (!upsertResult) {
       request.logger.error({
-        details: 'user document not present',
+        details: 'user upsert failed',
       });
-      throw new InternalServerError('user document not present');
+      throw new InternalServerError('user init failed');
     }
-    // if reinit call is made with any of the below fields not included in the call,
-    // then we will fetch the stored values of the field and return them in the response
-    // for consistent init response with 3 fields ['userId', 'group', 'workingGroup']
-    const { id, group, workingGroup } = userDocument[0];
+
     return { id, group, workingGroup };
   }
 

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v4.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v4.ts
@@ -180,26 +180,30 @@ export class ExperimentClientController {
     request.logger.info({ message: 'Starting the init call for user' });
     // getOriginalUserDoc call for alias
     const experimentUserDoc = await this.experimentUserService.getUserDoc(experimentUser.id, request.logger);
+    // if reinit call is made with any of the below fields not included in the call,
+    // then we will fetch the stored values of the field and return them in the response
+    // for consistent init response with 3 fields ['userId', 'group', 'workingGroup']
+    const { id, group, workingGroup } = { ...experimentUserDoc, ...experimentUser };
+
     if (experimentUserDoc) {
       // append userDoc in logger
       request.logger.child({ userDoc: experimentUserDoc });
       request.logger.info({ message: 'Got the original user doc' });
     }
-    const userDocument = await this.experimentUserService.upsertOnChange(
+
+    const upsertResult = await this.experimentUserService.upsertOnChange(
       experimentUserDoc,
       experimentUser,
       request.logger
     );
-    if (!userDocument || !userDocument[0]) {
+
+    if (!upsertResult) {
       request.logger.error({
-        details: 'user document not present',
+        details: 'user upsert failed',
       });
-      throw new InternalServerError('user document not present');
+      throw new InternalServerError('user init failed');
     }
-    // if reinit call is made with any of the below fields not included in the call,
-    // then we will fetch the stored values of the field and return them in the response
-    // for consistent init response with 3 fields ['userId', 'group', 'workingGroup']
-    const { id, group, workingGroup } = userDocument[0];
+
     return { id, group, workingGroup };
   }
 

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v5.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v5.ts
@@ -178,26 +178,30 @@ export class ExperimentClientController {
     request.logger.info({ message: 'Starting the init call for user' });
     // getOriginalUserDoc call for alias
     const experimentUserDoc = await this.experimentUserService.getUserDoc(experimentUser.id, request.logger);
+    // if reinit call is made with any of the below fields not included in the call,
+    // then we will fetch the stored values of the field and return them in the response
+    // for consistent init response with 3 fields ['userId', 'group', 'workingGroup']
+    const { id, group, workingGroup } = { ...experimentUserDoc, ...experimentUser };
+
     if (experimentUserDoc) {
       // append userDoc in logger
       request.logger.child({ userDoc: experimentUserDoc });
       request.logger.info({ message: 'Got the original user doc' });
     }
-    const userDocument = await this.experimentUserService.upsertOnChange(
+
+    const upsertResult = await this.experimentUserService.upsertOnChange(
       experimentUserDoc,
       experimentUser,
       request.logger
     );
-    if (!userDocument || !userDocument[0]) {
+
+    if (!upsertResult) {
       request.logger.error({
-        details: 'user document not present',
+        details: 'user upsert failed',
       });
-      throw new InternalServerError('user document not present');
+      throw new InternalServerError('user init failed');
     }
-    // if reinit call is made with any of the below fields not included in the call,
-    // then we will fetch the stored values of the field and return them in the response
-    // for consistent init response with 3 fields ['userId', 'group', 'workingGroup']
-    const { id, group, workingGroup } = userDocument[0];
+
     return { id, group, workingGroup };
   }
 

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentUserController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentUserController.ts
@@ -6,6 +6,7 @@ import { SERVER_ERROR } from 'upgrade_types';
 import { isUUID } from 'class-validator';
 import { AppRequest } from '../../types';
 import { ExperimentUserArrayValidator, ExperimentUserValidator } from './validators/ExperimentUserValidator';
+import { InsertResult } from 'typeorm';
 
 // TODO delete this from experiment system
 /**
@@ -110,7 +111,7 @@ export class UserController {
     @Body({ validate: true })
     users: ExperimentUserArrayValidator,
     @Req() request: AppRequest
-  ): Promise<ExperimentUser[]> {
+  ): Promise<InsertResult> {
     return this.userService.create(users.users, request.logger);
   }
 


### PR DESCRIPTION
- replaces `save()` with `upsert()` when creating/editing users from the 'init' endpoint
- fix the response object of 'init' so it always returns the current user data structure (id, group, workingGroup)