### PR TITLE
🐛 Hotfix: Fix for experiment level exclusions and code optimization for mark call

### DIFF
--- a/types/src/Experiment/enums.ts
+++ b/types/src/Experiment/enums.ts
@@ -72,15 +72,20 @@ export enum ENROLLMENT_CODE {
 }
 
 export enum EXCLUSION_CODE {
-  ERROR = 'participant excluded due to unspecified error',
+  // individual level:
   REACHED_PRIOR = 'participant reached experiment prior to experiment enrolling',
   REACHED_AFTER = 'participant reached experiment during enrollment complete',
+  // experiment level:
   PARTICIPANT_ON_EXCLUSION_LIST = 'participant was on the exclusion list',
   GROUP_ON_EXCLUSION_LIST = 'participant’s group was on the exclusion list',
+  // group level:
   EXCLUDED_DUE_TO_GROUP_LOGIC = 'participant excluded due to group assignment logic',
   NO_GROUP_SPECIFIED = 'participant excluded due to incomplete group information',
   INVALID_GROUP_OR_WORKING_GROUP = "participant's group or working group is incorrect",
+  // triggered by client SDK:
   EXCLUDED_BY_CLIENT = 'participant is excluded by client',
+  // generic error:
+  ERROR = 'participant excluded due to unspecified error',
 }
 
 export enum EXPERIMENT_LOG_TYPE {


### PR DESCRIPTION
This PR resolves #1301 

Here, below changes are made:
1. I have moved the experiment level exclusions logic from `updateEnrollmentExclusion()` which falls under individual/group level exclusions logic. So, basically the experiment level exclusions were not stored in DB.
2. Also, moved a code snippet in the `mark` apis' individual/group level exclusions code logic to be executed only in case of enrolling or enrollmentComplete experiment state.
3. There was duplicate code for storing monitoredDecisionPoint and monitoredDecisionPointLog documents in both individual/group level exclusions and experiment level exclusions logic. The individual/group level exclusions' monitoredDecisionPointLog document didnt had the check for within-subjects. And the experiment level exclusions' monitoredDecisionPoint existing document was not fetched and always a new document was getting stored. So, basically I have used a single code snippet common for both after the if-else branch executes.
4. Added a few comments in the exclusion code enum.