### PR TITLE
🐛 Hotfix: Fix for Exclusions logic(Simple & Within Subject Exps) and code optimization for mark call

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ab_testing_backend",
-    "version": "5.1.2",
+    "version": "5.1.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "ab_testing_backend",
-            "version": "5.1.2",
+            "version": "5.1.3",
             "license": "ISC",
             "dependencies": {
                 "dayjs": "^1.11.10",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ab_testing_backend",
-    "version": "5.1.2",
+    "version": "5.1.3",
     "description": "Backend for A/B Testing Project",
     "scripts": {
         "install:all": "npm ci && cd packages/Scheduler && npm ci && cd ../Upgrade && npm ci",

--- a/backend/packages/Scheduler/package-lock.json
+++ b/backend/packages/Scheduler/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppl-upgrade-serverless",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppl-upgrade-serverless",
-      "version": "5.1.2",
+      "version": "5.1.3",
       "license": "MIT",
       "dependencies": {
         "jsonwebtoken": "^9.0.0",

--- a/backend/packages/Scheduler/package.json
+++ b/backend/packages/Scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppl-upgrade-serverless",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "Serverless webpack example using Typescript",
   "main": "handler.js",
   "scripts": {

--- a/backend/packages/Upgrade/package-lock.json
+++ b/backend/packages/Upgrade/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ab_testing_backend",
-    "version": "5.1.2",
+    "version": "5.1.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ab_testing_backend",
-            "version": "5.1.2",
+            "version": "5.1.3",
             "license": "ISC",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.485.0",

--- a/backend/packages/Upgrade/package.json
+++ b/backend/packages/Upgrade/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ab_testing_backend",
-    "version": "5.1.2",
+    "version": "5.1.3",
     "description": "Backend for A/B Testing Project",
     "main": "index.js",
     "scripts": {

--- a/backend/packages/Upgrade/src/api/services/CheckService.ts
+++ b/backend/packages/Upgrade/src/api/services/CheckService.ts
@@ -18,7 +18,8 @@ export class CheckService {
     private groupEnrollmentRepository: GroupEnrollmentRepository,
     @InjectRepository()
     private individualEnrollmentRepository: IndividualEnrollmentRepository,
-    @InjectRepository() private groupExclusionRepository: GroupExclusionRepository,
+    @InjectRepository() 
+    private groupExclusionRepository: GroupExclusionRepository,
     @InjectRepository()
     private individualExclusionRepository: IndividualExclusionRepository,
     @InjectRepository()

--- a/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
@@ -155,6 +155,7 @@ export class ExperimentAssignmentService {
           'experiment',
           'experiment.conditions',
           'experiment.conditions.conditionPayloads',
+          'experiment.partitions',
           'experiment.experimentSegmentInclusion',
           'experiment.experimentSegmentExclusion',
           'experiment.experimentSegmentInclusion.segment',
@@ -240,7 +241,6 @@ export class ExperimentAssignmentService {
           experiment.state === EXPERIMENT_STATE.ENROLLMENT_COMPLETE) &&
         !previewUser
       ) {
-        const experiment = await this.experimentService.findOne(experimentId);
         const decisionPointId = selectedExperimentDP.id;
         let individualEnrollments: IndividualEnrollment;
         let individualExclusions: IndividualExclusion;

--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -28,6 +28,7 @@ import {
   SEGMENT_TYPE,
   EXPERIMENT_TYPE,
   CACHE_PREFIX,
+  ASSIGNMENT_UNIT,
 } from 'upgrade_types';
 import { IndividualExclusionRepository } from '../repositories/IndividualExclusionRepository';
 import { GroupExclusionRepository } from '../repositories/GroupExclusionRepository';
@@ -681,7 +682,11 @@ export class ExperimentService {
       await this.groupExclusionRepository.saveRawJson(groupExclusionDocs);
     }
 
-    if (consistencyRule === CONSISTENCY_RULE.INDIVIDUAL || consistencyRule === CONSISTENCY_RULE.GROUP) {
+    if (
+      consistencyRule === CONSISTENCY_RULE.INDIVIDUAL ||
+      consistencyRule === CONSISTENCY_RULE.GROUP ||
+      experiment.assignmentUnit === ASSIGNMENT_UNIT.WITHIN_SUBJECTS
+    ) {
       // individual exclusion document
       const individualExclusionDocs: Array<
         Omit<IndividualExclusion, 'id' | 'createdAt' | 'updatedAt' | 'versionNumber'>

--- a/backend/packages/Upgrade/test/unit/services/ExperimentAssignmentService.test.ts
+++ b/backend/packages/Upgrade/test/unit/services/ExperimentAssignmentService.test.ts
@@ -440,7 +440,7 @@ describe('Experiment Assignment Service Test', () => {
     const condition = 'testCondition';
     const clientError = 'clientError';
     const loggerMock = { info: sandbox.stub(), error: sandbox.stub() };
-    const decisionPointRespositoryMock = { find: sandbox.stub().resolves([]) };
+    const decisionPointRepositoryMock = { find: sandbox.stub().resolves([]) };
     const individualEnrollmentRepositoryMock = { findEnrollments: sandbox.stub().resolves([]) };
     const individualExclusionRepositoryMock = { findExcluded: sandbox.stub().resolves([]) };
     const groupEnrollmentRepositoryMock = { findEnrollments: sandbox.stub().resolves([]) };
@@ -451,7 +451,7 @@ describe('Experiment Assignment Service Test', () => {
       }),
     };
 
-    testedModule.decisionPointRepository = decisionPointRespositoryMock;
+    testedModule.decisionPointRepository = decisionPointRepositoryMock;
     testedModule.experimentService = experimentServiceMock;
     testedModule.experimentService.getCachedValidExperiments = sandbox.stub().resolves([]);
     testedModule.individualEnrollmentRepository = individualEnrollmentRepositoryMock;
@@ -485,7 +485,7 @@ describe('Experiment Assignment Service Test', () => {
     const target = 'testTarget';
     const condition = 'testCondition';
     const loggerMock = { info: sandbox.stub(), error: sandbox.stub() };
-    const decisionPointRespositoryMock = { find: sandbox.stub().resolves([]) };
+    const decisionPointRepositoryMock = { find: sandbox.stub().resolves([]) };
     const individualEnrollmentRepositoryMock = { findEnrollments: sandbox.stub().resolves([]) };
     const individualExclusionRepositoryMock = { findExcluded: sandbox.stub().resolves([]) };
     const groupEnrollmentRepositoryMock = { findEnrollments: sandbox.stub().resolves([]) };
@@ -496,7 +496,7 @@ describe('Experiment Assignment Service Test', () => {
       }),
     };
 
-    testedModule.decisionPointRepository = decisionPointRespositoryMock;
+    testedModule.decisionPointRepository = decisionPointRepositoryMock;
     testedModule.experimentService = experimentServiceMock;
     testedModule.cacheService.wrap = sandbox.stub().resolves([]);
     testedModule.individualEnrollmentRepository = individualEnrollmentRepositoryMock;
@@ -528,7 +528,7 @@ describe('Experiment Assignment Service Test', () => {
     const target = 'testTarget';
     const condition = 'testCondition';
     const loggerMock = { info: sandbox.stub(), error: sandbox.stub() };
-    const decisionPointRespositoryMock = { find: sandbox.stub().resolves([simpleDPExperiment]) };
+    const decisionPointRepositoryMock = { find: sandbox.stub().resolves([simpleDPExperiment]) };
     const individualEnrollmentRepositoryMock = { findEnrollments: sandbox.stub().resolves([]) };
     const individualExclusionRepositoryMock = { findExcluded: sandbox.stub().resolves([]) };
     const groupEnrollmentRepositoryMock = { findEnrollments: sandbox.stub().resolves([]) };
@@ -548,7 +548,7 @@ describe('Experiment Assignment Service Test', () => {
       findOne: sandbox.stub().resolves(monitoredDocument),
     };
 
-    testedModule.decisionPointRepository = decisionPointRespositoryMock;
+    testedModule.decisionPointRepository = decisionPointRepositoryMock;
     testedModule.experimentService = experimentServiceMock;
     testedModule.experimentService.getCachedValidExperiments = sandbox
       .stub()
@@ -578,7 +578,7 @@ describe('Experiment Assignment Service Test', () => {
     const target = 'testTarget';
     const condition = 'testCondition';
     const loggerMock = { info: sandbox.stub(), error: sandbox.stub() };
-    const decisionPointRespositoryMock = { find: sandbox.stub().resolves([simpleDPExperiment]) };
+    const decisionPointRepositoryMock = { find: sandbox.stub().resolves([simpleDPExperiment]) };
     const individualEnrollmentRepositoryMock = { findEnrollments: sandbox.stub().resolves([]) };
     const individualExclusionRepositoryMock = { findExcluded: sandbox.stub().resolves([]) };
     const groupEnrollmentRepositoryMock = { findEnrollments: sandbox.stub().resolves([]) };
@@ -598,7 +598,7 @@ describe('Experiment Assignment Service Test', () => {
       findOne: sandbox.stub().resolves(monitoredDocument),
     };
 
-    testedModule.decisionPointRepository = decisionPointRespositoryMock;
+    testedModule.decisionPointRepository = decisionPointRepositoryMock;
     testedModule.experimentService = experimentServiceMock;
     testedModule.experimentService.getCachedValidExperiments = sandbox
       .stub()
@@ -628,7 +628,7 @@ describe('Experiment Assignment Service Test', () => {
     const target = 'testTarget';
     const condition = 'testCondition';
     const loggerMock = { info: sandbox.stub(), error: sandbox.stub() };
-    const decisionPointRespositoryMock = { find: sandbox.stub().resolves([withinSubjectDPExperiment]) };
+    const decisionPointRepositoryMock = { find: sandbox.stub().resolves([withinSubjectDPExperiment]) };
     const individualEnrollmentRepositoryMock = { findEnrollments: sandbox.stub().resolves([]) };
     const individualExclusionRepositoryMock = { findExcluded: sandbox.stub().resolves([]) };
     const groupEnrollmentRepositoryMock = { findEnrollments: sandbox.stub().resolves([]) };
@@ -648,7 +648,7 @@ describe('Experiment Assignment Service Test', () => {
       findOne: sandbox.stub().resolves(monitoredDocument),
     };
 
-    testedModule.decisionPointRepository = decisionPointRespositoryMock;
+    testedModule.decisionPointRepository = decisionPointRepositoryMock;
     testedModule.experimentService = experimentServiceMock;
     testedModule.experimentService.getCachedValidExperiments = sandbox
       .stub()

--- a/clientlibs/java/pom.xml
+++ b/clientlibs/java/pom.xml
@@ -9,7 +9,7 @@
 		at the same time that happen to rev to the same new version will be caught 
 		by a merge conflict. -->
 
-	<version>5.1.2</version>
+	<version>5.1.3</version>
 	<build>
 		<plugins>
 			<plugin>

--- a/clientlibs/js/package-lock.json
+++ b/clientlibs/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "upgrade_client_lib",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "upgrade_client_lib",
-      "version": "5.1.2",
+      "version": "5.1.3",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.4.0",

--- a/clientlibs/js/package.json
+++ b/clientlibs/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upgrade_client_lib",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "Client library to communicate with the Upgrade server",
   "files": [
     "dist/*"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ab-testing",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ab-testing",
-      "version": "5.1.2",
+      "version": "5.1.3",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ab-testing",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "UpGrade",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "UpGrade",
-      "version": "5.1.2",
+      "version": "5.1.3",
       "license": "ISC",
       "devDependencies": {
         "@angular-eslint/eslint-plugin": "^14.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "UpGrade",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "This is a combined repository for UpGrade, an open-source platform to support large-scale A/B testing in educational applications.  Learn more at www.upgradeplatform.org",
   "main": "index.js",
   "devDependencies": {

--- a/types/package-lock.json
+++ b/types/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "upgrade_types",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "upgrade_types",
-      "version": "5.1.2",
+      "version": "5.1.3",
       "license": "ISC",
       "devDependencies": {
         "eslint": "^8.27.0",

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upgrade_types",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/types/src/Experiment/enums.ts
+++ b/types/src/Experiment/enums.ts
@@ -72,15 +72,20 @@ export enum ENROLLMENT_CODE {
 }
 
 export enum EXCLUSION_CODE {
-  ERROR = 'participant excluded due to unspecified error',
+  // individual level:
   REACHED_PRIOR = 'participant reached experiment prior to experiment enrolling',
   REACHED_AFTER = 'participant reached experiment during enrollment complete',
+  // experiment level:
   PARTICIPANT_ON_EXCLUSION_LIST = 'participant was on the exclusion list',
   GROUP_ON_EXCLUSION_LIST = 'participant’s group was on the exclusion list',
+  // group level:
   EXCLUDED_DUE_TO_GROUP_LOGIC = 'participant excluded due to group assignment logic',
   NO_GROUP_SPECIFIED = 'participant excluded due to incomplete group information',
   INVALID_GROUP_OR_WORKING_GROUP = "participant's group or working group is incorrect",
+  // triggered by client SDK:
   EXCLUDED_BY_CLIENT = 'participant is excluded by client',
+  // generic error (for future use):
+  ERROR = 'participant excluded due to unspecified error',
 }
 
 export enum EXPERIMENT_LOG_TYPE {


### PR DESCRIPTION
This PR resolves issue #1301

Below are the changes made in this PR.

For Simple experiment:
1. So, basically the experiment level exclusions were not getting stored in DB as `filteredExperiment` returned from experimentLevelExclusionInclusion() was empty.
2. Group Level exclusions were not getting stored in DB, as code block to fetch `groupexperiments` was checking for empty/invalid groups and returning empty `experiments` list. This code block was not required as we are already checking for `experimentsWithInvalidGroupAndWorkingGroup()` inside `updateEnrollmentExclusion()`.
3. Added conditions to check if group object has any keys or not for group level exclusions.
4. Also, moved a try catch code snippet in the mark apis' exclusions code logic to be executed only in case of enrolling or enrollmentComplete experiment state, else its not required to be executed for all other states of the experiment.
5. There was duplicate code for storing monitoredDecisionPoint and monitoredDecisionPointLog documents in both individual/group level exclusions and experiment level exclusions logic. The individual/group level exclusions' monitoredDecisionPointLog document didn't had the check for within-subjects. And the experiment level exclusions' monitoredDecisionPoint existing document was not fetched and always a new document was getting stored. So, basically I have used a single code snippet common for both after the if-else branch executes.
6. Added a few comments in the exclusion code enum.
7. Updated wrong variable names using 'Code Spell Checker' VSCode extension (ID: streetsidesoftware.code-spell-checker). Much helpful for oversight typos in variable naming.

For Within subjects experiment:
1. `REACHED_PRIOR` exclusion was not getting set as consistencyRule is null for Within subjects experiments.
2. Individual Enrollment document was not getting overwritten, so added a condition to check if the individualEnrollment is not present.

Please find attached [document](https://docs.google.com/document/d/1e-FPHZ5ofo1u_3MSuhf7VVJdMQmQ2U9vQGf_luyoCHo/edit?usp=sharing) to verify the exclusions and their expected behaviour. Might take some time to verify all, in case of doubts, do let me know.

Note: 
1. Will be adding detailed test cases to check alll exclusion codes in a separate PR using a separate ticket. It's better if these changes go in release branch asap.