### PR TITLE
Feature/error on details refresh undefined permissions

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/view-segment/view-segment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/view-segment/view-segment.component.html
@@ -29,8 +29,8 @@
             mat-flat-button
             class="ft-14-600 button"
             (click)="deleteSegment()"
-            [ngClass]="{ 'button--disabled': (permissions && !permissions.segments.delete) || segmentUsed }"
-            [disabled]="(permissions && !permissions.segments.delete) || segmentUsed"
+            [ngClass]="{ 'button--disabled': (segment.type === SegmentType.GLOBAL_EXCLUDE) || segmentUsed }"
+            [disabled]="(segment.type === SegmentStatus.GLOBAL_EXCLUDE) || segmentUsed"
           >
             {{ 'global.delete.text' | translate }}
           </button>
@@ -40,8 +40,8 @@
             mat-flat-button
             class="ft-14-600 button-long"
             (click)="duplicateSegmentDialog()"
-            [ngClass]="{ 'button-long--disabled': segment?.type == 'global_exclude' }"
-            [disabled]="segment?.type == 'global_exclude'"
+            [ngClass]="{ 'button-long--disabled': segment.type == SegmentType.GLOBAL_EXCLUDE }"
+            [disabled]="segment.type == SegmentType.GLOBAL_EXCLUDE"
           >
             {{ 'global.duplicate.text' | translate }}
           </button>

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/view-segment/view-segment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/view-segment/view-segment.component.html
@@ -29,8 +29,8 @@
             mat-flat-button
             class="ft-14-600 button"
             (click)="deleteSegment()"
-            [ngClass]="{ 'button--disabled': (segment.type === SegmentType.GLOBAL_EXCLUDE) || segmentUsed }"
-            [disabled]="(segment.type === SegmentStatus.GLOBAL_EXCLUDE) || segmentUsed"
+            [ngClass]="{ 'button--disabled': segment.type === SegmentType.GLOBAL_EXCLUDE || segmentUsed }"
+            [disabled]="segment.type === SegmentStatus.GLOBAL_EXCLUDE || segmentUsed"
           >
             {{ 'global.delete.text' | translate }}
           </button>

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/view-segment/view-segment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/view-segment/view-segment.component.html
@@ -29,8 +29,8 @@
             mat-flat-button
             class="ft-14-600 button"
             (click)="deleteSegment()"
-            [ngClass]="{ 'button--disabled': segment.type === SegmentType.GLOBAL_EXCLUDE || segmentUsed }"
-            [disabled]="segment.type === SegmentStatus.GLOBAL_EXCLUDE || segmentUsed"
+            [ngClass]="{ 'button--disabled': segment.type === SegmentType.GLOBAL_EXCLUDE || segmentUsed || !permissions?.segments.delete }"
+            [disabled]="segment.type === SegmentStatus.GLOBAL_EXCLUDE || segmentUsed || !permissions?.segments.delete"
           >
             {{ 'global.delete.text' | translate }}
           </button>

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/view-segment/view-segment.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/view-segment/view-segment.component.ts
@@ -3,7 +3,7 @@ import { UserPermission } from '../../../../../core/auth/store/auth.models';
 import { Subscription } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
 import { AuthService } from '../../../../../core/auth/auth.service';
-import { filter } from 'rxjs/operators';
+import { filter, withLatestFrom } from 'rxjs/operators';
 import { SegmentsService } from '../../../../../core/segments/segments.service';
 import { NewSegmentComponent } from '../../components/modal/new-segment/new-segment.component';
 import * as clonedeep from 'lodash.clonedeep';
@@ -43,6 +43,10 @@ export class ViewSegmentComponent implements OnInit, OnDestroy {
     return SEGMENT_STATUS;
   }
 
+  get SegmentType() {
+    return SEGMENT_TYPE;
+  }
+
   get SegmentStatusPipeTypes() {
     return SegmentStatusPipeType;
   }
@@ -62,7 +66,6 @@ export class ViewSegmentComponent implements OnInit, OnDestroy {
       .subscribe((segment) => {
         this.segment = { ...segment, status: segment.status || SEGMENT_STATUS.UNUSED };
 
-        this.permissions.segments.delete = this.segment.type !== SEGMENT_TYPE.GLOBAL_EXCLUDE;
         this.members = [];
         this.segment.individualForSegment.forEach((user) => {
           this.members.push({ type: MemberTypes.INDIVIDUAL, id: user.userId });

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/view-segment/view-segment.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/view-segment/view-segment.component.ts
@@ -3,7 +3,7 @@ import { UserPermission } from '../../../../../core/auth/store/auth.models';
 import { Subscription } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
 import { AuthService } from '../../../../../core/auth/auth.service';
-import { filter, withLatestFrom } from 'rxjs/operators';
+import { filter } from 'rxjs/operators';
 import { SegmentsService } from '../../../../../core/segments/segments.service';
 import { NewSegmentComponent } from '../../components/modal/new-segment/new-segment.component';
 import * as clonedeep from 'lodash.clonedeep';


### PR DESCRIPTION
This addresses another small bug unveiled after fixing segments page refresh in #1252, which was caused by a race condition between fetching permissions and fetching segments where if segments fetch finished first, permissions is null.

The permissions object was not being utilized properly though, that thing should be strictly read-only. The conditions currently used to disable those buttons are being determined by segment type / status, not user permissions.