### PR TITLE
Preview Users data not showing on hard refresh

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/experiment-users/experiment-users-root/experiment-users-root.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiment-users/experiment-users-root/experiment-users-root.component.ts
@@ -9,13 +9,19 @@ import { StratificationFactorsService } from '../../../../core/stratification-fa
   styleUrls: ['./experiment-users-root.component.scss'],
 })
 export class ExperimentUsersRootComponent {
+  selectedTabIndex = 0;
   constructor(
     private experimentService: ExperimentService,
     private previewUsersService: PreviewUsersService,
     private stratificationFactorsService: StratificationFactorsService
   ) {}
 
+  ngOnInit() {
+    this.selectedTabChange({ index: this.selectedTabIndex });
+  }
+
   selectedTabChange(event) {
+    this.selectedTabIndex = event.index;
     if (event.index === 0) {
       this.experimentService.fetchAllExperimentNames();
       this.previewUsersService.fetchPreviewUsers(true);

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiment-users/experiment-users-root/experiment-users-root.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiment-users/experiment-users-root/experiment-users-root.component.ts
@@ -9,7 +9,6 @@ import { StratificationFactorsService } from '../../../../core/stratification-fa
   styleUrls: ['./experiment-users-root.component.scss'],
 })
 export class ExperimentUsersRootComponent {
-  selectedTabIndex = 0;
   constructor(
     private experimentService: ExperimentService,
     private previewUsersService: PreviewUsersService,
@@ -17,11 +16,10 @@ export class ExperimentUsersRootComponent {
   ) {}
 
   ngOnInit() {
-    this.selectedTabChange({ index: this.selectedTabIndex });
+    this.selectedTabChange({ index: 0 });
   }
 
   selectedTabChange(event) {
-    this.selectedTabIndex = event.index;
     if (event.index === 0) {
       this.experimentService.fetchAllExperimentNames();
       this.previewUsersService.fetchPreviewUsers(true);


### PR DESCRIPTION
On hard refresh in the Preview-Users Tab, the data will not populate.
Updated the code so that on initialization the data call is created. 