### PR TITLE
Solve UI bugs of validation loading spinner

### DIFF
--- a/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
@@ -1146,21 +1146,44 @@ export class ExperimentController {
   /**
    * @swagger
    * /experiments/{validation}:
-   *    put:
+   *    post:
    *       description: Validating Experiment
    *       consumes:
    *         - application/json
    *       parameters:
-   *         - in: path
+   *         - in: body
+   *           name: experiments
+   *           required: true
+   *           schema:
+   *             type: array
+   *             items:
+   *               type: object
+   *               properties:
+   *                 fileName:
+   *                   type: string
+   *                 fileContent:
+   *                   type: string
+   *           description: Experiment Files
    *       tags:
    *         - Experiments
    *       produces:
    *         - application/json
    *       responses:
    *          '200':
-   *            description: Validations are done
+   *            description: Validations are completed
+   *            schema:
+   *             type: array
+   *             items:
+   *               type: object
+   *               properties:
+   *                 fileName:
+   *                   type: string
+   *                 error:
+   *                   type: string
    *          '401':
    *            description: AuthorizationRequiredError
+   *          '500':
+   *            description: Internal Server Error
    */
   @Post('/validation')
   public validateExperiment(
@@ -1173,12 +1196,24 @@ export class ExperimentController {
   /**
    * @swagger
    * /experiments/{import}:
-   *    put:
+   *    post:
    *       description: Import New Experiment
    *       consumes:
    *         - application/json
    *       parameters:
-   *         - in: path
+   *         - in: body
+   *           name: experiments
+   *           required: true
+   *           schema:
+   *             type: array
+   *             items:
+   *               type: object
+   *               properties:
+   *                 fileName:
+   *                   type: string
+   *                 fileContent:
+   *                   type: string
+   *           description: Experiment Files
    *       tags:
    *         - Experiments
    *       produces:
@@ -1186,8 +1221,19 @@ export class ExperimentController {
    *       responses:
    *          '200':
    *            description: Experiment is imported
+   *            schema:
+   *             type: array
+   *             items:
+   *               type: object
+   *               properties:
+   *                 fileName:
+   *                   type: string
+   *                 error:
+   *                   type: string
    *          '401':
    *            description: AuthorizationRequiredError
+   *          '500':
+   *            description: Internal Server Error
    */
   @Post('/import')
   public importExperiment(

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/import-experiment/import-experiment.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/import-experiment/import-experiment.component.ts
@@ -85,8 +85,6 @@ export class ImportExperimentComponent implements OnInit {
   }
 
   async uploadFile(event) {
-    const index = 0;
-    const reader = new FileReader();
     this.uploadedFileCount = event.target.files.length;
     this.importFileErrors = [];
     this.allExperiments = [];
@@ -96,25 +94,22 @@ export class ImportExperimentComponent implements OnInit {
     // Set loading to true before processing the files
     this.isLoadingExperiments$ = true;
 
-    const readFile = async (fileIndex) => {
-      if (fileIndex >= event.target.files.length) {
-        // Check if this is the last file
-        if (fileIndex >= this.uploadedFileCount) {
-          await this.checkValidation();
-          this.isLoadingExperiments$ = false;
-        }
-        return;
-      }
-      const file = event.target.files[fileIndex];
-      const fileName = file.name;
-      reader.onload = (e) => {
-        const fileContent = e.target.result;
-        this.allExperiments.push({ fileName: fileName, fileContent: fileContent });
-        readFile(fileIndex + 1);
-      };
-      reader.readAsText(file);
-    };
+    const filesArray = Array.from(event.target.files) as any[];
+    await Promise.all(
+      filesArray.map((file) => {
+        return new Promise<void>((resolve) => {
+          const reader = new FileReader();
+          reader.onload = (e) => {
+            const fileContent = e.target.result;
+            this.allExperiments.push({ fileName: file.name, fileContent: fileContent });
+            resolve();
+          };
+          reader.readAsText(file);
+        });
+      })
+    );
 
-    readFile(index);
+    await this.checkValidation();
+    this.isLoadingExperiments$ = false;
   }
 }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/import-experiment/import-experiment.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/import-experiment/import-experiment.component.ts
@@ -48,13 +48,12 @@ export class ImportExperimentComponent implements OnInit {
   }
 
   async importExperiment() {
+    this.onCancelClick();
     const importResult = (await this.dataService
       .importExperiment(this.allExperiments)
       .toPromise()) as ValidateExperimentError[];
     //this.experimentService.importExperiment(this.allExperiments);
     this.showNotification(importResult);
-    this.onCancelClick();
-
     this.experimentService.loadExperiments(true);
   }
 
@@ -97,11 +96,11 @@ export class ImportExperimentComponent implements OnInit {
     // Set loading to true before processing the files
     this.isLoadingExperiments$ = true;
 
-    const readFile = (fileIndex) => {
+    const readFile = async (fileIndex) => {
       if (fileIndex >= event.target.files.length) {
         // Check if this is the last file
         if (fileIndex >= this.uploadedFileCount) {
-          this.checkValidation();
+          await this.checkValidation();
           this.isLoadingExperiments$ = false;
         }
         return;

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/components/modal/import-segment/import-segment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/components/modal/import-segment/import-segment.component.html
@@ -6,27 +6,29 @@
       {{ 'segments.import-segmemt.message.text' | translate }}
     </p>
     <input accept=".json" type="file" multiple class="ft-14-400 file-input" (change)="uploadFile($event)" />
-    <ng-container *ngIf="importFileErrors.length">
-      <mat-table class="table" [dataSource]="importFileErrorsDataSource">
-        <!-- File Name -->
-        <ng-container matColumnDef="File Name">
-          <mat-header-cell class="ft-12-700" *matHeaderCellDef> File Name </mat-header-cell>
-          <mat-cell class="ft-12-600" *matCellDef="let element">
-            {{ element.fileName }}
-          </mat-cell>
-        </ng-container>
+    <ng-container *ngIf="!isLoadingSegments$; else loadingSegmentState">
+      <ng-container *ngIf="importFileErrors.length">
+        <mat-table class="table" [dataSource]="importFileErrorsDataSource">
+          <!-- File Name -->
+          <ng-container matColumnDef="File Name">
+            <mat-header-cell class="ft-12-700" *matHeaderCellDef> File Name </mat-header-cell>
+            <mat-cell class="ft-12-600" *matCellDef="let element">
+              {{ element.fileName }}
+            </mat-cell>
+          </ng-container>
 
-        <!-- Error -->
-        <ng-container matColumnDef="Error">
-          <mat-header-cell class="ft-12-700" *matHeaderCellDef> Error/Warning </mat-header-cell>
-          <mat-cell class="ft-12-600" *matCellDef="let element">
-            {{ element.error }}
-          </mat-cell>
-        </ng-container>
+          <!-- Error -->
+          <ng-container matColumnDef="Error">
+            <mat-header-cell class="ft-12-700" *matHeaderCellDef> Error/Warning </mat-header-cell>
+            <mat-cell class="ft-12-600" *matCellDef="let element">
+              {{ element.error }}
+            </mat-cell>
+          </ng-container>
 
-        <mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></mat-header-row>
-        <mat-row *matRowDef="let row; columns: displayedColumns"></mat-row>
-      </mat-table>
+          <mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></mat-header-row>
+          <mat-row *matRowDef="let row; columns: displayedColumns"></mat-row>
+        </mat-table>
+      </ng-container>
     </ng-container>
   </div>
 
@@ -50,3 +52,9 @@
     </button>
   </div>
 </div>
+
+<ng-template #loadingSegmentState>
+  <div class="loading-container">
+    <mat-spinner diameter="60"></mat-spinner>
+  </div>
+</ng-template>

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/components/modal/import-segment/import-segment.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/components/modal/import-segment/import-segment.component.scss
@@ -34,4 +34,12 @@
     justify-content: flex-end;
     padding: 0 40px 40px;
   }
+
+  .loading-container {
+    display: flex;
+    flex-grow: 1;
+    align-items: center;
+    justify-content: center;
+    margin-top: 60px;
+  }
 }

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/components/modal/import-segment/import-segment.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/components/modal/import-segment/import-segment.component.ts
@@ -37,12 +37,12 @@ export class ImportSegmentComponent {
   }
 
   async importSegments() {
+    this.onCancelClick();
     const importResult = (await this.segmentdataService
       .importSegments(this.fileData)
       .toPromise()) as SegmentImportError[];
 
     this.showNotification(importResult);
-    this.onCancelClick();
 
     this.segmentsService.fetchSegments(true);
   }
@@ -75,12 +75,12 @@ export class ImportSegmentComponent {
 
     fileList.forEach((file) => {
       const reader = new FileReader();
-      reader.onload = (e) => {
+      reader.onload = async (e) => {
         const fileContent = e.target?.result;
         this.fileData.push({ fileName: file.name, fileContent: fileContent });
         // Check if this is the last file and validate
         if (this.fileData.length === this.uploadedFileCount) {
-          this.validateFiles();
+          await this.validateFiles();
           this.isLoadingSegments$ = false;
         }
       };


### PR DESCRIPTION
Solved

For Import Experiment
- Swagger for validation and import now called through POST
- Swagger is updated to contain details of API
- In UI, the import button for experiments will be disabled until validations are completed
- Spinner will be shown while validations are processing for import
- FIXED - Spamming the import button leads to multiple import calls resulting in multiple imports of the same files.

For import Segment
- In UI, the import button for experiments will be disabled until validations are completed
- Created spinner while validations are processing for import
- FIXED - Spamming the import button leads to multiple import calls resulting in multiple imports of the same files.