### PR TITLE
Bugfix/1365 assignedcondition null mark issue

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ab_testing_backend",
-    "version": "5.1.1",
+    "version": "5.1.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "ab_testing_backend",
-            "version": "5.1.1",
+            "version": "5.1.2",
             "license": "ISC",
             "dependencies": {
                 "dayjs": "^1.11.10",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ab_testing_backend",
-    "version": "5.1.1",
+    "version": "5.1.2",
     "description": "Backend for A/B Testing Project",
     "scripts": {
         "install:all": "npm ci && cd packages/Scheduler && npm ci && cd ../Upgrade && npm ci",

--- a/backend/packages/Scheduler/package-lock.json
+++ b/backend/packages/Scheduler/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppl-upgrade-serverless",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppl-upgrade-serverless",
-      "version": "5.1.1",
+      "version": "5.1.2",
       "license": "MIT",
       "dependencies": {
         "jsonwebtoken": "^9.0.0",

--- a/backend/packages/Scheduler/package.json
+++ b/backend/packages/Scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppl-upgrade-serverless",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "Serverless webpack example using Typescript",
   "main": "handler.js",
   "scripts": {

--- a/backend/packages/Upgrade/package-lock.json
+++ b/backend/packages/Upgrade/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ab_testing_backend",
-    "version": "5.1.1",
+    "version": "5.1.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ab_testing_backend",
-            "version": "5.1.1",
+            "version": "5.1.2",
             "license": "ISC",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.485.0",

--- a/backend/packages/Upgrade/package.json
+++ b/backend/packages/Upgrade/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ab_testing_backend",
-    "version": "5.1.1",
+    "version": "5.1.2",
     "description": "Backend for A/B Testing Project",
     "main": "index.js",
     "scripts": {

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v5.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v5.ts
@@ -431,13 +431,13 @@ export class ExperimentClientController {
       experiment.userId,
       experiment.data.site,
       experiment.status,
-      experiment.data.assignedCondition.conditionCode,
+      experiment.data.assignedCondition?.conditionCode ?? null,
       {
         logger: request.logger,
         userDoc: experimentUserDoc,
       },
       experiment.data.target,
-      experiment.data.assignedCondition.experimentId ? experiment.data.assignedCondition.experimentId : null,
+      experiment.data.assignedCondition?.experimentId ?? null,
       experiment.uniquifier ? experiment.uniquifier : null,
       experiment.clientError ? experiment.clientError : null
     );

--- a/backend/packages/Upgrade/src/api/controllers/validators/MarkExperimentValidator.v5.ts
+++ b/backend/packages/Upgrade/src/api/controllers/validators/MarkExperimentValidator.v5.ts
@@ -25,6 +25,7 @@ class Data {
   @IsString()
   target: string;
 
+  @IsOptional()
   @ValidateNested()
   @Type(() => AssignedCondition)
   assignedCondition: AssignedCondition;

--- a/clientlibs/java/src/main/java/org/upgradeplatform/client/Main.java
+++ b/clientlibs/java/src/main/java/org/upgradeplatform/client/Main.java
@@ -12,6 +12,7 @@ import java.util.concurrent.ExecutionException;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.upgradeplatform.interfaces.ResponseCallback;
+import org.upgradeplatform.requestbeans.MarkExperimentRequestData;
 import org.upgradeplatform.responsebeans.Assignment;
 import org.upgradeplatform.responsebeans.Condition;
 import org.upgradeplatform.responsebeans.ErrorResponse;
@@ -24,7 +25,7 @@ import org.upgradeplatform.utils.Utils.MarkedDecisionPointStatus;
 public class Main {
     public static void main(String[] args) throws InterruptedException, ExecutionException
     {
-        final String baseUrl = "https://upgradeapi.qa-cli.net";
+        final String baseUrl = "http://localhost:3030";
         final String userId = UUID.randomUUID().toString();
         final String site = "SelectSection";
 
@@ -72,7 +73,8 @@ public class Main {
                                                     String code = condition == null ? null : condition.getConditionCode();
                                                     System.out.println(condition);
                                                     System.out.println(code);
-                                                    expResult.markDecisionPoint(MarkedDecisionPointStatus.CONDITION_APPLIED, new Date().toString(), new ResponseCallback<MarkDecisionPoint>(){
+                                                    MarkExperimentRequestData markData = new MarkExperimentRequestData(site, target);
+                                                    experimentClient.markDecisionPoint(MarkedDecisionPointStatus.CONDITION_APPLIED, markData, "", new Date().toString(), new ResponseCallback<MarkDecisionPoint>(){
                                                         @Override
                                                         public void onSuccess(@NonNull MarkDecisionPoint markResult){
                                                             result.complete("marked " + code + ": " + markResult.toString());

--- a/clientlibs/js/package-lock.json
+++ b/clientlibs/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "upgrade_client_lib",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "upgrade_client_lib",
-      "version": "5.1.1",
+      "version": "5.1.2",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.4.0",

--- a/clientlibs/js/package.json
+++ b/clientlibs/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upgrade_client_lib",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "Client library to communicate with the Upgrade server",
   "files": [
     "dist/*"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ab-testing",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ab-testing",
-      "version": "5.1.1",
+      "version": "5.1.2",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ab-testing",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "UpGrade",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "UpGrade",
-      "version": "5.1.1",
+      "version": "5.1.2",
       "license": "ISC",
       "devDependencies": {
         "@angular-eslint/eslint-plugin": "^14.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "UpGrade",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "This is a combined repository for UpGrade, an open-source platform to support large-scale A/B testing in educational applications.  Learn more at www.upgradeplatform.org",
   "main": "index.js",
   "devDependencies": {

--- a/types/package-lock.json
+++ b/types/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "upgrade_types",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "upgrade_types",
-      "version": "5.1.1",
+      "version": "5.1.2",
       "license": "ISC",
       "devDependencies": {
         "eslint": "^8.27.0",

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upgrade_types",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
#1365 

This was found in testing v5 Java Lib in Mathia. When no condition is returned by upgrade (aka 200 response but no not enrolled in any experiments), one would expect to be able to use `new MarkExperimentRequestData(site, target)` but this will send an object with `data.assignedCondition` as null, which is not currently allowed, we get a Bad Request

However, there's no good reason I can see to force this `data.assignedCondition` to be required, if it's null but there's a site and target supplied, we can safely assume a condition of `null`.

With a small adjustment in the null-coalescing code in the controller we can easily allow this to be an optional value and assume `null` for the conditionCode.