### PR TITLE
Bugfix/1382 experiment type in assign response

### DIFF
--- a/backend/packages/Upgrade/src/api/Algorithms.ts
+++ b/backend/packages/Upgrade/src/api/Algorithms.ts
@@ -61,11 +61,12 @@ export function randomCondition(
     }
   }
 
-  const randomAssignData = {
+  const randomAssignData: IExperimentAssignmentv5 = {
     site: assignedData.site,
     target: assignedData.target,
     assignedCondition: randomConditionArray,
     assignedFactor: experiment.type === EXPERIMENT_TYPE.FACTORIAL ? assignedFactorsArray : null,
+    experimentType: experiment.type,
   };
 
   // rotate elements in assigned condition array based on number of monitored decision point
@@ -103,11 +104,12 @@ export function randomRoundRobinCondition(
     }
   }
 
-  const randomRoundRobinAssignData = {
+  const randomRoundRobinAssignData: IExperimentAssignmentv5 = {
     site: assignedData.site,
     target: assignedData.target,
     assignedCondition: randomRoundRobinConditionArray,
     assignedFactor: experiment.type === EXPERIMENT_TYPE.FACTORIAL ? assignedFactorsArray : null,
+    experimentType: experiment.type,
   };
 
   // rotate elements in assigned condition array based on number of monitored decision point
@@ -175,6 +177,7 @@ function convertToAssignedCondition(
     target: target,
     assignedCondition: assignedConditionArray,
     assignedFactor: experiment.type === EXPERIMENT_TYPE.FACTORIAL ? assignedFactorsArray : null,
+    experimentType: experiment.type,
   };
 }
 

--- a/backend/packages/Upgrade/src/api/models/Experiment.ts
+++ b/backend/packages/Upgrade/src/api/models/Experiment.ts
@@ -175,5 +175,5 @@ export class Experiment extends BaseModel {
     enum: EXPERIMENT_TYPE,
     default: EXPERIMENT_TYPE.SIMPLE,
   })
-  public type: string;
+  public type: EXPERIMENT_TYPE;
 }

--- a/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
@@ -633,6 +633,7 @@ export class ExperimentAssignmentService {
                 },
               ],
               assignedFactor: assignedFactors ? [assignedFactors] : null,
+              experimentType: experiment.type,
             };
           }
         });

--- a/clientlibs/java/src/main/java/org/upgradeplatform/client/Main.java
+++ b/clientlibs/java/src/main/java/org/upgradeplatform/client/Main.java
@@ -20,6 +20,7 @@ import org.upgradeplatform.responsebeans.ExperimentUser;
 import org.upgradeplatform.responsebeans.InitializeUser;
 import org.upgradeplatform.responsebeans.MarkDecisionPoint;
 import org.upgradeplatform.responsebeans.UserAliasResponse;
+import org.upgradeplatform.utils.Utils;
 import org.upgradeplatform.utils.Utils.MarkedDecisionPointStatus;
 
 public class Main {
@@ -71,7 +72,14 @@ public class Main {
 
                                                     Condition condition = expResult.getAssignedCondition();
                                                     String code = condition == null ? null : condition.getConditionCode();
+                                                    Utils.ExperimentType experimentType = expResult.getExperimentType();
+                                                    System.out.println("experimentType");
+                                                    System.out.println(experimentType);
+
+                                                    System.out.println("condition");
                                                     System.out.println(condition);
+
+                                                    System.out.println("code");
                                                     System.out.println(code);
                                                     MarkExperimentRequestData markData = new MarkExperimentRequestData(site, target);
                                                     experimentClient.markDecisionPoint(MarkedDecisionPointStatus.CONDITION_APPLIED, markData, "", new Date().toString(), new ResponseCallback<MarkDecisionPoint>(){

--- a/types/src/Experiment/interfaces.ts
+++ b/types/src/Experiment/interfaces.ts
@@ -7,6 +7,7 @@ import {
   PAYLOAD_TYPE,
   SUPPORTED_CALIPER_EVENTS,
   SUPPORTED_CALIPER_PROFILES,
+  EXPERIMENT_TYPE,
 } from './enums';
 export interface IEnrollmentCompleteCondition {
   userCount: number;
@@ -60,6 +61,7 @@ export interface IExperimentAssignmentv5 {
   target: string;
   assignedCondition: AssignedCondition[];
   assignedFactor?: Record<string, { level: string; payload: IPayload }>[];
+  experimentType: EXPERIMENT_TYPE;
 }
 
 export interface AssignedCondition {


### PR DESCRIPTION
https://github.com/CarnegieLearningWeb/UpGrade/issues/1382

This change adds the `experimentType` string enum to the `IExperimentAssignmentv5` type and the response from `/assign`, as well as the responses created by the within-subjects algorithms. This is an expected field for the Java client, and really should be expected in TS client.

If this looks acceptable and won't cause issues elsewhere to modify the API, I will create a separate ticket to update the v5 TypeScript library to get experimentType directly from the server and not use `this._experimentType = assignedFactor ? EXPERIMENT_TYPE.FACTORIAL : EXPERIMENT_TYPE.SIMPLE;`, which seems bound to break in the future anyhow.

Please let me know what tests should also be updated, I'm not very familiar with that test suite. I was surprised this didn't break anything to add this.