### PR TITLE
add env flag for toggling feature flags UI nav

### DIFF
--- a/frontend/projects/upgrade/src/app/app.module.ts
+++ b/frontend/projects/upgrade/src/app/app.module.ts
@@ -29,7 +29,7 @@ export const getEnvironmentConfig = (http: HttpClient, env: Environment) => {
       .then((config: RuntimeEnvironmentConfig) => {
         env.apiBaseUrl = config.endpointApi || config.apiBaseUrl;
         env.googleClientId = config.gapiClientId || config.googleClientId;
-        env.featureFlagNavToggle = config.featureFlagNavToggle ?? env.featureFlagNavToggle;
+        env.featureFlagNavToggle = config.featureFlagNavToggle ?? env.featureFlagNavToggle ?? false;
       })
       .catch((error) => {
         console.log({ error });

--- a/frontend/projects/upgrade/src/app/app.module.ts
+++ b/frontend/projects/upgrade/src/app/app.module.ts
@@ -29,6 +29,7 @@ export const getEnvironmentConfig = (http: HttpClient, env: Environment) => {
       .then((config: RuntimeEnvironmentConfig) => {
         env.apiBaseUrl = config.endpointApi || config.apiBaseUrl;
         env.googleClientId = config.gapiClientId || config.googleClientId;
+        env.featureFlagNavToggle = config.featureFlagNavToggle ?? env.featureFlagNavToggle;
       })
       .catch((error) => {
         console.log({ error });

--- a/frontend/projects/upgrade/src/app/features/dashboard/dashboard-root/dashboard-root.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/dashboard-root/dashboard-root.component.ts
@@ -1,7 +1,8 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
 import { SettingsService } from '../../../core/settings/settings.service';
 import { AuthService } from '../../../core/auth/auth.service';
 import { VersionService } from '../../../core/version/version.service';
+import { ENV, Environment } from '../../../../environments/environment-types';
 
 @Component({
   selector: 'app-dashboard-root',
@@ -18,11 +19,6 @@ export class DashboardRootComponent implements OnInit {
       text: 'global.experiment.title',
       iconType: 'assignment',
     },
-    // {
-    //   path: ['/featureFlags'],
-    //   text: 'feature-flags.title.text',
-    //   iconType: 'toggle_on'
-    // },
     {
       path: ['/participants'],
       text: 'global.experiment-user.title',
@@ -41,10 +37,14 @@ export class DashboardRootComponent implements OnInit {
   ];
 
   constructor(
-    private settingsService: SettingsService,
+    @Inject(ENV) private environment: Environment,
     private authService: AuthService,
     private versionService: VersionService
-  ) {}
+  ) {
+    if (this.environment.featureFlagNavToggle) {
+      this.addFeatureFlagsLink();
+    }
+  }
 
   logout() {
     this.authService.authLogout();
@@ -52,5 +52,13 @@ export class DashboardRootComponent implements OnInit {
 
   async ngOnInit() {
     this.serverVersion = 'v' + (await this.versionService.getVersion());
+  }
+
+  addFeatureFlagsLink() {
+    this.routeLinks.splice(1, 0, {
+      path: ['/featureFlags'],
+      text: 'feature-flags.title.text',
+      iconType: 'toggle_on',
+    });
   }
 }

--- a/frontend/projects/upgrade/src/environments/environment-types.ts
+++ b/frontend/projects/upgrade/src/environments/environment-types.ts
@@ -58,6 +58,7 @@ export interface Environment {
   pollingInterval: number;
   pollingLimit: number;
   api: APIEndpoints;
+  featureFlagNavToggle: boolean;
 }
 
 export interface RuntimeEnvironmentConfig {
@@ -65,4 +66,5 @@ export interface RuntimeEnvironmentConfig {
   googleClientId?: string;
   endpointApi?: string;
   apiBaseUrl?: string;
+  featureFlagNavToggle?: boolean;
 }

--- a/frontend/projects/upgrade/src/environments/environment.bsnl.ts
+++ b/frontend/projects/upgrade/src/environments/environment.bsnl.ts
@@ -10,6 +10,7 @@ export const environment = {
   pollingEnabled: false,
   pollingInterval: 10 * 1000,
   pollingLimit: 600,
+  featureFlagNavToggle: false,
   api: {
     getAllExperiments: '/experiments/paginated',
     createNewExperiments: '/experiments',

--- a/frontend/projects/upgrade/src/environments/environment.demo.prod.ts
+++ b/frontend/projects/upgrade/src/environments/environment.demo.prod.ts
@@ -10,6 +10,7 @@ export const environment = {
   pollingEnabled: true,
   pollingInterval: 10 * 1000,
   pollingLimit: 600,
+  featureFlagNavToggle: false,
   api: {
     getAllExperiments: '/experiments/paginated',
     createNewExperiments: '/experiments',

--- a/frontend/projects/upgrade/src/environments/environment.prod.ts
+++ b/frontend/projects/upgrade/src/environments/environment.prod.ts
@@ -10,6 +10,7 @@ export const environment = {
   pollingEnabled: true,
   pollingInterval: 10 * 1000,
   pollingLimit: 600,
+  featureFlagNavToggle: false,
   api: {
     getAllExperiments: '/experiments/paginated',
     createNewExperiments: '/experiments',

--- a/frontend/projects/upgrade/src/environments/environment.staging.ts
+++ b/frontend/projects/upgrade/src/environments/environment.staging.ts
@@ -10,6 +10,7 @@ export const environment = {
   pollingEnabled: true,
   pollingInterval: 10 * 1000,
   pollingLimit: 600,
+  featureFlagNavToggle: false,
   api: {
     getAllExperiments: '/experiments/paginated',
     createNewExperiments: '/experiments',

--- a/frontend/projects/upgrade/src/environments/environment.ts
+++ b/frontend/projects/upgrade/src/environments/environment.ts
@@ -15,6 +15,7 @@ export const environment = {
   pollingEnabled: true,
   pollingInterval: 10 * 1000,
   pollingLimit: 600,
+  featureFlagNavToggle: true,
   api: {
     getAllExperiments: '/experiments/paginated',
     createNewExperiments: '/experiments',


### PR DESCRIPTION
This change will allow us to toggle on feature-flags navigation access in UI.

The boolean flag `featureFlagNavToggle` will be first checked for existence on the `environment.json` object that is fetched by the UI on app load. This will allow us to control this flag without a rebuild/redeploy.

If it is `undefined/null` it will fall back to the env configuration used for that build and look for a `featureFlagNavToggle` there. This will allow us to set a state in the build config as the default for that build.

If both are not defined, fall back to `false`.

Note, this uses the null-coalesce `??` operator instead of OR `||`, because with a boolean `false` is a valid value.