### PR TITLE
assignedCondition should never be null, always be a valid Condition

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ab_testing_backend",
-    "version": "5.1.4",
+    "version": "5.1.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "ab_testing_backend",
-            "version": "5.1.4",
+            "version": "5.1.5",
             "license": "ISC",
             "dependencies": {
                 "dayjs": "^1.11.10",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ab_testing_backend",
-    "version": "5.1.4",
+    "version": "5.1.5",
     "description": "Backend for A/B Testing Project",
     "scripts": {
         "install:all": "npm ci && cd packages/Scheduler && npm ci && cd ../Upgrade && npm ci",

--- a/backend/packages/Scheduler/package-lock.json
+++ b/backend/packages/Scheduler/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppl-upgrade-serverless",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppl-upgrade-serverless",
-      "version": "5.1.4",
+      "version": "5.1.5",
       "license": "MIT",
       "dependencies": {
         "jsonwebtoken": "^9.0.0",

--- a/backend/packages/Scheduler/package.json
+++ b/backend/packages/Scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppl-upgrade-serverless",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "description": "Serverless webpack example using Typescript",
   "main": "handler.js",
   "scripts": {

--- a/backend/packages/Upgrade/package-lock.json
+++ b/backend/packages/Upgrade/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ab_testing_backend",
-    "version": "5.1.4",
+    "version": "5.1.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ab_testing_backend",
-            "version": "5.1.4",
+            "version": "5.1.5",
             "license": "ISC",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.485.0",

--- a/backend/packages/Upgrade/package.json
+++ b/backend/packages/Upgrade/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ab_testing_backend",
-    "version": "5.1.4",
+    "version": "5.1.5",
     "description": "Backend for A/B Testing Project",
     "main": "index.js",
     "scripts": {

--- a/clientlibs/java/pom.xml
+++ b/clientlibs/java/pom.xml
@@ -9,7 +9,7 @@
 		at the same time that happen to rev to the same new version will be caught 
 		by a merge conflict. -->
 
-	<version>5.1.4</version>
+	<version>5.1.5</version>
 	<build>
 		<plugins>
 			<plugin>

--- a/clientlibs/java/src/main/java/org/upgradeplatform/requestbeans/MarkExperimentRequestData.java
+++ b/clientlibs/java/src/main/java/org/upgradeplatform/requestbeans/MarkExperimentRequestData.java
@@ -6,7 +6,7 @@ public class MarkExperimentRequestData {
 
   private String site;
   private String target;
-  private Condition assignedCondition;
+  private Condition assignedCondition = new Condition();
 
   public MarkExperimentRequestData() {
     super();
@@ -22,7 +22,7 @@ public class MarkExperimentRequestData {
     super();
     this.site = site;
     this.target = target;
-    this.assignedCondition = assignedCondition;
+    this.assignedCondition = assignedCondition != null ? assignedCondition : new Condition();
   }
 
   public String getSite() {

--- a/clientlibs/java/src/main/java/org/upgradeplatform/requestbeans/MarkExperimentRequestData.java
+++ b/clientlibs/java/src/main/java/org/upgradeplatform/requestbeans/MarkExperimentRequestData.java
@@ -46,7 +46,7 @@ public class MarkExperimentRequestData {
   }
 
   public void setAssignedCondition(Condition assignedCondition) {
-    this.assignedCondition = assignedCondition;
+    this.assignedCondition = assignedCondition != null ? assignedCondition : new Condition();
   }
 
 }

--- a/clientlibs/js/package-lock.json
+++ b/clientlibs/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "upgrade_client_lib",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "upgrade_client_lib",
-      "version": "5.1.4",
+      "version": "5.1.5",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.4.0",

--- a/clientlibs/js/package.json
+++ b/clientlibs/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upgrade_client_lib",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "description": "Client library to communicate with the Upgrade server",
   "files": [
     "dist/*"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ab-testing",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ab-testing",
-      "version": "5.1.4",
+      "version": "5.1.5",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ab-testing",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "UpGrade",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "UpGrade",
-      "version": "5.1.4",
+      "version": "5.1.5",
       "license": "ISC",
       "devDependencies": {
         "@angular-eslint/eslint-plugin": "^14.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "UpGrade",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "description": "This is a combined repository for UpGrade, an open-source platform to support large-scale A/B testing in educational applications.  Learn more at www.upgradeplatform.org",
   "main": "index.js",
   "devDependencies": {

--- a/types/package-lock.json
+++ b/types/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "upgrade_types",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "upgrade_types",
-      "version": "5.1.4",
+      "version": "5.1.5",
       "license": "ISC",
       "devDependencies": {
         "eslint": "^8.27.0",

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upgrade_types",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "description": "",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
This should unblock https://carnegielearning.atlassian.net/browse/STU-2269

See #1431 found during #996, a few things have been related to this but the root of all evil was always that we are allowing the Java client to send in an unproccessable request by allowing 2 different ways for `assignedCondition` to contain `null` instead of a `Condition`, either by using the default `new MarkExperimentRequest(site, target)` or by explicitly setting it, which we allow. `new MarkExperimentRequest(site, target, null)` is valid but would break.

The change is to always have a default 'blank' `new Condition()` object in there when there is no condition, which is the right way for `/mark` to consume 'no assignment' requests. (this is how the TypeScript library works, which is why this issue doesn't happen there).

Earlier in this same thread of tests I fixed this on the API side in 5.1 (#1366) to close the hole there with `assignedCondition` being undefined / null, but the Java lib should have been modified at that time also to just never even be able to do that.

This was sufficient for API v5.1, but API v5.0 does not have that fix. so the 5.1 Java lib is blocked from prod with v5.0 in there. 