### PR TITLE
Added appContext in Metrics

### DIFF
--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
@@ -884,7 +884,7 @@ export class ExperimentClientController {
     @Body({ validate: false })
     metric: MetricValidator
   ): Promise<Metric[]> {
-    return await this.metricService.saveAllMetrics(metric.metricUnit, request.logger);
+    return await this.metricService.saveAllMetrics(metric.metricUnit, metric.context, request.logger);
   }
 
   /**

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v1.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v1.ts
@@ -851,7 +851,7 @@ export class ExperimentClientController {
     @Body({ validate: false })
     metric: MetricValidator
   ): Promise<Metric[]> {
-    return await this.metricService.saveAllMetrics(metric.metricUnit, request.logger);
+    return await this.metricService.saveAllMetrics(metric.metricUnit, metric.context, request.logger);
   }
 
   /**

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v4.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v4.ts
@@ -813,7 +813,7 @@ export class ExperimentClientController {
     @Body({ validate: false })
     metric: MetricValidator
   ): Promise<Metric[]> {
-    return await this.metricService.saveAllMetrics(metric.metricUnit, request.logger);
+    return await this.metricService.saveAllMetrics(metric.metricUnit, metric.context, request.logger);
   }
 
   /**

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v5.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v5.ts
@@ -770,7 +770,7 @@ export class ExperimentClientController {
     @Body({ validate: true })
     metric: MetricValidator
   ): Promise<Metric[]> {
-    return await this.metricService.saveAllMetrics(metric.metricUnit, request.logger);
+    return await this.metricService.saveAllMetrics(metric.metricUnit, metric.context, request.logger);
   }
 
   /**

--- a/backend/packages/Upgrade/src/api/controllers/MetricController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/MetricController.ts
@@ -1,6 +1,6 @@
 import { Authorized, JsonController, Get, Delete, Param, Post, Req, Body } from 'routing-controllers';
 import { MetricService } from '../services/MetricService';
-import { IMetricUnit, SERVER_ERROR, } from 'upgrade_types';
+import { IMetricUnit, SERVER_ERROR } from 'upgrade_types';
 import { AppRequest } from '../../types';
 import { MetricValidator } from './validators/MetricValidator';
 
@@ -31,6 +31,33 @@ export class MetricController {
   @Get()
   public getAllMetrics(@Req() request: AppRequest): Promise<IMetricUnit[]> {
     return this.metricService.getAllMetrics(request.logger);
+  }
+
+  /**
+   * @swagger
+   * /metric/{context}:
+   *    get:
+   *       description: Get all metrics with context
+   *       parameters:
+   *         - in: path
+   *           name: context
+   *           required: true
+   *           schema:
+   *             type: string
+   *           description: context
+   *       tags:
+   *         - Metrics
+   *       produces:
+   *         - application/json
+   *       responses:
+   *          '200':
+   *            description: Get all metrics with context
+   *          '404':
+   *            description: Context not found
+   */
+  @Get('/:context')
+  public getMetricsByContext(@Param('context') context: string, @Req() request: AppRequest): Promise<IMetricUnit[]> {
+    return this.metricService.getMetricsByContext(context, request.logger);
   }
 
   /**
@@ -75,7 +102,7 @@ export class MetricController {
     @Body({ validate: true }) metric: MetricValidator,
     @Req() request: AppRequest
   ): Promise<IMetricUnit[]> {
-    return this.metricService.upsertAllMetrics(metric.metricUnit, request.logger);
+    return this.metricService.upsertAllMetrics(metric.metricUnit, metric.context, request.logger);
   }
 
   /**

--- a/backend/packages/Upgrade/src/api/controllers/validators/MetricValidator.ts
+++ b/backend/packages/Upgrade/src/api/controllers/validators/MetricValidator.ts
@@ -1,4 +1,13 @@
-import { IsArray, IsEnum, IsNotEmpty, IsOptional, IsString, ValidateNested, ValidationOptions, registerDecorator } from 'class-validator';
+import {
+  IsArray,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  ValidateNested,
+  ValidationOptions,
+  registerDecorator,
+} from 'class-validator';
 import { IMetricMetaData } from 'upgrade_types';
 
 const IsMetricUnit = (validationOptions?: ValidationOptions) => {
@@ -14,7 +23,7 @@ const IsMetricUnit = (validationOptions?: ValidationOptions) => {
       },
       validator: {
         validate(value: any) {
-          return validateMetricUnit(value)
+          return validateMetricUnit(value);
         },
       },
     });
@@ -23,11 +32,11 @@ const IsMetricUnit = (validationOptions?: ValidationOptions) => {
 
 function validateMetricUnit(data: unknown) {
   if (Array.isArray(data) && data.every(isValidMetric)) {
-    return true
+    return true;
   } else {
-    return false
+    return false;
   }
-};
+}
 
 function isValidMetric(value: any): value is IGroupMetric | ISingleMetric {
   if ('groupClass' in value) {
@@ -49,9 +58,7 @@ function isValidMetric(value: any): value is IGroupMetric | ISingleMetric {
       (value.allowedValues === undefined ||
         (Array.isArray(value.allowedValues) &&
           value.allowedValues.every(
-            (allowedValue) =>
-              typeof allowedValue === 'string' ||
-              typeof allowedValue === 'number'
+            (allowedValue) => typeof allowedValue === 'string' || typeof allowedValue === 'number'
           )))
     );
   }
@@ -68,7 +75,7 @@ class ISingleMetric {
   datatype: IMetricMetaData;
 
   @IsOptional()
-  @IsArray({each: true})
+  @IsArray({ each: true })
   allowedValues?: (string | number)[];
 }
 
@@ -77,7 +84,7 @@ class IGroupMetric {
   groupClass: string;
 
   @IsArray()
-  @IsString({each: true})
+  @IsString({ each: true })
   allowedKeys: string[];
 
   @IsArray()
@@ -91,4 +98,9 @@ export class MetricValidator {
   @IsNotEmpty()
   @IsMetricUnit()
   metricUnit: (ISingleMetric | IGroupMetric)[];
+
+  @IsArray()
+  @IsNotEmpty()
+  @IsString({ each: true })
+  context: string[];
 }

--- a/backend/packages/Upgrade/src/api/models/Metric.ts
+++ b/backend/packages/Upgrade/src/api/models/Metric.ts
@@ -19,6 +19,9 @@ export class Metric extends BaseModel {
   @Column({ type: 'simple-array', nullable: true })
   public allowedData: string[];
 
+  @Column('text', { array: true })
+  public context: string[];
+
   @ManyToMany(() => Log, (log) => log.metrics, {
     cascade: true,
   })

--- a/backend/packages/Upgrade/src/api/repositories/MetricRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/MetricRepository.ts
@@ -30,6 +30,16 @@ export class MetricRepository extends Repository<Metric> {
       });
   }
 
+  public async getMetricsByContext(context: string): Promise<Metric[]> {
+    return this.createQueryBuilder('metrics')
+      .where('context @> :searchContext', { searchContext: [context] })
+      .getMany()
+      .catch((errorMsg: any) => {
+        const errorMsgString = repositoryError(this.constructor.name, 'getMetricsByContext', { context }, errorMsg);
+        throw errorMsgString;
+      });
+  }
+
   public async findMetricsWithQueries(ids: string[]): Promise<Metric[]> {
     return this.createQueryBuilder('metrics')
       .innerJoin('metrics.queries', 'queries')

--- a/backend/packages/Upgrade/src/database/migrations/1712553037665-contextInMetric.ts
+++ b/backend/packages/Upgrade/src/database/migrations/1712553037665-contextInMetric.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class contextInMetric1712553037665 implements MigrationInterface {
+  name = 'contextInMetric1712553037665';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "metric" ADD "context" text array NOT NULL`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "metric" DROP COLUMN "context"`);
+  }
+}

--- a/frontend/projects/upgrade/src/app/core/analysis/store/analysis.models.ts
+++ b/frontend/projects/upgrade/src/app/core/analysis/store/analysis.models.ts
@@ -8,6 +8,7 @@ export const METRICS_JOIN_TEXT = '@__@';
 export interface MetricUnit {
   key: string;
   children: MetricUnit[];
+  context?: string[];
 }
 
 export interface UpsertMetrics {

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.ts
@@ -85,13 +85,16 @@ export class MonitoredMetricsComponent implements OnInit, OnChanges, OnDestroy {
   ) {}
 
   optionsSub() {
+    console.log('this.currentContext:', this.currentContext, this.experimentInfo?.context);
     this.allMetricsSub = this.analysisService.allMetrics$.subscribe((metrics) => {
       this.allMetrics = metrics;
       // Hide global metrics options if Within-subjects is selected
       this.options =
         this.currentAssignmentUnit === ASSIGNMENT_UNIT.WITHIN_SUBJECTS
           ? this.allMetrics.filter((metric) => metric.children.length > 0)
-          : this.allMetrics;
+          : this.allMetrics.filter((metric) =>
+              metric.context.includes(this.currentContext || this.experimentInfo?.context)
+            );
     });
   }
 
@@ -711,7 +714,7 @@ export class MonitoredMetricsComponent implements OnInit, OnChanges, OnDestroy {
 
   ngOnChanges() {
     if (this.isContextChanged || this.isExperimentTypeChanged) {
-      this.isContextChanged = false;
+      this.optionsSub();
       this.isExperimentTypeChanged = false;
       this.queries.clear();
       this.metricsDataSource.next(this.queries.controls);

--- a/types/src/Experiment/interfaces.ts
+++ b/types/src/Experiment/interfaces.ts
@@ -110,6 +110,7 @@ export interface IExperimentSortParams {
 
 export interface IMetricUnit {
   key: string | string[];
+  context?: string[];
   children?: IMetricUnit[];
   metadata?: { type: IMetricMetaData };
   allowedData?: string[];


### PR DESCRIPTION
**Completed**

- Updated Metric model to add context as an array
- Updated Migration file
- Update CRUD operations
- Added a new API to get metrics only having the given context.
- Updated stepper to show metrics belonging to the context

**Remaining**

- create a way to add context in the JSON editor of metrics.
- what should be the context in pre-created metrics and metrics from .env file
- Update test cases for the changes
