### PR TITLE
Resolve issue of user coming as undefined in audit logs

### DIFF
--- a/backend/packages/Upgrade/.env.docker.local
+++ b/backend/packages/Upgrade/.env.docker.local
@@ -66,7 +66,6 @@ MONITOR_PASSWORD=1234
 #
 GOOGLE_CLIENT_ID=google_project_id
 DOMAIN_NAME =
-AUTH_CHECK=false
 SCHEDULER_STEP_FUNCTION=arn:aws:states:us-east-1:781188149671:stateMachine:development-upgrade-experiment-scheduler
 AWS_REGION=us-east-1
 HOST_URL = https://upgrade-dev-backend.edoptimize.com/api

--- a/backend/packages/Upgrade/.env.example
+++ b/backend/packages/Upgrade/.env.example
@@ -65,7 +65,6 @@ MONITOR_PASSWORD=1234
 #
 GOOGLE_CLIENT_ID=google_project_id
 DOMAIN_NAME =
-AUTH_CHECK=false
 SCHEDULER_STEP_FUNCTION=arn:aws:states:us-east-1:781188149671:stateMachine:development-upgrade-experiment-scheduler
 # SCHEDULER_STEP_FUNCTION=arn:aws:states:us-east-1:781188149671:stateMachine:staging-upgrade-experiment-scheduler
 AWS_REGION=us-east-1

--- a/backend/packages/Upgrade/.env.test
+++ b/backend/packages/Upgrade/.env.test
@@ -67,7 +67,6 @@ MONITOR_PASSWORD=<replaceme>
 #
 GOOGLE_CLIENT_ID=google_project_id
 DOMAIN_NAME =
-AUTH_CHECK=false
 SCHEDULER_STEP_FUNCTION=arn:aws:states:us-east-1:781188149671:stateMachine:development-upgrade-experiment-scheduler
 # SCHEDULER_STEP_FUNCTION=arn:aws:states:us-east-1:781188149671:stateMachine:staging-upgrade-experiment-scheduler
 AWS_REGION=<anyAWSregion>

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
@@ -17,7 +17,7 @@ import { ExperimentNotFoundError } from '../errors/ExperimentNotFoundError';
 import { ExperimentService } from '../services/ExperimentService';
 import { ExperimentAssignmentService } from '../services/ExperimentAssignmentService';
 import { SERVER_ERROR } from 'upgrade_types';
-import { validate, isUUID } from 'class-validator';
+import { isUUID } from 'class-validator';
 import { ExperimentCondition } from '../models/ExperimentCondition';
 import { ExperimentPaginatedParamsValidator } from './validators/ExperimentPaginatedParamsValidator';
 import { User } from '../models/User';

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
@@ -1068,17 +1068,15 @@ export class ExperimentController {
     @CurrentUser() currentUser: User,
     @Req() request: AppRequest
   ): Promise<any> {
-    if (env.auth.authCheck) {
-      if (!currentUser) {
-        return Promise.reject(
-          new Error(JSON.stringify({ type: SERVER_ERROR.MISSING_PARAMS, message: ' : currentUser should not be null' }))
-        );
-      }
-
-      await validate(currentUser).catch((error) => {
-        return Promise.reject(new Error(error));
-      });
+    if (!currentUser) {
+      return Promise.reject(
+        new Error(JSON.stringify({ type: SERVER_ERROR.MISSING_PARAMS, message: ' : currentUser should not be null' }))
+      );
     }
+
+    await validate(currentUser).catch((error) => {
+      return Promise.reject(new Error(error));
+    });
 
     return this.experimentService.updateState(
       experiment.experimentId,

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
@@ -23,7 +23,6 @@ import { ExperimentPaginatedParamsValidator } from './validators/ExperimentPagin
 import { User } from '../models/User';
 import { DecisionPoint } from '../models/DecisionPoint';
 import { AssignmentStateUpdateValidator } from './validators/AssignmentStateUpdateValidator';
-import { env } from '../../env';
 import { AppRequest, PaginationResponse } from '../../types';
 import { ExperimentDTO, ExperimentFile, ValidatedExperimentError } from '../DTO/ExperimentDTO';
 import { ExperimentIds } from './validators/ExperimentIdsValidator';

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
@@ -1067,16 +1067,6 @@ export class ExperimentController {
     @CurrentUser() currentUser: User,
     @Req() request: AppRequest
   ): Promise<any> {
-    if (!currentUser) {
-      return Promise.reject(
-        new Error(JSON.stringify({ type: SERVER_ERROR.MISSING_PARAMS, message: ' : currentUser should not be null' }))
-      );
-    }
-
-    await validate(currentUser).catch((error) => {
-      return Promise.reject(new Error(error));
-    });
-
     return this.experimentService.updateState(
       experiment.experimentId,
       experiment.state,

--- a/backend/packages/Upgrade/src/auth/authorizationChecker.ts
+++ b/backend/packages/Upgrade/src/auth/authorizationChecker.ts
@@ -31,7 +31,7 @@ export function authorizationChecker(): (action: Action, roles: any[]) => Promis
       action.request.user = userDoc;
       return true;
     } catch (error) {
-      return env.auth.authCheck ? false : true;
+      return false;
     }
   };
 }

--- a/backend/packages/Upgrade/src/auth/authorizationChecker.ts
+++ b/backend/packages/Upgrade/src/auth/authorizationChecker.ts
@@ -23,7 +23,7 @@ export function authorizationChecker(): (action: Action, roles: any[]) => Promis
     const token = authService.parseBasicAuthFromRequest(action.request);
     if (token === undefined) {
       log.warn({ message: 'No token provided' });
-      return env.auth.authCheck ? false : true;
+      return false;
     }
     try {
       const userDoc = await authService.validateUser(token, action.request);

--- a/backend/packages/Upgrade/src/env.ts
+++ b/backend/packages/Upgrade/src/env.ts
@@ -80,9 +80,6 @@ export const env = {
     clientId: getOsEnv('GOOGLE_CLIENT_ID'),
     domainName: getOsEnvOptional('DOMAIN_NAME'),
   },
-  auth: {
-    authCheck: toBool(getOsEnvOptional('AUTH_CHECK')),
-  },
   scheduler: {
     stepFunctionArn: getOsEnv('SCHEDULER_STEP_FUNCTION'),
   },

--- a/backend/packages/Upgrade/test/unit/controllers/ExperimentClientController.test.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/ExperimentClientController.test.ts
@@ -8,8 +8,8 @@ import { ExperimentUserService } from '../../../src/api/services/ExperimentUserS
 import { FeatureFlagService } from '../../../src/api/services/FeatureFlagService';
 import { MetricService } from '../../../src/api/services/MetricService';
 import { ClientLibMiddleware } from '../../../src/api/middlewares/ClientLibMiddleware';
-import ExperimentServieMock from './mocks/ExperimentServiceMock';
-import ExperimentAssignmentServieMock from './mocks/ExperimentAssignmentServiceMock';
+import ExperimentServiceMock from './mocks/ExperimentServiceMock';
+import ExperimentAssignmentServiceMock from './mocks/ExperimentAssignmentServiceMock';
 import ExperimentUserServiceMock from './mocks/ExperimentUserServiceMock';
 import FeatureFlagServiceMock from './mocks/FeatureFlagServiceMock';
 import MetricServiceMock from './mocks/MetricServiceMock';
@@ -25,8 +25,8 @@ describe('Experiment Client Controller Testing', () => {
     ormUseContainer(Container);
     classValidatorUseContainer(Container);
 
-    Container.set(ExperimentService, new ExperimentServieMock());
-    Container.set(ExperimentAssignmentService, new ExperimentAssignmentServieMock());
+    Container.set(ExperimentService, new ExperimentServiceMock());
+    Container.set(ExperimentAssignmentService, new ExperimentAssignmentServiceMock());
     Container.set(ExperimentUserService, new ExperimentUserServiceMock());
     Container.set(FeatureFlagService, new FeatureFlagServiceMock());
     Container.set(MetricService, new MetricServiceMock());

--- a/backend/packages/Upgrade/test/unit/controllers/ExperimentController.test.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/ExperimentController.test.ts
@@ -89,17 +89,6 @@ describe('Experiment Controller Testing', () => {
     },
   };
 
-  const mockUser: User = {
-    email: 'test@user.com',
-    firstName: 'test',
-    lastName: 'user',
-    role: UserRole.READER,
-    versionNumber: 5,
-    imageUrl: '',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  };
-
   test('Get request for /api/experiments', () => {
     return request(app).get('/api/experiments').expect('Content-Type', /json/).expect(200);
   });

--- a/backend/packages/Upgrade/test/unit/controllers/ExperimentController.test.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/ExperimentController.test.ts
@@ -6,11 +6,12 @@ import { Container } from 'typedi';
 import { v4 as uuid } from 'uuid';
 import ExperimentServiceMock from './mocks/ExperimentServiceMock';
 import { ExperimentService } from '../../../src/api/services/ExperimentService';
-
+import { UserRole } from 'upgrade_types';
 import { useContainer as classValidatorUseContainer } from 'class-validator';
 import { useContainer as ormUseContainer } from 'typeorm';
 import { ExperimentAssignmentService } from '../../../src/api/services/ExperimentAssignmentService';
 import ExperimentAssignmentServiceMock from './mocks/ExperimentAssignmentServiceMock';
+import { User } from 'src/api/models/User';
 
 describe('Experiment Controller Testing', () => {
   beforeAll(() => {
@@ -86,6 +87,17 @@ describe('Experiment Controller Testing', () => {
         type: 'private',
       },
     },
+  };
+
+  const mockUser: User = {
+    email: 'test@user.com',
+    firstName: 'test',
+    lastName: 'user',
+    role: UserRole.READER,
+    versionNumber: 5,
+    imageUrl: '',
+    createdAt: new Date(),
+    updatedAt: new Date(),
   };
 
   test('Get request for /api/experiments', () => {

--- a/backend/packages/Upgrade/test/unit/controllers/ExperimentController.test.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/ExperimentController.test.ts
@@ -6,12 +6,10 @@ import { Container } from 'typedi';
 import { v4 as uuid } from 'uuid';
 import ExperimentServiceMock from './mocks/ExperimentServiceMock';
 import { ExperimentService } from '../../../src/api/services/ExperimentService';
-import { UserRole } from 'upgrade_types';
 import { useContainer as classValidatorUseContainer } from 'class-validator';
 import { useContainer as ormUseContainer } from 'typeorm';
 import { ExperimentAssignmentService } from '../../../src/api/services/ExperimentAssignmentService';
 import ExperimentAssignmentServiceMock from './mocks/ExperimentAssignmentServiceMock';
-import { User } from 'src/api/models/User';
 
 describe('Experiment Controller Testing', () => {
   beforeAll(() => {
@@ -88,6 +86,19 @@ describe('Experiment Controller Testing', () => {
       },
     },
   };
+
+  //for future use where user will be mocked for all testcases
+
+  // const mockUser: User = {
+  //   email: 'test@user.com',
+  //   firstName: 'test',
+  //   lastName: 'user',
+  //   role: UserRole.READER,
+  //   versionNumber: 5,
+  //   imageUrl: '',
+  //   createdAt: new Date(),
+  //   updatedAt: new Date(),
+  // };
 
   test('Get request for /api/experiments', () => {
     return request(app).get('/api/experiments').expect('Content-Type', /json/).expect(200);

--- a/backend/packages/Upgrade/test/unit/controllers/mocks/ExperimentAssignmentServiceMock.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/mocks/ExperimentAssignmentServiceMock.ts
@@ -2,7 +2,7 @@ import { Service } from 'typedi';
 import { ILogInput } from 'upgrade_types';
 
 @Service()
-export default class ExperimentAssignmentServieMock {
+export default class ExperimentAssignmentServiceMock {
   public markExperimentPoint(id: string, experimentPoint: string, condition: string, partitionId: string): Promise<[]> {
     return Promise.resolve([]);
   }

--- a/backend/packages/Upgrade/test/unit/controllers/mocks/ExperimentServiceMock.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/mocks/ExperimentServiceMock.ts
@@ -4,7 +4,7 @@ import { Service } from 'typedi';
 import { UpgradeLogger } from '../../../../src/lib/logger/UpgradeLogger';
 
 @Service()
-export default class ExperimentServieMock {
+export default class ExperimentServiceMock {
   public find(): Promise<[]> {
     return Promise.resolve([]);
   }

--- a/backend/packages/Upgrade/test/unit/controllers/mocks/StratificationServiceMock.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/mocks/StratificationServiceMock.ts
@@ -3,7 +3,7 @@ import { UpgradeLogger } from '../../../../src/lib/logger/UpgradeLogger';
 import { StratificationInputValidator } from 'src/api/controllers/validators/StratificationValidator';
 
 @Service()
-export default class StratificationServieMock {
+export default class StratificationServiceMock {
   public getAllStratification(logger: UpgradeLogger): Promise<[]> {
     return Promise.resolve([]);
   }


### PR DESCRIPTION
This PR address issue of user coming as undefined in audit logs.
Solution:
If user going as undefined, keep auth checker always on so if upgrad can't authenticate user it will log out user and audit logs won't get user as undefined.