### PR TITLE
Bugfix for consistent metrics statistics view

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ab_testing_backend",
-    "version": "5.1.8",
+    "version": "5.1.9",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "ab_testing_backend",
-            "version": "5.1.8",
+            "version": "5.1.9",
             "license": "ISC",
             "dependencies": {
                 "dayjs": "^1.11.10",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ab_testing_backend",
-    "version": "5.1.8",
+    "version": "5.1.9",
     "description": "Backend for A/B Testing Project",
     "scripts": {
         "install:all": "npm ci && cd packages/Scheduler && npm ci && cd ../Upgrade && npm ci",

--- a/backend/packages/Scheduler/package-lock.json
+++ b/backend/packages/Scheduler/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppl-upgrade-serverless",
-  "version": "5.1.8",
+  "version": "5.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppl-upgrade-serverless",
-      "version": "5.1.8",
+      "version": "5.1.9",
       "license": "MIT",
       "dependencies": {
         "jsonwebtoken": "^9.0.0",

--- a/backend/packages/Scheduler/package.json
+++ b/backend/packages/Scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppl-upgrade-serverless",
-  "version": "5.1.8",
+  "version": "5.1.9",
   "description": "Serverless webpack example using Typescript",
   "main": "handler.js",
   "scripts": {

--- a/backend/packages/Upgrade/package-lock.json
+++ b/backend/packages/Upgrade/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ab_testing_backend",
-    "version": "5.1.8",
+    "version": "5.1.9",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ab_testing_backend",
-            "version": "5.1.8",
+            "version": "5.1.9",
             "license": "ISC",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.485.0",

--- a/backend/packages/Upgrade/package.json
+++ b/backend/packages/Upgrade/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ab_testing_backend",
-    "version": "5.1.8",
+    "version": "5.1.9",
     "description": "Backend for A/B Testing Project",
     "main": "index.js",
     "scripts": {

--- a/backend/packages/Upgrade/test/integration/Experiment/dataLog/LogOperations.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/dataLog/LogOperations.ts
@@ -620,14 +620,14 @@ export default async function LogOperations(): Promise<void> {
         expect(countValue).toEqual(expectedValue);
         break;
       case OPERATION_TYPES.AVERAGE:
-        const aveValue = (res.reduce((accu, data) => {
+        const avgValue = (res.reduce((accu, data) => {
           return accu + data;
         }, 0))/res.length;
         expectedValue = 128;
         if (query.metric.key !== 'totalProblemsCompleted') {
           expectedValue = 250; // For completion metric
         }
-        expect(aveValue).toEqual(expectedValue);
+        expect(avgValue).toEqual(expectedValue);
         break;
       case OPERATION_TYPES.MODE:
         const modeValue = res[1];

--- a/backend/packages/Upgrade/test/integration/Experiment/stratification/MetricQueriesCheck.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/stratification/MetricQueriesCheck.ts
@@ -809,8 +809,8 @@ export default async function MetricQueriesCheck(): Promise<void> {
             return condition;
           }
         });
-        const Average = parseInt(condition.result, 10);
-        expect(Average).toEqual(expectedValue);
+        const meanValue = parseInt(condition.result, 10);
+        expect(meanValue).toEqual(expectedValue);
         break;
       }
 

--- a/backend/packages/Upgrade/test/integration/Experiment/withinSubject/MetricQueriesCheck.ts
+++ b/backend/packages/Upgrade/test/integration/Experiment/withinSubject/MetricQueriesCheck.ts
@@ -724,8 +724,8 @@ export default async function MetricQueriesCheck(): Promise<void> {
             return condition;
           }
         });
-        const sum = parseInt(condition.result, 10);
-        expect(sum).toEqual(expectedValue);
+        const sumValue = parseInt(condition.result, 10);
+        expect(sumValue).toEqual(expectedValue);
         break;
       }
 
@@ -809,8 +809,8 @@ export default async function MetricQueriesCheck(): Promise<void> {
             return condition;
           }
         });
-        const Average = parseInt(condition.result, 10);
-        expect(Average).toEqual(expectedValue);
+        const meanValue = parseInt(condition.result, 10);
+        expect(meanValue).toEqual(expectedValue);
         break;
       }
 
@@ -837,8 +837,8 @@ export default async function MetricQueriesCheck(): Promise<void> {
             return condition;
           }
         });
-        const Mode = parseInt(condition.result, 10);
-        expect(Mode).toEqual(expectedValue);
+        const modeValue = parseInt(condition.result, 10);
+        expect(modeValue).toEqual(expectedValue);
         break;
       }
 
@@ -865,8 +865,8 @@ export default async function MetricQueriesCheck(): Promise<void> {
             return condition;
           }
         });
-        const Median = parseInt(condition.result, 10);
-        expect(Median).toEqual(expectedValue);
+        const medianValue = parseInt(condition.result, 10);
+        expect(medianValue).toEqual(expectedValue);
         break;
       }
 
@@ -893,8 +893,8 @@ export default async function MetricQueriesCheck(): Promise<void> {
             return condition;
           }
         });
-        const StdDev = parseInt(condition.result, 10);
-        expect(StdDev).toEqual(expectedValue);
+        const stdDevValue = parseInt(condition.result, 10);
+        expect(stdDevValue).toEqual(expectedValue);
         break;
       }
 
@@ -938,8 +938,8 @@ export default async function MetricQueriesCheck(): Promise<void> {
             return condition;
           }
         });
-        const Count = parseInt(condition.result, 10);
-        expect(Count).toEqual(expectedValue);
+        const countValue = parseInt(condition.result, 10);
+        expect(countValue).toEqual(expectedValue);
         break;
       }
 
@@ -962,8 +962,8 @@ export default async function MetricQueriesCheck(): Promise<void> {
             return condition;
           }
         });
-        const Percentage = parseInt(condition.result, 10);
-        expect(Percentage).toEqual(expectedValue);
+        const percentageValue = parseInt(condition.result, 10);
+        expect(percentageValue).toEqual(expectedValue);
         break;
       }
       default:

--- a/clientlibs/java/pom.xml
+++ b/clientlibs/java/pom.xml
@@ -9,7 +9,7 @@
 		at the same time that happen to rev to the same new version will be caught 
 		by a merge conflict. -->
 
-	<version>5.1.8</version>
+	<version>5.1.9</version>
 	<build>
 		<plugins>
 			<plugin>

--- a/clientlibs/js/package-lock.json
+++ b/clientlibs/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "upgrade_client_lib",
-  "version": "5.1.8",
+  "version": "5.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "upgrade_client_lib",
-      "version": "5.1.8",
+      "version": "5.1.9",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.4.0",

--- a/clientlibs/js/package.json
+++ b/clientlibs/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upgrade_client_lib",
-  "version": "5.1.8",
+  "version": "5.1.9",
   "description": "Client library to communicate with the Upgrade server",
   "files": [
     "dist/*"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ab-testing",
-  "version": "5.1.8",
+  "version": "5.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ab-testing",
-      "version": "5.1.8",
+      "version": "5.1.9",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ab-testing",
-  "version": "5.1.8",
+  "version": "5.1.9",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.ts
@@ -249,7 +249,7 @@ export class ViewExperimentComponent implements OnInit, OnDestroy {
         }
         // separating keys from metric
         const rootKey: string[] = key.split(METRICS_JOIN_TEXT);
-        const statisticOperation: string[] = [query.query.operationType];
+        const statisticOperation: string[] = [];
         if (rootKey.length > 1) {
           statisticOperation.push(query.repeatedMeasure);
         }
@@ -263,6 +263,7 @@ export class ViewExperimentComponent implements OnInit, OnDestroy {
           statisticOperation.push(compareFn);
           statisticOperation.push(query.query.compareValue);
         }
+        query.query.operationType === "avg" ? statisticOperation.push("mean") : statisticOperation.push(query.query.operationType);
         this.displayMetrics.push({
           metric_Key: rootKey,
           metric_Operation: statisticOperation,

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.ts
@@ -25,7 +25,7 @@ import { StateTimeLogsComponent } from '../../components/modal/state-time-logs/s
 import { ExportModalComponent } from '../../components/modal/export-experiment/export-experiment.component';
 import { FLAG_SEARCH_SORT_KEY } from '../../../../../core/feature-flags/store/feature-flags.model';
 import { EnrollmentOverTimeComponent } from '../../components/enrollment-over-time/enrollment-over-time.component';
-import { EXPERIMENT_TYPE, IMetricMetaData, PAYLOAD_TYPE } from 'upgrade_types';
+import { EXPERIMENT_TYPE, IMetricMetaData, OPERATION_TYPES, PAYLOAD_TYPE } from 'upgrade_types';
 import { MemberTypes } from '../../../../../core/segments/store/segments.model';
 import { METRICS_JOIN_TEXT } from '../../../../../core/analysis/store/analysis.models';
 import { ExperimentDesignStepperService } from '../../../../../core/experiment-design-stepper/experiment-design-stepper.service';
@@ -76,6 +76,19 @@ export class ViewExperimentComponent implements OnInit, OnDestroy {
   comparisonFns = [
     { value: '=', viewValue: 'equal' },
     { value: '<>', viewValue: 'not equal' },
+  ];
+
+  queryOperations = [
+    { value: OPERATION_TYPES.SUM, viewValue: 'Sum' },
+    { value: OPERATION_TYPES.MIN, viewValue: 'Min' },
+    { value: OPERATION_TYPES.MAX, viewValue: 'Max' },
+    { value: OPERATION_TYPES.COUNT, viewValue: 'Count' },
+    { value: OPERATION_TYPES.AVERAGE, viewValue: 'Mean' },
+    { value: OPERATION_TYPES.MODE, viewValue: 'Mode' },
+    { value: OPERATION_TYPES.MEDIAN, viewValue: 'Median' },
+    { value: OPERATION_TYPES.STDEV, viewValue: 'Standard Deviation' },
+    { value: OPERATION_TYPES.COUNT, viewValue: 'Count' },
+    { value: OPERATION_TYPES.PERCENTAGE, viewValue: 'Percentage' },
   ];
 
   includeParticipants: Participants[] = [];
@@ -263,7 +276,8 @@ export class ViewExperimentComponent implements OnInit, OnDestroy {
           statisticOperation.push(compareFn);
           statisticOperation.push(query.query.compareValue);
         }
-        query.query.operationType === "avg" ? statisticOperation.push("mean") : statisticOperation.push(query.query.operationType);
+        const operationObject = this.queryOperations.find(op => op.value === query.query.operationType);
+        statisticOperation.push(operationObject.viewValue);
         this.displayMetrics.push({
           metric_Key: rootKey,
           metric_Operation: statisticOperation,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "UpGrade",
-  "version": "5.1.8",
+  "version": "5.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "UpGrade",
-      "version": "5.1.8",
+      "version": "5.1.9",
       "license": "ISC",
       "devDependencies": {
         "@angular-eslint/eslint-plugin": "^14.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "UpGrade",
-  "version": "5.1.8",
+  "version": "5.1.9",
   "description": "This is a combined repository for UpGrade, an open-source platform to support large-scale A/B testing in educational applications.  Learn more at www.upgradeplatform.org",
   "main": "index.js",
   "devDependencies": {

--- a/types/package-lock.json
+++ b/types/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "upgrade_types",
-  "version": "5.1.8",
+  "version": "5.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "upgrade_types",
-      "version": "5.1.8",
+      "version": "5.1.9",
       "license": "ISC",
       "devDependencies": {
         "eslint": "^8.27.0",

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upgrade_types",
-  "version": "5.1.8",
+  "version": "5.1.9",
   "description": "",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
Bugfix for issue #1452 

This PR has below changes:
1. Correct order for operation type in statistics column in details page (Metrics Tab)
2. 'Avg' is now shown as 'Mean' in statistics column in details page (Metrics Tab)
3. Also, updated few variable names for various log operation types to follow Camel Case.

Before:
<img width="999" alt="Screenshot 2024-04-18 at 3 36 06 PM" src="https://github.com/CarnegieLearningWeb/UpGrade/assets/33730817/58629a12-a21f-41f5-a8b7-36136707c68f">

After:
<img width="1022" alt="Screenshot 2024-04-19 at 7 22 00 PM" src="https://github.com/CarnegieLearningWeb/UpGrade/assets/33730817/ecd7d2da-2f86-4256-9972-df042e9585f2">



