### PR TITLE
Feature flag admin endpoints

### DIFF
--- a/backend/packages/Upgrade/src/api/controllers/validators/FeatureFlagValidator.ts
+++ b/backend/packages/Upgrade/src/api/controllers/validators/FeatureFlagValidator.ts
@@ -1,9 +1,11 @@
-import { IsNotEmpty, IsDefined, IsString, IsArray, IsEnum } from 'class-validator';
+import { IsNotEmpty, IsDefined, IsString, IsArray, IsEnum, IsOptional, ValidateNested } from 'class-validator';
+import { ParticipantsValidator } from 'src/api/DTO/ExperimentDTO';
+import { Column } from 'typeorm';
 import { FEATURE_FLAG_STATUS } from 'upgrade_types';
+import { Type } from 'class-transformer';
 
 export class FeatureFlagValidation {
-  @IsNotEmpty()
-  @IsDefined()
+  @IsOptional()
   @IsString()
   id: string;
 
@@ -28,10 +30,20 @@ export class FeatureFlagValidation {
   status: FEATURE_FLAG_STATUS;
 
   @IsNotEmpty()
-  @IsArray()
+  @Column('text', { array: true })
   public context: string[];
 
   @IsNotEmpty()
   @IsArray()
   public tags: string[];
+
+  @IsNotEmpty()
+  @ValidateNested()
+  @Type(() => ParticipantsValidator)
+  public featureFlagSegmentInclusion: ParticipantsValidator;
+
+  @IsNotEmpty()
+  @ValidateNested()
+  @Type(() => ParticipantsValidator)
+  public featureFlagSegmentExclusion: ParticipantsValidator;
 }

--- a/backend/packages/Upgrade/src/api/controllers/validators/FeatureFlagsPaginatedParamsValidator.ts
+++ b/backend/packages/Upgrade/src/api/controllers/validators/FeatureFlagsPaginatedParamsValidator.ts
@@ -4,26 +4,34 @@ import { EXPERIMENT_SORT_AS } from 'upgrade_types';
 
 // TODO: Move to upgrade types
 export interface IFeatureFlagSearchParams {
-  key: FLAG_SEARCH_SORT_KEY;
+  key: FLAG_SEARCH_KEY;
   string: string;
 }
 export interface IFeatureFlagSortParams {
-  key: FLAG_SEARCH_SORT_KEY;
+  key: FLAG_SORT_KEY;
   sortAs: EXPERIMENT_SORT_AS;
 }
 
-export enum FLAG_SEARCH_SORT_KEY {
+export enum FLAG_SORT_KEY {
+  NAME = 'name',
+  KEY = 'key',
+  STATUS = 'status',
+  UPDATED_AT = 'updatedAt',
+}
+
+export enum FLAG_SEARCH_KEY {
   ALL = 'all',
   NAME = 'name',
   KEY = 'key',
   STATUS = 'status',
-  VARIATION_TYPE = 'variationType',
+  TAG = 'tag',
+  CONTEXT = 'context',
 }
 
 class IFeatureFlagSortParamsValidator {
   @IsNotEmpty()
-  @IsEnum(FLAG_SEARCH_SORT_KEY)
-  key: FLAG_SEARCH_SORT_KEY;
+  @IsEnum(FLAG_SORT_KEY)
+  key: FLAG_SORT_KEY;
 
   @IsNotEmpty()
   @IsEnum(EXPERIMENT_SORT_AS)
@@ -32,8 +40,8 @@ class IFeatureFlagSortParamsValidator {
 
 class IFeatureFlagSearchParamsValidator {
   @IsNotEmpty()
-  @IsEnum(FLAG_SEARCH_SORT_KEY)
-  key: FLAG_SEARCH_SORT_KEY;
+  @IsEnum(FLAG_SEARCH_KEY)
+  key: FLAG_SEARCH_KEY;
 
   @IsNotEmpty()
   @IsString()

--- a/backend/packages/Upgrade/src/api/models/FeatureFlag.ts
+++ b/backend/packages/Upgrade/src/api/models/FeatureFlag.ts
@@ -1,8 +1,7 @@
-import { Column, Entity, PrimaryColumn, OneToMany, OneToOne } from 'typeorm';
-import { IsNotEmpty, ValidateNested } from 'class-validator';
+import { Column, Entity, PrimaryColumn, OneToOne } from 'typeorm';
+import { IsNotEmpty } from 'class-validator';
 import { BaseModel } from './base/BaseModel';
 import { Type } from 'class-transformer';
-import { FlagVariation } from './FlagVariation';
 import { FeatureFlagSegmentInclusion } from './FeatureFlagSegmentInclusion';
 import { FeatureFlagSegmentExclusion } from './FeatureFlagSegmentExclusion';
 import { FEATURE_FLAG_STATUS } from 'upgrade_types';
@@ -34,11 +33,6 @@ export class FeatureFlag extends BaseModel {
     default: FEATURE_FLAG_STATUS.DISABLED,
   })
   public status: FEATURE_FLAG_STATUS;
-
-  @OneToMany(() => FlagVariation, (variation) => variation.featureFlag)
-  @ValidateNested()
-  @Type(() => FlagVariation)
-  public variations: FlagVariation[];
 
   @OneToOne(() => FeatureFlagSegmentInclusion, (featureFlagSegmentInclusion) => featureFlagSegmentInclusion.featureFlag)
   @Type(() => FeatureFlagSegmentInclusion)

--- a/backend/packages/Upgrade/src/api/repositories/FeatureFlagSegmentExclusionRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/FeatureFlagSegmentExclusionRepository.ts
@@ -1,0 +1,75 @@
+import { Repository, EntityRepository, EntityManager } from 'typeorm';
+import repositoryError from './utils/repositoryError';
+import { UpgradeLogger } from 'src/lib/logger/UpgradeLogger';
+import { FeatureFlagSegmentExclusion } from '../models/FeatureFlagSegmentExclusion';
+
+@EntityRepository(FeatureFlagSegmentExclusion)
+export class FeatureFlagSegmentExclusionRepository extends Repository<FeatureFlagSegmentExclusion> {
+  public async insertData(
+    data: Partial<FeatureFlagSegmentExclusion>,
+    logger: UpgradeLogger,
+    entityManager: EntityManager
+  ): Promise<FeatureFlagSegmentExclusion> {
+    const result = await entityManager
+      .createQueryBuilder()
+      .insert()
+      .into(FeatureFlagSegmentExclusion)
+      .values(data)
+      .onConflict(`DO NOTHING`)
+      .returning('*')
+      .execute()
+      .catch((errorMsg: any) => {
+        const errorMsgString = repositoryError(
+          'FeatureFlagSegmentExclusionRepository',
+          'insertFeatureFlagSegmentExclusion',
+          { data },
+          errorMsg
+        );
+        logger.error(errorMsg);
+        throw errorMsgString;
+      });
+
+    return result.raw;
+  }
+
+  public async getFeatureFlagSegmentExclusionData(): Promise<Partial<FeatureFlagSegmentExclusion>[]> {
+    return this.createQueryBuilder('featureFlagSegmentExclusion')
+      .leftJoin('featureFlagSegmentExclusion.featureFlag', 'featureFlag')
+      .leftJoin('featureFlagSegmentExclusion.segment', 'segment')
+      .leftJoinAndSelect('segment.subSegments', 'subSegments')
+      .addSelect('featureFlag.name')
+      .addSelect('featureFlag.state')
+      .addSelect('featureFlag.context')
+      .addSelect('segment.id')
+      .getMany()
+      .catch((errorMsg: any) => {
+        const errorMsgString = repositoryError('FeatureFlagSegmentExclusion', 'getdata', {}, errorMsg);
+        throw errorMsgString;
+      });
+  }
+
+  public async deleteData(
+    segmentId: string,
+    featureFlagId: string,
+    logger: UpgradeLogger
+  ): Promise<FeatureFlagSegmentExclusion> {
+    const result = await this.createQueryBuilder()
+      .delete()
+      .from(FeatureFlagSegmentExclusion)
+      .where('segmentId=:segmentId AND featureFlagId=:featureFlagId', { segmentId, featureFlagId })
+      .returning('*')
+      .execute()
+      .catch((errorMsg: any) => {
+        const errorMsgString = repositoryError(
+          'FeatureFlagSegmentExclusionRepository',
+          'deleteFeatureFlagSegmentExclusion',
+          { segmentId, featureFlagId },
+          errorMsg
+        );
+        logger.error(errorMsg);
+        throw errorMsgString;
+      });
+
+    return result.raw;
+  }
+}

--- a/backend/packages/Upgrade/src/api/repositories/FeatureFlagSegmentInclusionRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/FeatureFlagSegmentInclusionRepository.ts
@@ -1,0 +1,74 @@
+import { Repository, EntityRepository, EntityManager } from 'typeorm';
+import repositoryError from './utils/repositoryError';
+import { UpgradeLogger } from 'src/lib/logger/UpgradeLogger';
+import { FeatureFlagSegmentInclusion } from '../models/FeatureFlagSegmentInclusion';
+
+@EntityRepository(FeatureFlagSegmentInclusion)
+export class FeatureFlagSegmentInclusionRepository extends Repository<FeatureFlagSegmentInclusion> {
+  public async insertData(
+    data: Partial<FeatureFlagSegmentInclusion>,
+    logger: UpgradeLogger,
+    entityManager: EntityManager
+  ): Promise<FeatureFlagSegmentInclusion> {
+    const result = await entityManager
+      .createQueryBuilder()
+      .insert()
+      .into(FeatureFlagSegmentInclusion)
+      .values(data)
+      .onConflict(`DO NOTHING`)
+      .returning('*')
+      .execute()
+      .catch((errorMsg: any) => {
+        const errorMsgString = repositoryError(
+          'FeatureFlagSegmentInclusionRepository',
+          'insertFeatureFlagSegmentInclusion',
+          { data },
+          errorMsg
+        );
+        logger.error(errorMsg);
+        throw errorMsgString;
+      });
+    return result.raw;
+  }
+
+  public async getFeatureFlagSegmentInclusionData(): Promise<Partial<FeatureFlagSegmentInclusion>[]> {
+    return this.createQueryBuilder('featureFlagSegmentInclusion')
+      .leftJoin('featureFlagSegmentInclusion.featureFlag', 'featureFlag')
+      .leftJoin('featureFlagSegmentInclusion.segment', 'segment')
+      .leftJoinAndSelect('segment.subSegments', 'subSegments')
+      .addSelect('featureFlag.name')
+      .addSelect('featureFlag.state')
+      .addSelect('featureFlag.context')
+      .addSelect('segment.id')
+      .getMany()
+      .catch((errorMsg: any) => {
+        const errorMsgString = repositoryError('FeatureFlagSegmentInclusion', 'getdata', {}, errorMsg);
+        throw errorMsgString;
+      });
+  }
+
+  public async deleteData(
+    segmentId: string,
+    featureFlagId: string,
+    logger: UpgradeLogger
+  ): Promise<FeatureFlagSegmentInclusion> {
+    const result = await this.createQueryBuilder()
+      .delete()
+      .from(FeatureFlagSegmentInclusion)
+      .where('segmentId=:segmentId AND featureFlagId=:featureFlagId', { segmentId, featureFlagId })
+      .returning('*')
+      .execute()
+      .catch((errorMsg: any) => {
+        const errorMsgString = repositoryError(
+          'FeatureFlagSegmentInclusionRepository',
+          'deleteFeatureFlagSegmentInclusion',
+          { segmentId, featureFlagId },
+          errorMsg
+        );
+        logger.error(errorMsg);
+        throw errorMsgString;
+      });
+
+    return result.raw;
+  }
+}

--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -84,6 +84,8 @@ import { ArchivedStatsRepository } from '../repositories/ArchivedStatsRepository
 import { validate } from 'class-validator';
 import { plainToClass } from 'class-transformer';
 import { StratificationFactorRepository } from '../repositories/StratificationFactorRepository';
+import { FeatureFlagSegmentExclusion } from '../models/FeatureFlagSegmentExclusion';
+import { FeatureFlagSegmentInclusion } from '../models/FeatureFlagSegmentInclusion';
 
 const errorRemovePart = 'instance of ExperimentDTO has failed the validation:\n - ';
 const stratificationErrorMessage =
@@ -1878,9 +1880,13 @@ export class ExperimentService {
     return { ...experiment, factors: updatedFactors, conditionPayloads: updatedConditionPayloads };
   }
 
-  private includeExcludeSegmentCreation(
+  public includeExcludeSegmentCreation(
     experimentSegment: ParticipantsValidator,
-    experimentDocSegmentData: ExperimentSegmentInclusion | ExperimentSegmentExclusion,
+    experimentDocSegmentData:
+      | ExperimentSegmentInclusion
+      | ExperimentSegmentExclusion
+      | FeatureFlagSegmentExclusion
+      | FeatureFlagSegmentInclusion,
     experimentId: string,
     context: string[],
     isIncludeMode: boolean

--- a/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
+++ b/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
@@ -4,31 +4,63 @@ import { InjectRepository } from 'typeorm-typedi-extensions';
 import { FeatureFlagRepository } from '../repositories/FeatureFlagRepository';
 import { getConnection } from 'typeorm';
 import { v4 as uuid } from 'uuid';
-import { FlagVariation } from '../models/FlagVariation';
-import { FlagVariationRepository } from '../repositories/FlagVariationRepository';
 import {
   IFeatureFlagSearchParams,
   IFeatureFlagSortParams,
-  FLAG_SEARCH_SORT_KEY,
+  FLAG_SEARCH_KEY,
 } from '../controllers/validators/FeatureFlagsPaginatedParamsValidator';
-import { SERVER_ERROR, FEATURE_FLAG_STATUS } from 'upgrade_types';
+import { SERVER_ERROR, FEATURE_FLAG_STATUS, SEGMENT_TYPE } from 'upgrade_types';
 import { UpgradeLogger } from '../../lib/logger/UpgradeLogger';
 import { FeatureFlagValidation } from '../controllers/validators/FeatureFlagValidator';
+import { FeatureFlagSegmentInclusion } from '../models/FeatureFlagSegmentInclusion';
+import { Segment } from '../models/Segment';
+import { SegmentInputValidator } from '../controllers/validators/SegmentInputValidator';
+import { ErrorWithType } from '../errors/ErrorWithType';
+import { FeatureFlagSegmentExclusion } from '../models/FeatureFlagSegmentExclusion';
+import { FeatureFlagSegmentExclusionRepository } from '../repositories/FeatureFlagSegmentExclusionRepository';
+import { FeatureFlagSegmentInclusionRepository } from '../repositories/FeatureFlagSegmentInclusionRepository';
+import { SegmentService } from './SegmentService';
+import { ExperimentService } from './ExperimentService';
 
 @Service()
 export class FeatureFlagService {
   constructor(
     @InjectRepository() private featureFlagRepository: FeatureFlagRepository,
-    @InjectRepository() private flagVariationRepository: FlagVariationRepository
+    @InjectRepository() private featureFlagSegmentInclusionRepository: FeatureFlagSegmentInclusionRepository,
+    @InjectRepository() private featureFlagSegmentExclusionRepository: FeatureFlagSegmentExclusionRepository,
+    public segmentService: SegmentService,
+    public experimentService: ExperimentService
   ) {}
 
   public find(logger: UpgradeLogger): Promise<FeatureFlag[]> {
     logger.info({ message: 'Get all feature flags' });
-    return this.featureFlagRepository.find({ relations: ['variations'] });
+    return this.featureFlagRepository.find();
+  }
+
+  public async findOne(id: string, logger?: UpgradeLogger): Promise<FeatureFlag | undefined> {
+    if (logger) {
+      logger.info({ message: `Find feature flag by id => ${id}` });
+    }
+    const featureFlag = await this.featureFlagRepository
+      .createQueryBuilder('feature_flag')
+      .leftJoinAndSelect('feature_flag.featureFlagSegmentInclusion', 'featureFlagSegmentInclusion')
+      .leftJoinAndSelect('featureFlagSegmentInclusion.segment', 'segmentInclusion')
+      .leftJoinAndSelect('segmentInclusion.individualForSegment', 'individualForSegment')
+      .leftJoinAndSelect('segmentInclusion.groupForSegment', 'groupForSegment')
+      .leftJoinAndSelect('segmentInclusion.subSegments', 'subSegment')
+      .leftJoinAndSelect('feature_flag.featureFlagSegmentExclusion', 'featureFlagSegmentExclusion')
+      .leftJoinAndSelect('featureFlagSegmentExclusion.segment', 'segmentExclusion')
+      .leftJoinAndSelect('segmentExclusion.individualForSegment', 'individualForSegmentExclusion')
+      .leftJoinAndSelect('segmentExclusion.groupForSegment', 'groupForSegmentExclusion')
+      .leftJoinAndSelect('segmentExclusion.subSegments', 'subSegmentExclusion')
+      .where({ id })
+      .getOne();
+
+    return featureFlag;
   }
 
   public create(flagDTO: FeatureFlagValidation, logger: UpgradeLogger): Promise<FeatureFlag> {
-    logger.info({ message: 'Create a new feature flag' });
+    logger.info({ message: 'Create a new feature flag', details: flagDTO });
     return this.addFeatureFlagInDB(this.featureFlagValidatorToFlag(flagDTO), logger);
   }
 
@@ -45,9 +77,7 @@ export class FeatureFlagService {
   ): Promise<FeatureFlag[]> {
     logger.info({ message: 'Find paginated Feature flags' });
 
-    let queryBuilder = this.featureFlagRepository
-      .createQueryBuilder('feature_flag')
-      .innerJoinAndSelect('feature_flag.variations', 'variations');
+    let queryBuilder = this.featureFlagRepository.createQueryBuilder('feature_flag');
     if (searchParams) {
       const customSearchString = searchParams.string.split(' ').join(`:*&`);
       // add search query
@@ -69,7 +99,6 @@ export class FeatureFlagService {
     logger.info({ message: `Delete Feature Flag => ${featureFlagId}` });
     const featureFlag = await this.featureFlagRepository.find({
       where: { id: featureFlagId },
-      relations: ['variations'],
     });
 
     if (featureFlag) {
@@ -96,8 +125,9 @@ export class FeatureFlagService {
   private async addFeatureFlagInDB(flag: FeatureFlag, logger: UpgradeLogger): Promise<FeatureFlag> {
     const createdFeatureFlag = await getConnection().transaction(async (transactionalEntityManager) => {
       flag.id = uuid();
-      const { variations, ...flagDoc } = flag;
-      // saving experiment doc
+      // saving feature flag doc
+      const { featureFlagSegmentExclusion, featureFlagSegmentInclusion, ...flagDoc } = flag;
+
       let featureFlagDoc: FeatureFlag;
       try {
         featureFlagDoc = (
@@ -110,36 +140,120 @@ export class FeatureFlagService {
         throw error;
       }
 
-      // creating variations docs
-      const variationDocsToSave =
-        variations &&
-        variations.length > 0 &&
-        variations.map((variation: FlagVariation) => {
-          variation.id = variation.id || uuid();
-          variation.featureFlag = featureFlagDoc;
-          return variation;
-        });
+      const setSegmentInEx = (inEx: FeatureFlagSegmentExclusion | FeatureFlagSegmentInclusion) => {
+        const segment = inEx.segment;
+        return segment
+          ? {
+              ...featureFlagSegmentInclusion.segment,
+              type: segment.type,
+              userIds: segment.individualForSegment?.map((x) => x.userId) || [],
+              groups:
+                segment.groupForSegment?.map((x) => {
+                  return { type: x.type, groupId: x.groupId };
+                }) || [],
+              subSegmentIds: segment.subSegments?.map((x) => x.id) || [],
+            }
+          : inEx;
+      };
 
-      // saving variations
-      let variationDocs: FlagVariation[];
+      let includeSegmentExists = true;
+      let segmentIncludeDoc: Segment;
+      let segmentIncludeDocToSave: Partial<FeatureFlagSegmentInclusion> = {};
+      if (featureFlagSegmentInclusion) {
+        const segmentInclude: any = setSegmentInEx(featureFlagSegmentInclusion);
+
+        const segmentIncludeData: SegmentInputValidator = {
+          ...segmentInclude,
+          id: segmentInclude.id || uuid(),
+          name: flagDoc.id + ' Inclusion Segment',
+          description: flagDoc.id + ' Inclusion Segment',
+          context: flagDoc.context[0],
+          type: SEGMENT_TYPE.PRIVATE,
+        };
+        try {
+          segmentIncludeDoc = await this.segmentService.upsertSegment(segmentIncludeData, logger);
+        } catch (err) {
+          const error = err as ErrorWithType;
+          error.details = 'Error in adding segment in DB';
+          error.type = SERVER_ERROR.QUERY_FAILED;
+          logger.error(error);
+          throw error;
+        }
+        // creating segmentInclude doc
+        const includeTempDoc = new FeatureFlagSegmentInclusion();
+        includeTempDoc.segment = segmentIncludeDoc;
+        includeTempDoc.featureFlag = flag;
+        segmentIncludeDocToSave = this.getSegmentDoc(includeTempDoc);
+      } else {
+        includeSegmentExists = false;
+      }
+
+      let excludeSegmentExists = true;
+      let segmentExcludeDoc: Segment;
+      let segmentExcludeDocToSave: Partial<FeatureFlagSegmentExclusion> = {};
+      if (featureFlagSegmentExclusion) {
+        const segmentExclude: any = setSegmentInEx(featureFlagSegmentExclusion);
+
+        const segmentExcludeData: SegmentInputValidator = {
+          ...segmentExclude,
+          id: segmentExclude.id || uuid(),
+          name: flagDoc.id + ' Exclusion Segment',
+          description: flagDoc.id + ' Exclusion Segment',
+          context: flagDoc.context[0],
+          type: SEGMENT_TYPE.PRIVATE,
+        };
+        try {
+          segmentExcludeDoc = await this.segmentService.upsertSegment(segmentExcludeData, logger);
+        } catch (err) {
+          const error = err as ErrorWithType;
+          error.details = 'Error in adding segment in DB';
+          error.type = SERVER_ERROR.QUERY_FAILED;
+          logger.error(error);
+          throw error;
+        }
+        // creating segmentInclude doc
+        const excludeTempDoc = new FeatureFlagSegmentExclusion();
+        excludeTempDoc.segment = segmentExcludeDoc;
+        excludeTempDoc.featureFlag = flag;
+        segmentExcludeDocToSave = this.getSegmentDoc(excludeTempDoc);
+      } else {
+        excludeSegmentExists = false;
+      }
+      let featureFlagSegmentInclusionDoc: FeatureFlagSegmentInclusion;
+      let featureFlagSegmentExclusionDoc: FeatureFlagSegmentExclusion;
+
       try {
-        variationDocs = await this.flagVariationRepository.insertVariations(
-          variationDocsToSave,
-          transactionalEntityManager
-        );
+        [featureFlagSegmentInclusionDoc, featureFlagSegmentExclusionDoc] = await Promise.all([
+          includeSegmentExists
+            ? this.featureFlagSegmentInclusionRepository.insertData(
+                segmentIncludeDocToSave,
+                logger,
+                transactionalEntityManager
+              )
+            : (Promise.resolve([]) as any),
+          excludeSegmentExists
+            ? this.featureFlagSegmentExclusionRepository.insertData(
+                segmentExcludeDocToSave,
+                logger,
+                transactionalEntityManager
+              )
+            : (Promise.resolve([]) as any),
+        ]);
       } catch (err) {
-        const error = new Error(`Error in creating variation "addFeatureFlagInDB" ${err}`);
-        (error as any).type = SERVER_ERROR.QUERY_FAILED;
+        const error = err as Error;
+        error.message = `Error in creating inclusion or exclusion segments "addFeatureFlagInDB"`;
         logger.error(error);
         throw error;
       }
 
-      const variationDocToReturn = variationDocs.map((variationDoc) => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { featureFlagId, ...rest } = variationDoc as any;
-        return rest;
-      });
-      return { ...featureFlagDoc, variations: variationDocToReturn as any };
+      const newFeatureFlagObject = {
+        ...featureFlagDoc,
+        featureFlagSegmentInclusion: { ...featureFlagSegmentInclusionDoc, segment: segmentIncludeDoc } as any,
+        featureFlagSegmentExclusion: { ...featureFlagSegmentExclusionDoc, segment: segmentExcludeDoc } as any,
+      };
+
+      // return { ...featureFlagDoc, variations: variationDocToReturn as any };
+      return newFeatureFlagObject;
     });
 
     // TODO: Add log for feature flag creation
@@ -148,15 +262,18 @@ export class FeatureFlagService {
 
   private async updateFeatureFlagInDB(flag: FeatureFlag, logger: UpgradeLogger): Promise<FeatureFlag> {
     // get old feature flag document
-    const oldFeatureFlag = await this.featureFlagRepository.find({
-      where: { id: flag.id },
-      relations: ['variations'],
-    });
-    const oldVariations = oldFeatureFlag[0].variations;
+    const oldFeatureFlag = await this.findOne(flag.id);
 
     return getConnection().transaction(async (transactionalEntityManager) => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { variations, versionNumber, createdAt, updatedAt, ...flagDoc } = flag;
+      const {
+        featureFlagSegmentExclusion,
+        featureFlagSegmentInclusion,
+        versionNumber,
+        createdAt,
+        updatedAt,
+        ...flagDoc
+      } = flag;
       let featureFlagDoc: FeatureFlag;
       try {
         featureFlagDoc = (await this.featureFlagRepository.updateFeatureFlag(flagDoc, transactionalEntityManager))[0];
@@ -166,92 +283,72 @@ export class FeatureFlagService {
         logger.error(error);
         throw error;
       }
+      featureFlagDoc.featureFlagSegmentInclusion = oldFeatureFlag.featureFlagSegmentInclusion;
+      const segmentIncludeData = this.experimentService.includeExcludeSegmentCreation(
+        featureFlagSegmentInclusion,
+        featureFlagDoc.featureFlagSegmentInclusion,
+        flag.id,
+        flag.context,
+        true
+      );
 
-      // creating variations docs
-      const variationDocToSave: Array<Partial<FlagVariation>> =
-        (variations &&
-          variations.length > 0 &&
-          variations.map((variation: FlagVariation) => {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const { createdAt, updatedAt, versionNumber, ...rest } = variation;
-            rest.featureFlag = featureFlagDoc;
-            rest.id = rest.id || uuid();
-            return rest;
-          })) ||
-        [];
+      featureFlagDoc.featureFlagSegmentExclusion = oldFeatureFlag.featureFlagSegmentExclusion;
+      const segmentExcludeData = this.experimentService.includeExcludeSegmentCreation(
+        featureFlagSegmentExclusion,
+        featureFlagDoc.featureFlagSegmentExclusion,
+        flag.id,
+        flag.context,
+        false
+      );
 
-      // delete variations which don't exist in new  feature flag document
-      const toDeleteVariations = [];
-      oldVariations.forEach(({ id }) => {
-        if (
-          !variationDocToSave.find((doc) => {
-            return doc.id === id;
-          })
-        ) {
-          toDeleteVariations.push(this.flagVariationRepository.deleteVariation(id, transactionalEntityManager));
-        }
-      });
-
-      // delete old variations
-      await Promise.all(toDeleteVariations);
-
-      // saving variations
-      let variationDocs: FlagVariation[];
+      let segmentIncludeDoc: Segment;
       try {
-        [variationDocs] = await Promise.all([
-          Promise.all(
-            variationDocToSave.map(async (variationDoc) => {
-              return this.flagVariationRepository.upsertFlagVariation(variationDoc, transactionalEntityManager);
-            })
-          ) as any,
-        ]);
+        segmentIncludeDoc = await this.segmentService.upsertSegment(segmentIncludeData, logger);
       } catch (err) {
-        const error = new Error(`Error in creating variations "updateFeatureFlagInDB" ${err}`);
-        (error as any).type = SERVER_ERROR.QUERY_FAILED;
+        const error = err as ErrorWithType;
+        error.details = 'Error in updating IncludeSegment in DB';
+        error.type = SERVER_ERROR.QUERY_FAILED;
         logger.error(error);
         throw error;
       }
 
-      const variationDocToReturn = variationDocs.map((variationDoc) => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { featureFlagId, ...rest } = variationDoc as any;
-        return { ...rest, featureFlag: variationDoc.featureFlag };
-      });
+      let segmentExcludeDoc: Segment;
+      try {
+        segmentExcludeDoc = await this.segmentService.upsertSegment(segmentExcludeData, logger);
+      } catch (err) {
+        const error = err as ErrorWithType;
+        error.details = 'Error in updating ExcludeSegment in DB';
+        error.type = SERVER_ERROR.QUERY_FAILED;
+        logger.error(error);
+        throw error;
+      }
 
-      const newFeatureFlag = {
-        ...featureFlagDoc,
-        variations: variationDocToReturn as any,
-      };
-
-      // add log of diff of new and old feature flag doc
-      return newFeatureFlag;
+      featureFlagDoc.featureFlagSegmentInclusion.segment = segmentIncludeDoc;
+      featureFlagDoc.featureFlagSegmentExclusion.segment = segmentExcludeDoc;
+      return featureFlagDoc;
     });
   }
 
-  private postgresSearchString(type: FLAG_SEARCH_SORT_KEY): string {
+  private postgresSearchString(type: FLAG_SEARCH_KEY): string {
     const searchString: string[] = [];
     switch (type) {
-      case FLAG_SEARCH_SORT_KEY.NAME:
+      case FLAG_SEARCH_KEY.NAME:
         searchString.push("coalesce(feature_flag.name::TEXT,'')");
-        searchString.push("coalesce(variations.value::TEXT,'')");
         break;
-      case FLAG_SEARCH_SORT_KEY.KEY:
+      case FLAG_SEARCH_KEY.KEY:
         searchString.push("coalesce(feature_flag.key::TEXT,'')");
         break;
-      case FLAG_SEARCH_SORT_KEY.STATUS:
+      case FLAG_SEARCH_KEY.STATUS:
         searchString.push("coalesce(feature_flag.status::TEXT,'')");
         break;
-      case FLAG_SEARCH_SORT_KEY.VARIATION_TYPE:
-        // TODO: Update column name
-        // searchString.push("coalesce(feature_flag.variationType::TEXT,'')");
+      case FLAG_SEARCH_KEY.CONTEXT:
+        searchString.push("coalesce(feature_flag.context::TEXT,'')");
         break;
       default:
         searchString.push("coalesce(feature_flag.name::TEXT,'')");
-        searchString.push("coalesce(variations.value::TEXT,'')");
         searchString.push("coalesce(feature_flag.key::TEXT,'')");
         searchString.push("coalesce(feature_flag.status::TEXT,'')");
-        // TODO: Update column name
-        // searchString.push("coalesce(feature_flag.variationType::TEXT,'')");
+        searchString.push("coalesce(feature_flag.context::TEXT,'')");
         break;
     }
     const stringConcat = searchString.join(',');
@@ -266,6 +363,18 @@ export class FeatureFlagService {
     featureFlag.id = flagDTO.id;
     featureFlag.key = flagDTO.key;
     featureFlag.status = flagDTO.status;
+    featureFlag.context = flagDTO.context;
+    featureFlag.tags = flagDTO.tags;
+    const newExclusion = new FeatureFlagSegmentExclusion();
+    const newInclusion = new FeatureFlagSegmentInclusion();
+    featureFlag.featureFlagSegmentExclusion = { ...flagDTO.featureFlagSegmentExclusion, ...newExclusion };
+    featureFlag.featureFlagSegmentInclusion = { ...flagDTO.featureFlagSegmentInclusion, ...newInclusion };
     return featureFlag;
+  }
+
+  private getSegmentDoc(doc: FeatureFlagSegmentInclusion | FeatureFlagSegmentExclusion) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { createdAt, updatedAt, versionNumber, ...newDoc } = doc;
+    return newDoc;
   }
 }


### PR DESCRIPTION
Adds (or updates) the following endpoints:

GET /flags
- get all feature flags

POST /flags
- create feature flag

GET /flags/{id}
- get flag by id

DELETE /flags/{id}
- delete flag by id

PUT /flags/{id}
- update flag by id

POST  /flags/paginated
- get all flags paginated

POST  /flags/status
- update flag status

The request (for POST and PUT) and response bodies for these endpoints can be viewed by looking at the swagger page.