### PR TITLE
add google client id in env files

### DIFF
--- a/backend/packages/Upgrade/.env.docker.local
+++ b/backend/packages/Upgrade/.env.docker.local
@@ -64,7 +64,7 @@ MONITOR_PASSWORD=1234
 #
 # Google Client Id
 #
-GOOGLE_CLIENT_ID=google_project_id
+GOOGLE_CLIENT_ID=135765367152-pq4jhd3gra10jda9l6bpnmu9gqt48tup.apps.googleusercontent.com
 DOMAIN_NAME =
 SCHEDULER_STEP_FUNCTION=arn:aws:states:us-east-1:781188149671:stateMachine:development-upgrade-experiment-scheduler
 AWS_REGION=us-east-1

--- a/backend/packages/Upgrade/.env.example
+++ b/backend/packages/Upgrade/.env.example
@@ -63,7 +63,7 @@ MONITOR_PASSWORD=1234
 #
 # Google Client Id
 #
-GOOGLE_CLIENT_ID=google_project_id
+GOOGLE_CLIENT_ID=135765367152-pq4jhd3gra10jda9l6bpnmu9gqt48tup.apps.googleusercontent.com
 DOMAIN_NAME =
 SCHEDULER_STEP_FUNCTION=arn:aws:states:us-east-1:781188149671:stateMachine:development-upgrade-experiment-scheduler
 # SCHEDULER_STEP_FUNCTION=arn:aws:states:us-east-1:781188149671:stateMachine:staging-upgrade-experiment-scheduler

--- a/backend/packages/Upgrade/.env.test
+++ b/backend/packages/Upgrade/.env.test
@@ -65,7 +65,7 @@ MONITOR_PASSWORD=<replaceme>
 #
 # Google Client Id
 #
-GOOGLE_CLIENT_ID=google_project_id
+GOOGLE_CLIENT_ID=135765367152-pq4jhd3gra10jda9l6bpnmu9gqt48tup.apps.googleusercontent.com
 DOMAIN_NAME =
 SCHEDULER_STEP_FUNCTION=arn:aws:states:us-east-1:781188149671:stateMachine:development-upgrade-experiment-scheduler
 # SCHEDULER_STEP_FUNCTION=arn:aws:states:us-east-1:781188149671:stateMachine:staging-upgrade-experiment-scheduler


### PR DESCRIPTION
This PR is created to add google client id in env files, to fix auth fail which is made mandatory in last audit log PR.
All devs have to add same change in there personal `.env` file to avoid auth fail. 