### PR TITLE
Snackbar issue for experiment status update resolved

### DIFF
--- a/frontend/projects/upgrade/src/app/core/experiments/store/experiments.effects.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/store/experiments.effects.ts
@@ -182,10 +182,16 @@ export class ExperimentEffects {
       filter(({ experimentId, experimentState }) => !!experimentId && !!experimentState),
       switchMap(({ experimentId, experimentState }) =>
         this.experimentDataService.updateExperimentState(experimentId, experimentState).pipe(
-          switchMap((result: Experiment) => [
-            experimentAction.actionUpdateExperimentStateSuccess({ experiment: result }),
-          ]),
-          catchError(() => [experimentAction.actionUpdateExperimentStateFailure()])
+          switchMap((result: Experiment) => {
+            this.notificationService.showSuccess(
+              this.translate.instant('home.change-experiment-status.change-confirmation.text')
+            );
+            return [experimentAction.actionUpdateExperimentStateSuccess({ experiment: result })];
+          }),
+          catchError((error) => {
+            this.notificationService.showError(error.message);
+            return [experimentAction.actionUpdateExperimentStateFailure()];
+          })
         )
       )
     )

--- a/frontend/projects/upgrade/src/assets/i18n/en.json
+++ b/frontend/projects/upgrade/src/assets/i18n/en.json
@@ -274,6 +274,7 @@
   "home.change-experiment-status.enrolling-info.text": "*Once the experiment is started you won’t be allowed to update Experiment’s Condition and Sites",
   "home.change-experiment-status.enrolling-error.text": "*Experiment start date should not be greater than experiment end date {{ endDate }}",
   "home.change-experiment-status.condition-count-error.text": "*Please have at least 2 conditions to move forward",
+  "home.change-experiment-status.change-confirmation.text": "Experiment status is updated successfully!",
   "home.change-experiment-status.archiving-confirmation.text": "Please acknowledge that you agree to permanently transition this experiment to archive status.",
   "home.change-experiment-status.archiving-info.text": "*Archiving the experiment will cancel the post rule. The archived experiments are hidden from the experiment list and can be found by explicitly searching for 'Archived' experiments.",
   "home.change-post-experiment-rule.title.text": "Change Post Experiment Condition",


### PR DESCRIPTION
This PR addresses the issue of the snack bar not showing up after the experiment status gets updated.