### PR TITLE
Schedule date not visible in experiment details page 

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
@@ -137,6 +137,9 @@
                     <span class="ft-18-700 section-data-value">{{ experiment.state | experimentState }}</span>
                   </ng-template>
                 </div>
+                <span class="experiment-schedule ft-10-400" *ngIf="experiment.state === ExperimentState.SCHEDULED && experiment.startOn !== null">
+                  {{ '(' + (experiment.startOn | date: 'MMM d, y h:mm a') + ')' }}
+                </span>
               </div>
 
               <!-- Experiment post experiment rule -->

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
@@ -137,9 +137,13 @@
                     <span class="ft-18-700 section-data-value">{{ experiment.state | experimentState }}</span>
                   </ng-template>
                 </div>
-                <span class="experiment-schedule ft-10-400" *ngIf="experiment.state === ExperimentState.SCHEDULED && experiment.startOn !== null">
-                  {{ '(' + (experiment.startOn | date: 'MMM d, y h:mm a') + ')' }}
-                </span>
+                <div class="section-data-schedule-date">
+                  <ng-container *ngIf="experiment.state === ExperimentState.SCHEDULED && experiment.startOn !== null">
+                    <span class="ft-12-600">
+                      {{ '(' + (experiment.startOn | date: 'MMM d, y h:mm a') + ')' }}
+                    </span>
+                  </ng-container>
+                </div>
               </div>
 
               <!-- Experiment post experiment rule -->

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.scss
@@ -151,6 +151,10 @@ $font-size-small: 15px;
               }
             }
 
+            &-schedule-date {
+              color: var(--grey-3);
+            }
+
             &.end-criteria-container {
               .end-criteria-underline {
                 &--blue {


### PR DESCRIPTION
This PR fixes the issue of the scheduled date not being visible on the experiment details page.