### PR TITLE
Update Ending Criteria text style on details page

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
@@ -273,7 +273,7 @@
                 >
                   <!-- if we have custom ending criteria -->
                   <ng-container *ngIf="experiment.enrollmentCompleteCondition as endCondition">
-                    <span class="ft-18-700 end-criteria end-criteria--text"> ( </span>
+                    <span class="ft-18-700 end-criteria end-criteria--text"></span>
                     <span
                       *ngIf="
                         permissions?.experiments.update && !isExperimentStateCancelled && experiment.state !== ExperimentState.ARCHIVED;
@@ -325,7 +325,7 @@
                       </span>
                     </ng-template>
 
-                    <span class="ft-18-700 end-criteria end-criteria--text"> ) </span>
+                    <span class="ft-18-700 end-criteria end-criteria--text"></span>
                     <mat-icon class="edit-icon" *ngIf="permissions?.experiments.update && !isExperimentStateCancelled && experiment.state !== ExperimentState.ARCHIVED">
                       create
                     </mat-icon>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.scss
@@ -186,8 +186,8 @@ $font-size-small: 15px;
 
               .edit-icon {
                 position: relative;
-                top: 5px;
-                margin-left: 5px;
+                top: 2px;
+                margin-left: 8px;
                 width: 18px;
                 height: 18px;
                 font-size: var(--text-size-x-large);


### PR DESCRIPTION
This PR just makes the Ending Criteria text (removed parenthesis) and edit-icon (repositioned) on the details page look better and more consistent.

## Before:
<img width="750" alt="Screenshot 2024-05-01 at 4 57 51 PM" src="https://github.com/CarnegieLearningWeb/UpGrade/assets/90279765/68723f8c-6554-447c-9782-04a62dd02850">

## After:
<img width="750" alt="Screenshot 2024-05-01 at 4 57 06 PM" src="https://github.com/CarnegieLearningWeb/UpGrade/assets/90279765/480037a5-fc06-4595-8098-0311ec723b4f">
