### PR TITLE
Remove unused relation in Experiment Assignment Service

### DIFF
--- a/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
@@ -218,7 +218,7 @@ export class ExperimentAssignmentService {
       where: {
         site: site,
         target: target,
-        user: userId,
+        user: userDoc,
       },
     });
     if (experimentId && experiments.length) {

--- a/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
@@ -220,7 +220,6 @@ export class ExperimentAssignmentService {
         target: target,
         user: userId,
       },
-      relations: ['user'],
     });
     if (experimentId && experiments.length) {
       const selectedExperimentDP = dpExperiments.find((dp) => dp.experiment.id === experimentId);


### PR DESCRIPTION
Improve Monitored-Decision-Point query by removing unnecessory relations.