### PR TITLE
Remove Ghost Header Element and Unnecessary Styling Adjustments

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/common/tabs-view.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/common/tabs-view.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   box-shadow: unset !important;
   background: unset !important;
-  padding: 0 2.75rem 2.75rem;
+  padding: 25px 2.75rem 2.75rem;
 
   .title {
     margin-bottom: 0;

--- a/frontend/projects/upgrade/src/app/features/dashboard/dashboard-root/dashboard-root.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/dashboard-root/dashboard-root.component.html
@@ -41,8 +41,7 @@
       </div>
     </div>
   </mat-drawer>
-  <mat-drawer-content class="drawer__main-content">
-    <div class="drawer__main-content-header"></div>
+  <mat-drawer-content>
     <router-outlet></router-outlet>
   </mat-drawer-content>
 </mat-drawer-container>

--- a/frontend/projects/upgrade/src/app/features/dashboard/dashboard-root/dashboard-root.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/dashboard-root/dashboard-root.component.scss
@@ -109,15 +109,6 @@ mat-drawer {
   }
 }
 
-.drawer__main-content {
-  &-header {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    height: 25px;
-  }
-}
-
 .version {
   display: flex;
   flex-direction: column;

--- a/frontend/projects/upgrade/src/app/features/dashboard/dashboard-root/dashboard-root.theme.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/dashboard-root/dashboard-root.theme.scss
@@ -20,8 +20,4 @@
       }
     }
   }
-
-  .drawer__main-content {
-    background-color: mat.get-color-from-palette($background, background);
-  }
 }

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiment-users/experiment-users-root/experiment-users-root.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiment-users/experiment-users-root/experiment-users-root.component.scss
@@ -2,5 +2,5 @@
 @import '../../common/tabs-view.scss';
 
 .users-container {
-  height: calc(100% - 25px); // Subtract header height
+  height: 100%;
 }

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags-legacy/feature-flags-root/feature-flags-root.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags-legacy/feature-flags-root/feature-flags-root.component.scss
@@ -3,8 +3,8 @@
   flex-direction: column;
   box-shadow: unset;
   background: unset;
-  padding: 0 2.75rem 2.75rem;
-  height: calc(100% - 25px); // Subtract theme selector's height
+  padding: 25px 2.75rem 2.75rem;
+  height: 100%;
 
   .title {
     margin-bottom: 0;

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags-legacy/pages/view-feature-flag/view-feature-flag.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags-legacy/pages/view-feature-flag/view-feature-flag.component.scss
@@ -3,7 +3,7 @@ $font-size-small: 15px;
 
 .flag-container {
   box-shadow: unset !important;
-  padding: 0 2.75rem 2.75rem;
+  padding: 25px 2.75rem 2.75rem;
 
   .flag-link {
     text-decoration: none;

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.scss
@@ -2,7 +2,7 @@ $dark-grey-text-color: #646e7b;
 $font-size-small: 15px;
 
 .experiment-container {
-  padding: 0 2.75rem 2.75rem;
+  padding: 25px 2.75rem 2.75rem;
   box-shadow: 0px 0px #888888 !important;
 
   .experiment-link {

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/root/home.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/root/home.component.scss
@@ -3,8 +3,8 @@
   flex-direction: column;
   box-shadow: unset;
   background: unset;
-  padding: 0 2.75rem 2.75rem;
-  height: calc(100% - 25px); // Subtract theme selector's height
+  padding: 25px 2.75rem 2.75rem;
+  height: 100%;
 
   .title {
     margin-bottom: 0;

--- a/frontend/projects/upgrade/src/app/features/dashboard/logs/root/logs.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/logs/root/logs.component.scss
@@ -1,7 +1,7 @@
 @import '../../common/tabs-view.scss';
 
 .logs-container {
-  height: calc(100% - 25px); // Subtract header height
+  height: 100%;
 
   .tabs-wrapper {
     position: relative;

--- a/frontend/projects/upgrade/src/app/features/dashboard/profile/profile-root/profile-root.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/profile/profile-root/profile-root.component.scss
@@ -1,5 +1,5 @@
 @import '../../common/tabs-view.scss';
 
 .profile-container {
-  height: calc(100% - 25px); // Subtract header height
+  height: 100%;
 }

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/view-segment/view-segment.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/view-segment/view-segment.component.scss
@@ -3,7 +3,7 @@ $font-size-small: 15px;
 
 .segment-container {
   box-shadow: unset !important;
-  padding: 0 2.75rem 2.75rem;
+  padding: 25px 2.75rem 2.75rem;
 
   .segment-link {
     text-decoration: none;

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/segments-root/segments-root.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/segments-root/segments-root.component.scss
@@ -3,8 +3,8 @@
   flex-direction: column;
   box-shadow: unset;
   background: unset;
-  padding: 0 2.75rem 2.75rem;
-  height: calc(100% - 25px); // Subtract theme selector's height
+  padding: 25px 2.75rem 2.75rem;
+  height: 100%;
 
   .title {
     margin-bottom: 0;

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-details-page-header/common-details-page-header.component.scss
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-details-page-header/common-details-page-header.component.scss
@@ -1,5 +1,4 @@
 ::ng-deep .header {
-  margin-top: -25px; // drawer__main-content-header pushes the header down by 25px
   height: 64px;
   display: flex;
   flex-direction: column;

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-page/common-page.component.scss
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-page/common-page.component.scss
@@ -2,6 +2,6 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: calc(100% - 25px); // Subtract theme selector's height
+  height: 100%;
   padding: 0 32px;
 }

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-root-page-header/common-root-page-header.component.scss
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-root-page-header/common-root-page-header.component.scss
@@ -1,6 +1,4 @@
 ::ng-deep .header {
-  // TODO: Remove the drawer__main-content-header element from dashboard-root.component.html and update the existing root page styles (e.g., height and margin in home.component.scss)
-  margin-top: -25px; // drawer__main-content-header pushes the header down by 25px
   height: 112px;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
This PR removes the ghost header element from the `dashboard-root.component.html` file and eliminates unnecessary styling adjustments for height and margin.