### PR TITLE
restore section-card-list usage and content slot in page

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-page-content.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-page-content.component.html
@@ -1,1 +1,3 @@
-
+<app-common-section-card-list>
+  <app-feature-flag-root-section-card section-card></app-feature-flag-root-section-card>
+</app-common-section-card-list>

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-page-content.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-page-content.component.ts
@@ -1,10 +1,11 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { CommonSectionCardListComponent } from '../../../../../../shared-standalone-component-lib/components';
+import { FeatureFlagRootSectionCardComponent } from '../feature-flag-root-section-card/feature-flag-root-section-card.component';
 
 @Component({
   selector: 'app-feature-flag-root-page-content',
   standalone: true,
-  imports: [CommonSectionCardListComponent],
+  imports: [CommonSectionCardListComponent, FeatureFlagRootSectionCardComponent],
   templateUrl: './feature-flag-root-page-content.component.html',
   styleUrl: './feature-flag-root-page-content.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page.component.html
@@ -1,4 +1,4 @@
 <app-common-page>
   <app-feature-flag-root-page-header header></app-feature-flag-root-page-header>
-  <app-feature-flag-root-section-card section-card></app-feature-flag-root-section-card>
+  <app-feature-flag-root-page-content content></app-feature-flag-root-page-content>
 </app-common-page>

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page.component.ts
@@ -1,13 +1,13 @@
 import { Component } from '@angular/core';
 import { CommonPageComponent } from '../../../../../shared-standalone-component-lib/components';
 import { FeatureFlagRootPageHeaderComponent } from './feature-flag-root-page-header/feature-flag-root-page-header.component';
-import { FeatureFlagRootSectionCardComponent } from './feature-flag-root-section-card/feature-flag-root-section-card.component';
+import { FeatureFlagRootPageContentComponent } from './feature-flag-root-page-content/feature-flag-root-page-content.component';
 
 @Component({
   selector: 'app-feature-flag-root-page',
   standalone: true,
   templateUrl: './feature-flag-root-page.component.html',
   styleUrl: './feature-flag-root-page.component.scss',
-  imports: [CommonPageComponent, FeatureFlagRootPageHeaderComponent, FeatureFlagRootSectionCardComponent],
+  imports: [CommonPageComponent, FeatureFlagRootPageHeaderComponent, FeatureFlagRootPageContentComponent],
 })
 export class FeatureFlagRootPageComponent {}

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-page/common-page.component.html
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-page/common-page.component.html
@@ -3,6 +3,6 @@
     <ng-content select="[header]"></ng-content>
   </header>
   <section class="content">
-    <ng-content select="[section-card]"></ng-content>
+    <ng-content select="[content]"></ng-content>
   </section>
 </div>


### PR DESCRIPTION
follow-up to deciding to keep the content area of page and section card list