### PR TITLE
Added Expand/Collapse Functionality in Common Section Card header

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card.component.html
@@ -14,19 +14,21 @@
     [showPrimaryButton]="true"
     [primaryButtonText]="'feature-flags.add-feature-flag.text' | translate"
     [menuButtonItems]="menuButtonItems"
+    [isSectionCardExpanded]="isSectionCardExpanded"
     (primaryButtonClick)="onAddFeatureFlagButtonClick()"
     (menuButtonItemClick)="onMenuButtonItemClick($event)"
     (sectionCardExpandChange)="onSectionCardExpandChange($event)"
   ></app-common-section-card-action-buttons>
 
   <!-- content -->
-  <ng-container content>
+  <ng-container content *ngIf="isSectionCardExpanded">
     <ng-container *ngIf="!(isInitialLoading$ | async); else table">
       <mat-spinner></mat-spinner>
     </ng-container>
 
     <ng-template #table>
-      <app-feature-flag-root-section-card-table class="full-width"
+      <app-feature-flag-root-section-card-table
+        class="full-width"
         [dataSource$]="allFeatureFlags$"
         [isLoading$]="isLoadingFeatureFlags$"
       ></app-feature-flag-root-section-card-table>

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card.component.ts
@@ -36,6 +36,7 @@ export class FeatureFlagRootSectionCardComponent {
   isInitialLoading$ = this.featureFlagService.isInitialFeatureFlagsLoading$;
   allFeatureFlags$ = this.featureFlagService.allFeatureFlags$;
   isAllFlagsFetched$ = this.featureFlagService.isAllFlagsFetched$;
+  isSectionCardExpanded = true;
 
   menuButtonItems: IMenuButtonItem[] = [
     {
@@ -69,5 +70,6 @@ export class FeatureFlagRootSectionCardComponent {
 
   onSectionCardExpandChange(isSectionCardExpanded: boolean) {
     console.log('onSectionCardExpandChange:', isSectionCardExpanded);
+    this.isSectionCardExpanded = isSectionCardExpanded;
   }
 }

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card/common-section-card.component.scss
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card/common-section-card.component.scss
@@ -19,7 +19,7 @@
     justify-content: center;
     align-items: center;
     width: 100%;
-    min-height: 200px;
+    min-height: 10px;
   }
 
   .footer {


### PR DESCRIPTION
This PR resolves issue: #1580 

Using 'isSectionCardExpanded' property to conditionally display the content