### PR TITLE
Description should not be required for posting flag

### DIFF
--- a/backend/packages/Upgrade/src/api/controllers/validators/FeatureFlagValidator.ts
+++ b/backend/packages/Upgrade/src/api/controllers/validators/FeatureFlagValidator.ts
@@ -14,8 +14,7 @@ export class FeatureFlagValidation {
   @IsString()
   name: string;
 
-  @IsNotEmpty()
-  @IsDefined()
+  @IsOptional()
   @IsString()
   description: string;
 


### PR DESCRIPTION
Refactored feature flag validator to make 'description' optional