### PR TITLE
detect change on chipClass and update chipText on change

### DIFF
--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-status-indicator-chip/common-status-indicator-chip.component.ts
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-status-indicator-chip/common-status-indicator-chip.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, SimpleChanges } from '@angular/core';
 import { MatChipsModule } from '@angular/material/chips';
 import { TranslateModule } from '@ngx-translate/core';
 import { STATUS_INDICATOR_CHIP_TYPE } from 'upgrade_types';
@@ -28,6 +28,12 @@ export class CommonStatusIndicatorChipComponent {
 
   ngOnInit() {
     this.chipText = this.convertKebabToTitleCase(this.chipClass);
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.chipClass && changes.chipClass.currentValue) {
+      this.chipText = this.convertKebabToTitleCase(changes.chipClass.currentValue);
+    }
   }
 
   convertKebabToTitleCase(kebabCaseStr: STATUS_INDICATOR_CHIP_TYPE): string {


### PR DESCRIPTION
This PR will fix the chipText issue in the feature flag's status indicator not getting updated on the enable button toggle. 
![image](https://github.com/CarnegieLearningWeb/UpGrade/assets/50392803/ac6710ac-46f1-42ce-93d3-d3d1cbcd984a)
