### PR TITLE
Bugfix/throw toggle around experiment metrics view with warning msg

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ab_testing_backend",
-    "version": "5.1.15",
+    "version": "5.1.16",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "ab_testing_backend",
-            "version": "5.1.15",
+            "version": "5.1.16",
             "license": "ISC",
             "dependencies": {
                 "dayjs": "^1.11.10",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ab_testing_backend",
-    "version": "5.1.15",
+    "version": "5.1.16",
     "description": "Backend for A/B Testing Project",
     "scripts": {
         "install:all": "npm ci && cd packages/Scheduler && npm ci && cd ../Upgrade && npm ci",

--- a/backend/packages/Scheduler/package-lock.json
+++ b/backend/packages/Scheduler/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppl-upgrade-serverless",
-  "version": "5.1.15",
+  "version": "5.1.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppl-upgrade-serverless",
-      "version": "5.1.15",
+      "version": "5.1.16",
       "license": "MIT",
       "dependencies": {
         "jsonwebtoken": "^9.0.0",

--- a/backend/packages/Scheduler/package.json
+++ b/backend/packages/Scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppl-upgrade-serverless",
-  "version": "5.1.15",
+  "version": "5.1.16",
   "description": "Serverless webpack example using Typescript",
   "main": "handler.js",
   "scripts": {

--- a/backend/packages/Upgrade/package-lock.json
+++ b/backend/packages/Upgrade/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ab_testing_backend",
-    "version": "5.1.15",
+    "version": "5.1.16",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ab_testing_backend",
-            "version": "5.1.15",
+            "version": "5.1.16",
             "license": "ISC",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.485.0",

--- a/backend/packages/Upgrade/package.json
+++ b/backend/packages/Upgrade/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ab_testing_backend",
-    "version": "5.1.15",
+    "version": "5.1.16",
     "description": "Backend for A/B Testing Project",
     "main": "index.js",
     "scripts": {

--- a/clientlibs/java/pom.xml
+++ b/clientlibs/java/pom.xml
@@ -9,7 +9,7 @@
 		at the same time that happen to rev to the same new version will be caught 
 		by a merge conflict. -->
 
-	<version>5.1.15</version>
+	<version>5.1.16</version>
 	<build>
 		<plugins>
 			<plugin>

--- a/clientlibs/js/package-lock.json
+++ b/clientlibs/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "upgrade_client_lib",
-  "version": "5.1.15",
+  "version": "5.1.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "upgrade_client_lib",
-      "version": "5.1.15",
+      "version": "5.1.16",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.4.0",

--- a/clientlibs/js/package.json
+++ b/clientlibs/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upgrade_client_lib",
-  "version": "5.1.15",
+  "version": "5.1.16",
   "description": "Client library to communicate with the Upgrade server",
   "files": [
     "dist/*"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ab-testing",
-  "version": "5.1.15",
+  "version": "5.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ab-testing",
-      "version": "5.1.15",
+      "version": "5.1.16",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ab-testing",
-  "version": "5.1.15",
+  "version": "5.1.16",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/frontend/projects/upgrade/src/app/app.module.ts
+++ b/frontend/projects/upgrade/src/app/app.module.ts
@@ -29,7 +29,10 @@ export const getEnvironmentConfig = (http: HttpClient, env: Environment) => {
       .then((config: RuntimeEnvironmentConfig) => {
         env.apiBaseUrl = config.endpointApi || config.apiBaseUrl;
         env.googleClientId = config.gapiClientId || config.googleClientId;
-        env.withinSubjectExperimentSupportToggle = config.withinSubjectExperimentSupportToggle ?? env.withinSubjectExperimentSupportToggle ?? false;
+        env.withinSubjectExperimentSupportToggle =
+          config.withinSubjectExperimentSupportToggle ?? env.withinSubjectExperimentSupportToggle ?? false;
+        env.metricAnalyticsExperimentDisplayDisabledToggle =
+          config.metricAnalyticsExperimentDisplayToggle ?? env.metricAnalyticsExperimentDisplayDisabledToggle ?? false;
       })
       .catch((error) => {
         console.log({ error });

--- a/frontend/projects/upgrade/src/app/app.module.ts
+++ b/frontend/projects/upgrade/src/app/app.module.ts
@@ -31,8 +31,8 @@ export const getEnvironmentConfig = (http: HttpClient, env: Environment) => {
         env.googleClientId = config.gapiClientId || config.googleClientId;
         env.withinSubjectExperimentSupportToggle =
           config.withinSubjectExperimentSupportToggle ?? env.withinSubjectExperimentSupportToggle ?? false;
-        env.metricAnalyticsExperimentDisplayDisabledToggle =
-          config.metricAnalyticsExperimentDisplayToggle ?? env.metricAnalyticsExperimentDisplayDisabledToggle ?? false;
+        env.metricAnalyticsExperimentDisplayToggle =
+          config.metricAnalyticsExperimentDisplayToggle ?? env.metricAnalyticsExperimentDisplayToggle ?? false;
       })
       .catch((error) => {
         console.log({ error });

--- a/frontend/projects/upgrade/src/app/core/analysis/analysis.service.spec.ts
+++ b/frontend/projects/upgrade/src/app/core/analysis/analysis.service.spec.ts
@@ -23,7 +23,7 @@ jest.mock('./store/analysis.selectors', () => ({
 
 describe('AnalysisService', () => {
   const mockStore: any = mockStateStore$;
-  let mockEnvironment: Environment = { metricAnalyticsExperimentDisplayToggle: false } as Environment;
+  let mockEnvironment: Environment = { metricAnalyticsExperimentDisplayToggle: true } as Environment;
   let service: AnalysisService;
 
   beforeEach(() => {
@@ -93,9 +93,8 @@ describe('AnalysisService', () => {
       mockEnvironment = { ...originalEnvironment };
     });
 
-    it('should dispatch executeQuery with the supplied string input array when metricAnalyticsExperimentDisplayToggle is false', () => {
-      // Mock environment with metricAnalyticsExperimentDisplayToggle as false
-      mockEnvironment = { metricAnalyticsExperimentDisplayToggle: false } as Environment;
+    it('should dispatch executeQuery with the supplied string input array when metricAnalyticsExperimentDisplayToggle is true', () => {
+      mockEnvironment = { metricAnalyticsExperimentDisplayToggle: true } as Environment;
       const mockQueryIds = ['test', 'test2'];
 
       service.executeQuery(mockQueryIds);
@@ -103,9 +102,8 @@ describe('AnalysisService', () => {
       expect(mockStore.dispatch).toHaveBeenCalledWith(actionExecuteQuery({ queryIds: mockQueryIds }));
     });
 
-    it('should not dispatch executeQuery and log a warning when metricAnalyticsExperimentDisplayToggle is true', () => {
-      // Mock environment with metricAnalyticsExperimentDisplayToggle as true
-      mockEnvironment = { metricAnalyticsExperimentDisplayToggle: true } as Environment;
+    it('should not dispatch executeQuery and log a warning when metricAnalyticsExperimentDisplayToggle is false', () => {
+      mockEnvironment = { metricAnalyticsExperimentDisplayToggle: false } as Environment;
       const mockQueryIds = ['test3', 'test4'];
 
       service.executeQuery(mockQueryIds);

--- a/frontend/projects/upgrade/src/app/core/analysis/analysis.service.spec.ts
+++ b/frontend/projects/upgrade/src/app/core/analysis/analysis.service.spec.ts
@@ -23,7 +23,7 @@ jest.mock('./store/analysis.selectors', () => ({
 
 describe('AnalysisService', () => {
   const mockStore: any = mockStateStore$;
-  let mockEnvironment: Environment = { metricAnalyticsExperimentDisplayDisabledToggle: false } as Environment;
+  let mockEnvironment: Environment = { metricAnalyticsExperimentDisplayToggle: false } as Environment;
   let service: AnalysisService;
 
   beforeEach(() => {
@@ -93,9 +93,9 @@ describe('AnalysisService', () => {
       mockEnvironment = { ...originalEnvironment };
     });
 
-    it('should dispatch executeQuery with the supplied string input array when metricAnalyticsExperimentDisplayDisabledToggle is false', () => {
-      // Mock environment with metricAnalyticsExperimentDisplayDisabledToggle as false
-      mockEnvironment = { metricAnalyticsExperimentDisplayDisabledToggle: false } as Environment;
+    it('should dispatch executeQuery with the supplied string input array when metricAnalyticsExperimentDisplayToggle is false', () => {
+      // Mock environment with metricAnalyticsExperimentDisplayToggle as false
+      mockEnvironment = { metricAnalyticsExperimentDisplayToggle: false } as Environment;
       const mockQueryIds = ['test', 'test2'];
 
       service.executeQuery(mockQueryIds);
@@ -103,9 +103,9 @@ describe('AnalysisService', () => {
       expect(mockStore.dispatch).toHaveBeenCalledWith(actionExecuteQuery({ queryIds: mockQueryIds }));
     });
 
-    it('should not dispatch executeQuery and log a warning when metricAnalyticsExperimentDisplayDisabledToggle is true', () => {
-      // Mock environment with metricAnalyticsExperimentDisplayDisabledToggle as true
-      mockEnvironment = { metricAnalyticsExperimentDisplayDisabledToggle: true } as Environment;
+    it('should not dispatch executeQuery and log a warning when metricAnalyticsExperimentDisplayToggle is true', () => {
+      // Mock environment with metricAnalyticsExperimentDisplayToggle as true
+      mockEnvironment = { metricAnalyticsExperimentDisplayToggle: true } as Environment;
       const mockQueryIds = ['test3', 'test4'];
 
       service.executeQuery(mockQueryIds);

--- a/frontend/projects/upgrade/src/app/core/analysis/analysis.service.ts
+++ b/frontend/projects/upgrade/src/app/core/analysis/analysis.service.ts
@@ -36,12 +36,12 @@ export class AnalysisService {
   }
 
   executeQuery(queryIds: string[]) {
-    if (!this.environment.metricAnalyticsExperimentDisplayDisabledToggle) {
+    if (this.environment.metricAnalyticsExperimentDisplayToggle) {
       this.store$.dispatch(AnalysisActions.actionExecuteQuery({ queryIds }));
     } else {
       console.warn(
-        'executeQuery is currently disabled via metricAnalyticsExperimentDisplayDisabledToggle:',
-        this.environment.metricAnalyticsExperimentDisplayDisabledToggle
+        'executeQuery is currently disabled via metricAnalyticsExperimentDisplayToggle:',
+        this.environment.metricAnalyticsExperimentDisplayToggle
       );
     }
   }

--- a/frontend/projects/upgrade/src/app/core/analysis/analysis.service.ts
+++ b/frontend/projects/upgrade/src/app/core/analysis/analysis.service.ts
@@ -36,7 +36,6 @@ export class AnalysisService {
   }
 
   executeQuery(queryIds: string[]) {
-    console.warn('>> store', this.store$);
     if (!this.environment.metricAnalyticsExperimentDisplayDisabledToggle) {
       this.store$.dispatch(AnalysisActions.actionExecuteQuery({ queryIds }));
     } else {

--- a/frontend/projects/upgrade/src/app/core/analysis/analysis.service.ts
+++ b/frontend/projects/upgrade/src/app/core/analysis/analysis.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
 import { AppState } from '../core.module';
 import { Store, select } from '@ngrx/store';
 import {
@@ -11,10 +11,11 @@ import {
 import * as AnalysisActions from './store/analysis.actions';
 import { UpsertMetrics } from './store/analysis.models';
 import { selectExperimentQueries } from '../experiments/store/experiments.selectors';
+import { ENV, Environment } from '../../../environments/environment-types';
 
 @Injectable()
 export class AnalysisService {
-  constructor(private store$: Store<AppState>) {}
+  constructor(private store$: Store<AppState>, @Inject(ENV) private environment: Environment) {}
 
   isMetricsLoading$ = this.store$.pipe(select(selectIsMetricsLoading));
   isQueryExecuting$ = this.store$.pipe(select(selectIsQueryExecuting));
@@ -35,7 +36,15 @@ export class AnalysisService {
   }
 
   executeQuery(queryIds: string[]) {
-    this.store$.dispatch(AnalysisActions.actionExecuteQuery({ queryIds }));
+    console.warn('>> store', this.store$);
+    if (!this.environment.metricAnalyticsExperimentDisplayDisabledToggle) {
+      this.store$.dispatch(AnalysisActions.actionExecuteQuery({ queryIds }));
+    } else {
+      console.warn(
+        'executeQuery is currently disabled via metricAnalyticsExperimentDisplayDisabledToggle:',
+        this.environment.metricAnalyticsExperimentDisplayDisabledToggle
+      );
+    }
   }
 
   experimentQueryResult$(experimentId: string) {

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
@@ -80,16 +80,11 @@
       </div>
     </div>
 
-    <mat-tab-group
-      [selectedIndex]="0"
-      [mat-stretch-tabs]="false"
-      [dynamicHeight]="true"
-      disableRipple
-    >
+    <mat-tab-group [selectedIndex]="0" [mat-stretch-tabs]="false" [dynamicHeight]="true" disableRipple>
       <mat-tab>
         <ng-template mat-tab-label>
           <span class="ft-22-600 tab-label">
-              {{ 'home.view-experiment.mattab.overview.text' | translate }}
+            {{ 'home.view-experiment.mattab.overview.text' | translate }}
           </span>
         </ng-template>
         <div class="experiment-secondary-info tab-body-container">
@@ -195,9 +190,7 @@
 
               <!-- Experiment Type-->
               <div class="section-data">
-                <span
-                  class="ft-16-600 section-data-title"
-                >
+                <span class="ft-16-600 section-data-title">
                   {{ 'home-global.design-type.text' | translate | uppercase }}
                 </span>
                 <span class="ft-18-700 section-data-value">{{ experiment.type | titlecase }} Experiment </span>
@@ -247,9 +240,7 @@
 
               <!-- Stratification Factor Assinment Algorithm -->
               <div class="section-data">
-                <span
-                  class="ft-16-600 section-data-title"
-                >
+                <span class="ft-16-600 section-data-title">
                   {{ 'home-global.assignment-algorithm.text' | translate | uppercase }}
                 </span>
                 <span class="ft-18-700 section-data-value">{{ experiment.assignmentAlgorithm | titlecase }} </span>
@@ -269,7 +260,9 @@
                     <span class="ft-18-700 end-criteria end-criteria--text"> ( </span>
                     <span
                       *ngIf="
-                        permissions?.experiments.update && !isExperimentStateCancelled && experiment.state !== ExperimentState.ARCHIVED;
+                        permissions?.experiments.update &&
+                          !isExperimentStateCancelled &&
+                          experiment.state !== ExperimentState.ARCHIVED;
                         else endingCriteriaCommonTempReadOnly
                       "
                       (click)="updateEndingCriteria()"
@@ -319,7 +312,14 @@
                     </ng-template>
 
                     <span class="ft-18-700 end-criteria end-criteria--text"> ) </span>
-                    <mat-icon class="edit-icon" *ngIf="permissions?.experiments.update && !isExperimentStateCancelled && experiment.state !== ExperimentState.ARCHIVED">
+                    <mat-icon
+                      class="edit-icon"
+                      *ngIf="
+                        permissions?.experiments.update &&
+                        !isExperimentStateCancelled &&
+                        experiment.state !== ExperimentState.ARCHIVED
+                      "
+                    >
                       create
                     </mat-icon>
                   </ng-container>
@@ -327,7 +327,12 @@
                   <!-- if we have end date -->
                   <span class="ft-18-700 end-criteria" *ngIf="experiment.endOn">
                     <ng-container
-                      *ngIf="permissions?.experiments.update && !isExperimentStateCancelled && experiment.state !== ExperimentState.ARCHIVED; else endOnReadOnly"
+                      *ngIf="
+                        permissions?.experiments.update &&
+                          !isExperimentStateCancelled &&
+                          experiment.state !== ExperimentState.ARCHIVED;
+                        else endOnReadOnly
+                      "
                     >
                       <span class="end-criteria-underline--grey" (click)="updateEndingCriteria()">
                         {{ experiment.endOn | formatDate: 'medium date' }}
@@ -346,7 +351,9 @@
                   <span
                     class="ft-18-700 end-criteria"
                     *ngIf="
-                      permissions?.experiments.update && !isExperimentStateCancelled  && experiment.state !== ExperimentState.ARCHIVED;
+                      permissions?.experiments.update &&
+                        !isExperimentStateCancelled &&
+                        experiment.state !== ExperimentState.ARCHIVED;
                       else noCriteriaTemplateReadOnly
                     "
                   >
@@ -369,8 +376,7 @@
                   {{ 'home.new-experiment.design.exclude-if-reached.text' | translate }}
                 </mat-header-cell>
                 <mat-cell *matCellDef="let data; let groupIndex = index" style="margin-left: 25px">
-                  <mat-checkbox color="primary" [checked]="data.excludeIfReached" [disabled]="true">
-                  </mat-checkbox>
+                  <mat-checkbox color="primary" [checked]="data.excludeIfReached" [disabled]="true"> </mat-checkbox>
                 </mat-cell>
               </ng-container>
 
@@ -388,14 +394,13 @@
               </div>
 
               <!-- Stratification Factor-->
-              <div class="section-data"
-              *ngIf="(experiment.assignmentAlgorithm === 'stratified random sampling')">
-                <span
-                  class="ft-16-600 section-data-title"
-                >
+              <div class="section-data" *ngIf="experiment.assignmentAlgorithm === 'stratified random sampling'">
+                <span class="ft-16-600 section-data-title">
                   {{ 'home-global.stratification-factor.text' | translate | uppercase }}
                 </span>
-                <span class="ft-18-700 section-data-value">{{ experiment.stratificationFactor.stratificationFactorName }} </span>
+                <span class="ft-18-700 section-data-value"
+                  >{{ experiment.stratificationFactor.stratificationFactorName }}
+                </span>
               </div>
             </div>
           </div>
@@ -405,10 +410,7 @@
             <span class="ft-16-600 experiment-chips-title">{{ 'global.context.text' | translate }}</span>
             <ng-container *ngFor="let context of experiment.context">
               <mat-chip>
-                <span
-                  class="ft-12-600 chip-label"
-                  (click)="searchExperiment(ExperimentSearchKey.CONTEXT, context)"
-                >
+                <span class="ft-12-600 chip-label" (click)="searchExperiment(ExperimentSearchKey.CONTEXT, context)">
                   {{ context }}
                 </span>
               </mat-chip>
@@ -420,10 +422,7 @@
             <span class="ft-16-600 experiment-chips-title">{{ 'global.tags.text' | translate }}</span>
             <ng-container *ngFor="let tag of experiment.tags">
               <mat-chip>
-                <span
-                  class="ft-12-600 chip-label"
-                  (click)="searchExperiment(ExperimentSearchKey.TAG, tag)"
-                >
+                <span class="ft-12-600 chip-label" (click)="searchExperiment(ExperimentSearchKey.TAG, tag)">
                   {{ tag }}
                 </span>
               </mat-chip>
@@ -436,7 +435,9 @@
               [checked]="experiment.logging"
               color="primary"
               (change)="toggleVerboseLogging($event)"
-              [disabled]="experiment.state === ExperimentState.CANCELLED || experiment.state === ExperimentState.ARCHIVED"
+              [disabled]="
+                experiment.state === ExperimentState.CANCELLED || experiment.state === ExperimentState.ARCHIVED
+              "
             >
               <span class="ft-16-600 checkbox-label">
                 {{ 'home.view-experiment.logging.text' | translate | uppercase }}
@@ -449,7 +450,7 @@
       <mat-tab>
         <ng-template mat-tab-label>
           <span class="ft-22-600 tab-label">
-              {{ 'home.view-experiment.mattab.design.text' | translate }}
+            {{ 'home.view-experiment.mattab.design.text' | translate }}
           </span>
         </ng-template>
         <div class="tab-body-container tab-table-body-container">
@@ -497,8 +498,7 @@
                   {{ 'home.new-experiment.design.exclude-if-reached.text' | translate }}
                 </mat-header-cell>
                 <mat-cell *matCellDef="let data; let groupIndex = index" style="margin-left: 25px">
-                  <mat-checkbox color="primary" [checked]="data.excludeIfReached" [disabled]="true">
-                  </mat-checkbox>
+                  <mat-checkbox color="primary" [checked]="data.excludeIfReached" [disabled]="true"> </mat-checkbox>
                 </mat-cell>
               </ng-container>
               <mat-header-row *matHeaderRowDef="displayedPartitionColumns"></mat-header-row>
@@ -767,7 +767,7 @@
       <mat-tab>
         <ng-template mat-tab-label>
           <span class="ft-22-600 tab-label">
-              {{ 'home.view-experiment.mattab.participants.text' | translate }}
+            {{ 'home.view-experiment.mattab.participants.text' | translate }}
           </span>
         </ng-template>
         <div class="tab-body-container tab-table-body-container">
@@ -862,7 +862,7 @@
       <mat-tab>
         <ng-template mat-tab-label>
           <span class="ft-22-600 tab-label">
-              {{ 'home.view-experiment.mattab.metrics.text' | translate }}
+            {{ 'home.view-experiment.mattab.metrics.text' | translate }}
           </span>
         </ng-template>
         <div class="tab-body-container tab-table-body-container">
@@ -925,7 +925,7 @@
       <mat-tab>
         <ng-template mat-tab-label>
           <span class="ft-22-600 tab-label">
-              {{ 'home.view-experiment.mattab.data.text' | translate }}
+            {{ 'home.view-experiment.mattab.data.text' | translate }}
           </span>
         </ng-template>
         <div class="tab-body-container">
@@ -945,7 +945,18 @@
           <ng-container *ngIf="experiment.queries.length">
             <div class="box-shadow"></div>
             <!-- Experiment queries results -->
-            <home-experiment-query-result [experiment]="experiment"></home-experiment-query-result>
+            <ng-container *ngIf="disableMetricAnalysisDisplay; else noMetricsAnalysisView">
+              <home-experiment-query-result [experiment]="experiment"></home-experiment-query-result>
+            </ng-container>
+            <ng-template #noMetricsAnalysisView>
+              <div class="disabled-analysis-view-messsage-container">
+                <mat-icon class="warning-icon" color="warn">warning</mat-icon>
+                <p class="message">
+                  {{ 'home.view-experiment.metrics-analysis-unavailable.text' | translate }}
+                </p>
+              </div>
+              <div class="box-shadow"></div>
+            </ng-template>
           </ng-container>
         </div>
       </mat-tab>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
@@ -945,7 +945,7 @@
           <ng-container *ngIf="experiment.queries.length">
             <div class="box-shadow"></div>
             <!-- Experiment queries results -->
-            <ng-container *ngIf="disableMetricAnalysisDisplay; else noMetricsAnalysisView">
+            <ng-container *ngIf="!disableMetricAnalysisDisplay; else noMetricsAnalysisView">
               <home-experiment-query-result [experiment]="experiment"></home-experiment-query-result>
             </ng-container>
             <ng-template #noMetricsAnalysisView>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
@@ -945,7 +945,7 @@
           <ng-container *ngIf="experiment.queries.length">
             <div class="box-shadow"></div>
             <!-- Experiment queries results -->
-            <ng-container *ngIf="!disableMetricAnalysisDisplay; else noMetricsAnalysisView">
+            <ng-container *ngIf="showMetricAnalysisDisplay; else noMetricsAnalysisView">
               <home-experiment-query-result [experiment]="experiment"></home-experiment-query-result>
             </ng-container>
             <ng-template #noMetricsAnalysisView>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.scss
@@ -393,6 +393,17 @@ $font-size-small: 15px;
     margin-bottom: 24px;
     padding: 10px;
   }
+
+  .disabled-analysis-view-messsage-container {
+    padding-top: 50px;
+    padding-bottom: 20px;
+    display: flex;
+    justify-content: center;
+
+    .mat-icon {
+      margin-right: 20px;
+    }
+  }
 }
 
 ::ng-deep .owl-dt-calendar-table .owl-dt-calendar-cell-selected {

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.ts
@@ -127,8 +127,8 @@ export class ViewExperimentComponent implements OnInit, OnDestroy {
     return this.experiment.state === EXPERIMENT_STATE.CANCELLED;
   }
 
-  get disableMetricAnalysisDisplay() {
-    return this.environment.metricAnalyticsExperimentDisplayDisabledToggle;
+  get showMetricAnalysisDisplay() {
+    return this.environment.metricAnalyticsExperimentDisplayToggle;
   }
 
   ngOnInit() {

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ViewEncapsulation } from '@angular/core';
+import { Component, OnInit, OnDestroy, ViewEncapsulation, Inject } from '@angular/core';
 import { ExperimentService } from '../../../../../core/experiments/experiments.service';
 import { MatDialog } from '@angular/material/dialog';
 import { ExperimentStatusComponent } from '../../components/modal/experiment-status/experiment-status.component';
@@ -33,6 +33,7 @@ import {
   FactorialConditionTableDataFromConditionPayload,
   SimpleExperimentPayloadTableRowData,
 } from '../../../../../core/experiment-design-stepper/store/experiment-design-stepper.model';
+import { ENV, Environment } from '../../../../../../environments/environment-types';
 // Used in view-experiment component only
 enum DialogType {
   CHANGE_STATUS = 'Change status',
@@ -102,7 +103,8 @@ export class ViewExperimentComponent implements OnInit, OnDestroy {
     private dialog: MatDialog,
     private authService: AuthService,
     private router: Router,
-    private _Activatedroute: ActivatedRoute
+    private _Activatedroute: ActivatedRoute,
+    @Inject(ENV) private environment: Environment
   ) {}
 
   get DialogType() {
@@ -123,6 +125,10 @@ export class ViewExperimentComponent implements OnInit, OnDestroy {
 
   get isExperimentStateCancelled() {
     return this.experiment.state === EXPERIMENT_STATE.CANCELLED;
+  }
+
+  get disableMetricAnalysisDisplay() {
+    return this.environment.metricAnalyticsExperimentDisplayDisabledToggle;
   }
 
   ngOnInit() {
@@ -276,7 +282,7 @@ export class ViewExperimentComponent implements OnInit, OnDestroy {
           statisticOperation.push(compareFn);
           statisticOperation.push(query.query.compareValue);
         }
-        const operationObject = this.queryOperations.find(op => op.value === query.query.operationType);
+        const operationObject = this.queryOperations.find((op) => op.value === query.query.operationType);
         statisticOperation.push(operationObject.viewValue);
         this.displayMetrics.push({
           metric_Key: rootKey,

--- a/frontend/projects/upgrade/src/assets/i18n/en.json
+++ b/frontend/projects/upgrade/src/assets/i18n/en.json
@@ -248,6 +248,7 @@
   "home.view-experiment.experiment-payloads.column-label.target": "TARGET",
   "home.view-experiment.experiment-payloads.column-label.condition": "CONDITION",
   "home.view-experiment.experiment-payloads.column-label.payload": "PAYLOAD",
+  "home.view-experiment.metrics-analysis-unavailable.text": "Experiment metrics analysis has been temporarily disabled in this view. This information is still available when exporting the experiment data.",
   "home.view-experiment.graph-type.text": "Type",
   "home.view-experiment.graph-conditions.text": "Conditions",
   "home.view-experiment.graph-decision-point.text": "Sites",

--- a/frontend/projects/upgrade/src/environments/environment-types.ts
+++ b/frontend/projects/upgrade/src/environments/environment-types.ts
@@ -57,7 +57,7 @@ export interface Environment {
   pollingLimit: number;
   api: APIEndpoints;
   withinSubjectExperimentSupportToggle: boolean;
-  metricAnalyticsExperimentDisplayDisabledToggle: boolean;
+  metricAnalyticsExperimentDisplayToggle: boolean;
 }
 
 export interface RuntimeEnvironmentConfig {

--- a/frontend/projects/upgrade/src/environments/environment-types.ts
+++ b/frontend/projects/upgrade/src/environments/environment-types.ts
@@ -56,7 +56,8 @@ export interface Environment {
   pollingInterval: number;
   pollingLimit: number;
   api: APIEndpoints;
-  withinSubjectExperimentSupportToggle: boolean,
+  withinSubjectExperimentSupportToggle: boolean;
+  metricAnalyticsExperimentDisplayDisabledToggle: boolean;
 }
 
 export interface RuntimeEnvironmentConfig {
@@ -64,5 +65,6 @@ export interface RuntimeEnvironmentConfig {
   googleClientId?: string;
   endpointApi?: string;
   apiBaseUrl?: string;
-  withinSubjectExperimentSupportToggle?: boolean,
+  withinSubjectExperimentSupportToggle?: boolean;
+  metricAnalyticsExperimentDisplayToggle?: boolean;
 }

--- a/frontend/projects/upgrade/src/environments/environment.bsnl.ts
+++ b/frontend/projects/upgrade/src/environments/environment.bsnl.ts
@@ -11,6 +11,7 @@ export const environment = {
   pollingInterval: 10 * 1000,
   pollingLimit: 600,
   withinSubjectExperimentSupportToggle: false,
+  metricAnalyticsExperimentDisplayDisabledToggle: false,
   api: {
     getAllExperiments: '/experiments/paginated',
     createNewExperiments: '/experiments',

--- a/frontend/projects/upgrade/src/environments/environment.bsnl.ts
+++ b/frontend/projects/upgrade/src/environments/environment.bsnl.ts
@@ -11,7 +11,7 @@ export const environment = {
   pollingInterval: 10 * 1000,
   pollingLimit: 600,
   withinSubjectExperimentSupportToggle: false,
-  metricAnalyticsExperimentDisplayDisabledToggle: false,
+  metricAnalyticsExperimentDisplayToggle: true,
   api: {
     getAllExperiments: '/experiments/paginated',
     createNewExperiments: '/experiments',

--- a/frontend/projects/upgrade/src/environments/environment.demo.prod.ts
+++ b/frontend/projects/upgrade/src/environments/environment.demo.prod.ts
@@ -11,7 +11,7 @@ export const environment = {
   pollingInterval: 10 * 1000,
   pollingLimit: 600,
   withinSubjectExperimentSupportToggle: false,
-  metricAnalyticsExperimentDisplayDisabledToggle: true,
+  metricAnalyticsExperimentDisplayToggle: false,
   api: {
     getAllExperiments: '/experiments/paginated',
     createNewExperiments: '/experiments',

--- a/frontend/projects/upgrade/src/environments/environment.demo.prod.ts
+++ b/frontend/projects/upgrade/src/environments/environment.demo.prod.ts
@@ -11,6 +11,7 @@ export const environment = {
   pollingInterval: 10 * 1000,
   pollingLimit: 600,
   withinSubjectExperimentSupportToggle: false,
+  metricAnalyticsExperimentDisplayDisabledToggle: true,
   api: {
     getAllExperiments: '/experiments/paginated',
     createNewExperiments: '/experiments',

--- a/frontend/projects/upgrade/src/environments/environment.prod.ts
+++ b/frontend/projects/upgrade/src/environments/environment.prod.ts
@@ -11,7 +11,7 @@ export const environment = {
   pollingInterval: 10 * 1000,
   pollingLimit: 600,
   withinSubjectExperimentSupportToggle: false,
-  metricAnalyticsExperimentDisplayDisabledToggle: true,
+  metricAnalyticsExperimentDisplayToggle: false,
   api: {
     getAllExperiments: '/experiments/paginated',
     createNewExperiments: '/experiments',

--- a/frontend/projects/upgrade/src/environments/environment.prod.ts
+++ b/frontend/projects/upgrade/src/environments/environment.prod.ts
@@ -11,6 +11,7 @@ export const environment = {
   pollingInterval: 10 * 1000,
   pollingLimit: 600,
   withinSubjectExperimentSupportToggle: false,
+  metricAnalyticsExperimentDisplayDisabledToggle: false,
   api: {
     getAllExperiments: '/experiments/paginated',
     createNewExperiments: '/experiments',

--- a/frontend/projects/upgrade/src/environments/environment.prod.ts
+++ b/frontend/projects/upgrade/src/environments/environment.prod.ts
@@ -11,7 +11,7 @@ export const environment = {
   pollingInterval: 10 * 1000,
   pollingLimit: 600,
   withinSubjectExperimentSupportToggle: false,
-  metricAnalyticsExperimentDisplayDisabledToggle: false,
+  metricAnalyticsExperimentDisplayDisabledToggle: true,
   api: {
     getAllExperiments: '/experiments/paginated',
     createNewExperiments: '/experiments',

--- a/frontend/projects/upgrade/src/environments/environment.staging.ts
+++ b/frontend/projects/upgrade/src/environments/environment.staging.ts
@@ -11,7 +11,7 @@ export const environment = {
   pollingInterval: 10 * 1000,
   pollingLimit: 600,
   withinSubjectExperimentSupportToggle: false,
-  metricAnalyticsExperimentDisplayDisabledToggle: true,
+  metricAnalyticsExperimentDisplayToggle: false,
   api: {
     getAllExperiments: '/experiments/paginated',
     createNewExperiments: '/experiments',

--- a/frontend/projects/upgrade/src/environments/environment.staging.ts
+++ b/frontend/projects/upgrade/src/environments/environment.staging.ts
@@ -11,6 +11,7 @@ export const environment = {
   pollingInterval: 10 * 1000,
   pollingLimit: 600,
   withinSubjectExperimentSupportToggle: false,
+  metricAnalyticsExperimentDisplayDisabledToggle: true,
   api: {
     getAllExperiments: '/experiments/paginated',
     createNewExperiments: '/experiments',

--- a/frontend/projects/upgrade/src/environments/environment.ts
+++ b/frontend/projects/upgrade/src/environments/environment.ts
@@ -16,7 +16,7 @@ export const environment = {
   pollingInterval: 10 * 1000,
   pollingLimit: 600,
   withinSubjectExperimentSupportToggle: false,
-  metricAnalyticsExperimentDisplayDisabledToggle: true,
+  metricAnalyticsExperimentDisplayToggle: false,
   api: {
     getAllExperiments: '/experiments/paginated',
     createNewExperiments: '/experiments',

--- a/frontend/projects/upgrade/src/environments/environment.ts
+++ b/frontend/projects/upgrade/src/environments/environment.ts
@@ -16,6 +16,7 @@ export const environment = {
   pollingInterval: 10 * 1000,
   pollingLimit: 600,
   withinSubjectExperimentSupportToggle: false,
+  metricAnalyticsExperimentDisplayDisabledToggle: true,
   api: {
     getAllExperiments: '/experiments/paginated',
     createNewExperiments: '/experiments',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "UpGrade",
-  "version": "5.1.15",
+  "version": "5.1.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "UpGrade",
-      "version": "5.1.15",
+      "version": "5.1.16",
       "license": "ISC",
       "devDependencies": {
         "@angular-eslint/eslint-plugin": "^14.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "UpGrade",
-  "version": "5.1.15",
+  "version": "5.1.16",
   "description": "This is a combined repository for UpGrade, an open-source platform to support large-scale A/B testing in educational applications.  Learn more at www.upgradeplatform.org",
   "main": "index.js",
   "devDependencies": {

--- a/types/package-lock.json
+++ b/types/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "upgrade_types",
-  "version": "5.1.15",
+  "version": "5.1.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "upgrade_types",
-      "version": "5.1.15",
+      "version": "5.1.16",
       "license": "ISC",
       "devDependencies": {
         "eslint": "^8.27.0",

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upgrade_types",
-  "version": "5.1.15",
+  "version": "5.1.16",
   "description": "",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
This adds a new front end env toggle `metricAnalyticsExperimentDisplayDisabledToggle` so that we can disable both the problematic `/analyse` query. 

This toggle also controls whether or not to show a message in the ui.

This functionality can be turned on or off via environment file at build time or the `environment.json` at runtime.

<img width="1501" alt="image" src="https://github.com/CarnegieLearningWeb/UpGrade/assets/97542869/118b49ce-0bb4-469e-b5f3-3b2153e3561e">
