### PR TITLE
Adding segment controller unit test cases and resolved other small issues in unit tests

### DIFF
--- a/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
@@ -1232,6 +1232,46 @@ export class ExperimentController {
     return this.experimentService.importExperiment(experiments, currentUser, request.logger);
   }
 
+  /**
+   * @swagger
+   * /experiments/{export}:
+   *    get:
+   *       description: Export Experiment JSON
+   *       parameters:
+   *         - in: body
+   *           name: experiments
+   *           required: true
+   *           schema:
+   *             type: array
+   *             items:
+   *               type: object
+   *               properties:
+   *                 fileName:
+   *                   type: string
+   *                 fileContent:
+   *                   type: string
+   *           description: Experiment Files
+   *       tags:
+   *         - Experiments
+   *       produces:
+   *         - application/json
+   *       responses:
+   *          '200':
+   *            description: Experiment is exported
+   *            schema:
+   *             type: array
+   *             items:
+   *               type: object
+   *               properties:
+   *                 fileName:
+   *                   type: string
+   *                 error:
+   *                   type: string
+   *          '401':
+   *            description: AuthorizationRequiredError
+   *          '500':
+   *            description: Internal Server Error
+   */
   @Get('/export')
   public exportExperiment(
     @QueryParams()

--- a/backend/packages/Upgrade/test/unit/controllers/AnalyticsController.test.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/AnalyticsController.test.ts
@@ -56,7 +56,7 @@ describe('Analytics Controller Testing', () => {
       .expect(200);
   });
 
-  test('Post request for /api/stats/csv', () => {
+  test('Get request for /api/stats/csv', () => {
     return request(app)
       .get('/api/stats/csv')
       .query({

--- a/backend/packages/Upgrade/test/unit/controllers/ExperimentController.test.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/ExperimentController.test.ts
@@ -198,8 +198,10 @@ describe('Experiment Controller Testing', () => {
 
   test('Get request for /api/experiments/export', () => {
     return request(app)
-      .post('/api/experiments/import')
-      .send([experimentData.id])
+      .get('/api/experiments/export')
+      .query({
+        ids: [uuid()],
+      })
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
       .expect(200);

--- a/backend/packages/Upgrade/test/unit/controllers/SegmentController.test.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/SegmentController.test.ts
@@ -1,0 +1,115 @@
+import app from '../../utils/expressApp';
+import request from 'supertest';
+import { configureLogger } from '../../utils/logger';
+import { useContainer as routingUseContainer } from 'routing-controllers';
+import { Container } from 'typedi';
+import { v4 as uuid } from 'uuid';
+import SegmentServiceMock from './mocks/SegmentServiceMock';
+import { SegmentService } from '../../../src/api/services/SegmentService';
+
+import { useContainer as classValidatorUseContainer } from 'class-validator';
+import { useContainer as ormUseContainer } from 'typeorm';
+
+describe('Segment Controller Testing', () => {
+  beforeAll(() => {
+    configureLogger();
+    routingUseContainer(Container);
+    ormUseContainer(Container);
+    classValidatorUseContainer(Container);
+
+    // set mock container
+    Container.set(SegmentService, new SegmentServiceMock());
+  });
+
+  afterAll(() => {
+    Container.reset();
+  });
+
+  const segmentData = {
+    id: uuid(),
+    name: "segment1",
+    description: "desc",
+    context: "home",
+    type: "public",
+    status: "Unused",
+    userIds: ["user1"],
+    groups: {
+      groupId : "group1",
+      type: "school"
+    },
+    subSegmentIds: ["seg2"]
+  };
+
+  test('Get request for /api/segments', () => {
+    return request(app)
+      .get('/api/segments')
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
+  });
+
+  test('Get request for /api/segments/:segmentId', () => {
+    return request(app)
+      .get(`/api/segments/${uuid()}`)
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
+  });
+
+  test('Get request for /api/segments/status/:segmentId', () => {
+    return request(app)
+      .get(`/api/segments/status/${uuid()}`)
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
+  });
+
+  test('Post request for /api/segments', () => {
+    return request(app)
+      .post('/api/segments')
+      .send([segmentData])
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
+  });
+
+  test('Delete request for /api/segments/:segmentId', () => {
+    return request(app).delete(`/api/segments/${uuid()}`).expect('Content-Type', /json/).expect(200);
+  });
+
+  test('Post request for /api/segments/import', () => {
+    return request(app)
+      .post('/api/segments/import')
+      .send(segmentData)
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
+  });
+
+  test('Post request for /api/segments/validation', () => {
+    return request(app).post('/api/segments/validation').send(segmentData).expect('Content-Type', /json/).expect(200);
+  });
+
+  test('Get request for /api/segments/export/json', () => {
+    return request(app)
+      .get('/api/segments/export/json')
+      .query({
+        ids: [uuid()],
+      })
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
+  });
+
+  test('Get request for /api/segments/export/csv', () => {
+    return request(app)
+      .get('/api/segments/export/csv')
+      .query({
+        ids: [uuid()],
+      })
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
+  });
+
+});

--- a/backend/packages/Upgrade/test/unit/controllers/mocks/SegmentServiceMock.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/mocks/SegmentServiceMock.ts
@@ -1,0 +1,52 @@
+import { Service } from 'typedi';
+
+@Service()
+export default class ExcludeServiceMock {
+  public getAllSegments(): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public getAllSegmentWithStatus(): Promise<[]> {
+    return Promise.resolve([]);
+  }
+  
+  public getSegmentById(id: string): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public getSegmentWithStatusById(id: string): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public getSingleSegmentWithStatus(id: string): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public upsertSegment(): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public importSegments(): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public deleteSegment(id: string): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public validateSegments(): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public exportSegments(id: string): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public exportSegment(id: string): Promise<[]> {
+    return Promise.resolve([]);
+  }
+
+  public exportSegmentCSV(id: string): Promise<[]> {
+    return Promise.resolve([]);
+  }
+}


### PR DESCRIPTION
This resolves 4 subtasks from #1447 

- [x] We are missing unit test cases for Segment Controller, we need to add that. 
- [x] The export experiment api unit test case is hitting post request for import api instead of get request for export.
- [x] Swagger details are missing for various new apis.
- [x] Analytics Controller tests has post request details for export csv data.