### PR TITLE
Update .env.example to avoid confusion

### DIFF
--- a/backend/packages/Upgrade/.env.docker.local.example
+++ b/backend/packages/Upgrade/.env.docker.local.example
@@ -73,9 +73,9 @@ EMAIL_BUCKET="s3_bucket"
 #
 # Initialization
 #
-ADMIN_USERS=user@email:role/\user2@email:role
+ADMIN_USERS=user@email:admin/\user2@email:admin
 CLIENT_API_SECRET=secret
 CLIENT_API_KEY=key
 
-CONTEXT_METADATA={"context_identifier_1":{"CONDITIONS":["potential-condition-1","potential-condition-1"],"GROUP_TYPES":["client_group_identifier_1","client_group_identifier_2","client_group_identifier_3"],"EXP_IDS":["decision_point_target_identifier_1","decision_point_target_identifier_2"],"EXP_POINTS":["decision_point_site_identifier_1","decision_point_site_identifier_2"]}}
+CONTEXT_METADATA={"context_identifier_1":{"CONDITIONS":["potential-condition-1","potential-condition-2"],"GROUP_TYPES":["client_group_identifier_1","client_group_identifier_2","client_group_identifier_3"],"EXP_IDS":["decision_point_target_identifier_1","decision_point_target_identifier_2"],"EXP_POINTS":["decision_point_site_identifier_1","decision_point_site_identifier_2"]}}
 METRICS=[{"metric":"totalTimeSeconds","datatype":"continuous"},{"groupClass":"masteryWorkspace","allowedKeys":["calculating_area_various_figures","Compare_functions_diff_reps_quadratic"],"attributes":[{"metric":"timeSeconds","datatype":"continuous"}]}]

--- a/backend/packages/Upgrade/.env.example
+++ b/backend/packages/Upgrade/.env.example
@@ -73,9 +73,9 @@ EMAIL_BUCKET="s3_bucket"
 #
 # Initialization
 #
-ADMIN_USERS=user@email:role/\user2@email:role
+ADMIN_USERS=user@email:admin/\user2@email:admin
 CLIENT_API_SECRET=secret
 CLIENT_API_KEY=key
 
-CONTEXT_METADATA={"context_identifier_1":{"CONDITIONS":["potential-condition-1","potential-condition-1"],"GROUP_TYPES":["client_group_identifier_1","client_group_identifier_2","client_group_identifier_3"],"EXP_IDS":["decision_point_target_identifier_1","decision_point_target_identifier_2"],"EXP_POINTS":["decision_point_site_identifier_1","decision_point_site_identifier_2"]}}
+CONTEXT_METADATA={"context_identifier_1":{"CONDITIONS":["potential-condition-1","potential-condition-2"],"GROUP_TYPES":["client_group_identifier_1","client_group_identifier_2","client_group_identifier_3"],"EXP_IDS":["decision_point_target_identifier_1","decision_point_target_identifier_2"],"EXP_POINTS":["decision_point_site_identifier_1","decision_point_site_identifier_2"]}}
 METRICS=[{"metrics":[{"metric":"totalTimeSeconds","datatype":"continuous"},{"groupClass":"masteryWorkspace","allowedKeys":["calculating_area_various_figures","Compare_functions_diff_reps_quadratic"],"attributes":[{"metric":"timeSeconds","datatype":"continuous"}]}],"contexts":["context_identifier_1"]}]


### PR DESCRIPTION
This PR changes the default value of `ADMIN_USERS` from `user@email:role/\user2@email:role` to `user@email:admin/\user2@email:admin` to avoid confusion. The current value causes the `QueryFailedError: invalid input value for enum user_role_enum: "role"` error. Additionally, it updates one of the conditions in the `CONTEXT_METADATA` to `potential-condition-2` to avoid having two identical condition names.
