### PR TITLE
Feature/add list modal

### DIFF
--- a/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.model.ts
+++ b/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.model.ts
@@ -43,14 +43,14 @@ export interface UpdateFeatureFlagStatusRequest {
   status: FEATURE_FLAG_STATUS;
 }
 
-export enum UpsertFeatureFlagListAction {
+export enum UPSERT_FEATURE_FLAG_LIST_ACTION {
   ADD = 'add',
   EDIT = 'edit',
 }
 
 export interface UpsertFeatureFlagListParams {
   sourceList: any; // TODO define me
-  action: UpsertFeatureFlagListAction;
+  action: UPSERT_FEATURE_FLAG_LIST_ACTION;
 }
 
 export enum LIST_OPTION_TYPE {

--- a/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.model.ts
+++ b/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.model.ts
@@ -43,6 +43,21 @@ export interface UpdateFeatureFlagStatusRequest {
   status: FEATURE_FLAG_STATUS;
 }
 
+export enum UpsertFeatureFlagListAction {
+  ADD = 'add',
+  EDIT = 'edit',
+}
+
+export interface UpsertFeatureFlagListParams {
+  sourceList: any; // TODO define me
+  action: UpsertFeatureFlagListAction;
+}
+
+export enum LIST_OPTION_TYPE {
+  INDIVIDUAL = 'Individual',
+  SEGMENT = 'Segment',
+}
+
 export interface FeatureFlagFormData {
   name: string;
   key: string;

--- a/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.selectors.ts
+++ b/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.selectors.ts
@@ -1,6 +1,5 @@
 import { createSelector, createFeatureSelector } from '@ngrx/store';
 import {
-  AnySegmentType,
   EmptyPrivateSegment,
   FLAG_SEARCH_KEY,
   FeatureFlag,
@@ -11,10 +10,7 @@ import {
 import { selectRouterState } from '../../core.state';
 import { selectAll } from './feature-flags.reducer';
 import { GroupForSegment, IndividualForSegment, Segment } from '../../segments/store/segments.model';
-import {
-  FEATURE_FLAG_PARTICIPANT_LIST_KEY,
-  FEATURE_FLAG_STATUS,
-} from '../../../../../../../../types/src/Experiment/enums';
+import { FEATURE_FLAG_PARTICIPANT_LIST_KEY } from '../../../../../../../../types/src/Experiment/enums';
 
 export const selectFeatureFlagsState = createFeatureSelector<FeatureFlagState>('featureFlags');
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-list-modal/upsert-feature-flag-list-modal.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-list-modal/upsert-feature-flag-list-modal.component.html
@@ -7,7 +7,7 @@
     (primaryActionBtnClicked)="onPrimaryActionBtnClicked()"
   >
     <form [formGroup]="featureFlagListForm" class="full-width">
-      <mat-form-field appearance="fill">
+      <mat-form-field appearance="outline">
         <mat-label>Type</mat-label>
         <mat-select formControlName="type">
           <mat-option *ngFor="let type of listOptionTypes$ | async" [value]="type.value">

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-list-modal/upsert-feature-flag-list-modal.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-list-modal/upsert-feature-flag-list-modal.component.html
@@ -1,0 +1,20 @@
+<div class="upsert-feature-flag-list-container">
+  <app-common-dialog
+    [title]="config.title"
+    [cancelBtnLabel]="config.cancelBtnLabel"
+    [primaryActionBtnLabel]="config.primaryActionBtnLabel"
+    [primaryActionBtnColor]="config.primaryActionBtnColor"
+    (primaryActionBtnClicked)="onPrimaryActionBtnClicked()"
+  >
+    <form [formGroup]="featureFlagListForm" class="full-width">
+      <mat-form-field appearance="fill">
+        <mat-label>Type</mat-label>
+        <mat-select formControlName="type">
+          <mat-option *ngFor="let type of listOptionTypes$ | async" [value]="type.value">
+            {{ type.viewValue }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+    </form>
+  </app-common-dialog>
+</div>

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-list-modal/upsert-feature-flag-list-modal.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-list-modal/upsert-feature-flag-list-modal.component.scss
@@ -1,11 +1,14 @@
-@import '@angular/material/prebuilt-themes/indigo-pink.css';
-
 :host ::ng-deep .upsert-feature-flag-list-container {
   display: flex;
   flex-direction: column;
   align-items: space-between;
+  width: 100%;
 
-  form.full-width {
+  .mat-mdc-form-field {
     width: 100%;
+  }
+
+  .mat-mdc-form-field:not(:last-child) {
+    margin-bottom: 20px;
   }
 }

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-list-modal/upsert-feature-flag-list-modal.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-list-modal/upsert-feature-flag-list-modal.component.scss
@@ -1,0 +1,11 @@
+@import '@angular/material/prebuilt-themes/indigo-pink.css';
+
+:host ::ng-deep .upsert-feature-flag-list-container {
+  display: flex;
+  flex-direction: column;
+  align-items: space-between;
+
+  form.full-width {
+    width: 100%;
+  }
+}

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-list-modal/upsert-feature-flag-list-modal.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-list-modal/upsert-feature-flag-list-modal.component.ts
@@ -1,0 +1,74 @@
+import { ChangeDetectionStrategy, Component, Inject } from '@angular/core';
+import { CommonModalComponent } from '../../../../../shared-standalone-component-lib/components';
+import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { CommonModalConfig } from '../../../../../shared-standalone-component-lib/components/common-modal/common-modal-config';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { FeatureFlagsService } from '../../../../../core/feature-flags/feature-flags.service';
+import { CommonFormHelpersService } from '../../../../../shared/services/common-form-helpers.service';
+import { TranslateModule } from '@ngx-translate/core';
+import { ExperimentService } from '../../../../../core/experiments/experiments.service';
+import { UpsertFeatureFlagListParams } from '../../../../../core/feature-flags/store/feature-flags.model';
+import { MatInputModule } from '@angular/material/input';
+
+@Component({
+  selector: 'upsert-feature-flag-list-modal',
+  standalone: true,
+  imports: [
+    CommonModalComponent,
+    MatSelectModule,
+    MatFormFieldModule,
+    MatInputModule,
+    CommonModule,
+    ReactiveFormsModule,
+    TranslateModule,
+  ],
+  templateUrl: './upsert-feature-flag-list-modal.component.html',
+  styleUrl: './upsert-feature-flag-list-modal.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class UpsertFeatureFlagListModalComponent {
+  selectedFlag$ = this.featureFlagsService.selectedFeatureFlag$;
+  listOptionTypes$ = this.featureFlagsService.selectFeatureFlagListTypeOptions$;
+
+  featureFlagListForm: FormGroup;
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA)
+    public config: CommonModalConfig<UpsertFeatureFlagListParams>,
+    public dialog: MatDialog,
+    private formBuilder: FormBuilder,
+    private featureFlagsService: FeatureFlagsService,
+    private formHelpersService: CommonFormHelpersService,
+    private experimentService: ExperimentService,
+    public dialogRef: MatDialogRef<UpsertFeatureFlagListModalComponent>
+  ) {}
+
+  ngOnInit(): void {
+    this.experimentService.fetchContextMetaData();
+    this.createFeatureFlagListForm();
+  }
+
+  createFeatureFlagListForm(): void {
+    this.featureFlagListForm = this.formBuilder.group({
+      type: ['', Validators.required],
+    });
+  }
+
+  onPrimaryActionBtnClicked(): void {
+    if (this.featureFlagListForm.valid) {
+      // Handle extra frontend form validation logic here?
+      // TODO: create request
+      console.log(this.featureFlagListForm.value);
+    } else {
+      // If the form is invalid, manually mark all form controls as touched
+      this.formHelpersService.triggerTouchedToDisplayErrors(this.featureFlagListForm);
+    }
+  }
+
+  closeModal() {
+    this.dialogRef.close();
+  }
+}

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-inclusions-section-card/feature-flag-inclusions-section-card.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-inclusions-section-card/feature-flag-inclusions-section-card.component.ts
@@ -9,6 +9,7 @@ import { CommonModule } from '@angular/common';
 import { IMenuButtonItem } from 'upgrade_types';
 import { FeatureFlagInclusionsTableComponent } from './feature-flag-inclusions-table/feature-flag-inclusions-table.component';
 import { FeatureFlagsService } from '../../../../../../../core/feature-flags/feature-flags.service';
+import { DialogService } from '../../../../../../../shared/services/common-dialog.service';
 
 @Component({
   selector: 'app-feature-flag-inclusions-section-card',
@@ -29,7 +30,7 @@ export class FeatureFlagInclusionsSectionCardComponent {
   @Input() isSectionCardExpanded;
   tableRowCount$ = this.featureFlagService.selectFeatureFlagInclusionsLength$;
 
-  constructor(private featureFlagService: FeatureFlagsService) {}
+  constructor(private featureFlagService: FeatureFlagsService, private dialogService: DialogService) {}
 
   menuButtonItems: IMenuButtonItem[] = [
     { name: 'Edit', disabled: false },
@@ -37,7 +38,7 @@ export class FeatureFlagInclusionsSectionCardComponent {
   ];
 
   addIncludeListClicked() {
-    console.log('add Include List Clicked');
+    this.dialogService.openAddIncludeListModal();
   }
 
   onMenuButtonItemClick(event) {

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-modal/common-modal-config.ts
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-modal/common-modal-config.ts
@@ -1,11 +1,12 @@
 import { MatDialogConfig } from '@angular/material/dialog';
 
-export interface CommonModalConfig {
+export interface CommonModalConfig<ParamsType = unknown> {
   title: string;
   cancelBtnLabel?: string;
   primaryActionBtnLabel?: string;
   primaryActionBtnColor?: string; // TODO mat-button enum? or just string?
   hideFooter?: boolean;
+  params?: ParamsType;
 }
 
 export interface CommonDialogMatDialogConfig extends MatDialogConfig {

--- a/frontend/projects/upgrade/src/app/shared/services/common-dialog.service.ts
+++ b/frontend/projects/upgrade/src/app/shared/services/common-dialog.service.ts
@@ -9,7 +9,7 @@ import { ImportFeatureFlagModalComponent } from '../../features/dashboard/featur
 import { UpdateFlagStatusConfirmationModalComponent } from '../../features/dashboard/feature-flags/modals/update-flag-status-confirmation-modal/update-flag-status-confirmation-modal.component';
 import { EditFeatureFlagModalComponent } from '../../features/dashboard/feature-flags/modals/edit-feature-flag-modal/edit-feature-flag-modal.component';
 import {
-  UpsertFeatureFlagListAction,
+  UPSERT_FEATURE_FLAG_LIST_ACTION,
   UpsertFeatureFlagListParams,
 } from '../../core/feature-flags/store/feature-flags.model';
 import { UpsertFeatureFlagListModalComponent } from '../../features/dashboard/feature-flags/modals/upsert-feature-flag-list-modal/upsert-feature-flag-list-modal.component';
@@ -95,12 +95,12 @@ export class DialogService {
   openAddIncludeListModal() {
     const commonModalConfig: CommonModalConfig<UpsertFeatureFlagListParams> = {
       title: 'Add Include List',
-      primaryActionBtnLabel: 'Add',
+      primaryActionBtnLabel: 'Create',
       primaryActionBtnColor: 'primary',
       cancelBtnLabel: 'Cancel',
       params: {
         sourceList: null,
-        action: UpsertFeatureFlagListAction.ADD,
+        action: UPSERT_FEATURE_FLAG_LIST_ACTION.ADD,
       },
     };
     return this.openAddFeatureFlagListModal(commonModalConfig);

--- a/frontend/projects/upgrade/src/app/shared/services/common-dialog.service.ts
+++ b/frontend/projects/upgrade/src/app/shared/services/common-dialog.service.ts
@@ -8,6 +8,11 @@ import { DeleteFeatureFlagModalComponent } from '../../features/dashboard/featur
 import { ImportFeatureFlagModalComponent } from '../../features/dashboard/feature-flags/modals/import-feature-flag-modal/import-feature-flag-modal.component';
 import { UpdateFlagStatusConfirmationModalComponent } from '../../features/dashboard/feature-flags/modals/update-flag-status-confirmation-modal/update-flag-status-confirmation-modal.component';
 import { EditFeatureFlagModalComponent } from '../../features/dashboard/feature-flags/modals/edit-feature-flag-modal/edit-feature-flag-modal.component';
+import {
+  UpsertFeatureFlagListAction,
+  UpsertFeatureFlagListParams,
+} from '../../core/feature-flags/store/feature-flags.model';
+import { UpsertFeatureFlagListModalComponent } from '../../features/dashboard/feature-flags/modals/upsert-feature-flag-list-modal/upsert-feature-flag-list-modal.component';
 
 @Injectable({
   providedIn: 'root',
@@ -85,6 +90,32 @@ export class DialogService {
     };
 
     return this.dialog.open(UpdateFlagStatusConfirmationModalComponent, config);
+  }
+
+  openAddIncludeListModal() {
+    const commonModalConfig: CommonModalConfig<UpsertFeatureFlagListParams> = {
+      title: 'Add Include List',
+      primaryActionBtnLabel: 'Add',
+      primaryActionBtnColor: 'primary',
+      cancelBtnLabel: 'Cancel',
+      params: {
+        sourceList: null,
+        action: UpsertFeatureFlagListAction.ADD,
+      },
+    };
+    return this.openAddFeatureFlagListModal(commonModalConfig);
+  }
+
+  openAddFeatureFlagListModal(commonModalConfig: CommonModalConfig) {
+    const config: MatDialogConfig = {
+      data: commonModalConfig,
+      width: '670px',
+      // height: '460px',
+      height: 'auto', // TODO: fixed height or not?
+      autoFocus: 'input',
+      disableClose: true,
+    };
+    return this.dialog.open(UpsertFeatureFlagListModalComponent, config);
   }
 
   openDeleteFeatureFlagModal() {

--- a/frontend/projects/upgrade/src/styles.scss
+++ b/frontend/projects/upgrade/src/styles.scss
@@ -249,6 +249,10 @@ button[mat-icon-button] {
   width: 805px;
 }
 
+.full-width {
+  width: 100%;
+}
+
 .mat-mdc-checkbox {
   .mdc-checkbox {
     transform: scale(0.889); // transform 18px to 16px


### PR DESCRIPTION
Initial add-list-modal #1749 

This creates the base modal and the type field to get this general modal started.
It also implements it for the `Add Include List` button.

Eventually this modal is planned to be used for Add and Edit list flows in both the include / exclude flows.

You'll notice a few placeholder things, i tried to comment most places that are expected to need to change as we go.

<img width="969" alt="image" src="https://github.com/user-attachments/assets/a9b3e377-6547-48c1-bd1e-9d963269f08d">

<img width="688" alt="Feature Flag - Add Include List" src="https://github.com/user-attachments/assets/502129da-23ed-48b2-bfc9-d86389174041">
