### PR TITLE
simple modal style fixes and naming convention updates

### DIFF
--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-modal/common-modal-config.ts
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-modal/common-modal-config.ts
@@ -16,5 +16,5 @@ export interface CommonDialogMatDialogConfig extends MatDialogConfig {
 export interface SimpleConfirmationModalParams {
   message: string;
   subMessage?: string;
-  subMessageColor?: string;
+  subMessageClass?: 'info' | 'warn';
 }

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-simple-confirmation-modal/common-simple-confirmation-modal.component.html
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-simple-confirmation-modal/common-simple-confirmation-modal.component.html
@@ -1,4 +1,4 @@
-<div class="modal-container">
+<div>
     <app-common-dialog
       [title]="data.title"
       [cancelBtnLabel]="data.cancelBtnLabel"
@@ -6,13 +6,13 @@
       [primaryActionBtnColor]="data.primaryActionBtnColor"
       (primaryActionBtnClicked)="onPrimaryActionBtnClicked()"
     >
-      <div mat-dialog-content class="dialog">
-        <div class="ft-18-600 message">
+      <div class="confirm-modal-content">
+        <p class="confirm-modal-content-text ft-16-400">
           {{ data.params.message | translate }}
-        </div>
-        <div class="ft-18-500 subMessage" [color]="data.params.subMessageColor" *ngIf="data.params.subMessage">
+        </p>
+        <p class="confirm-modal-content-text ft-14-400" [ngClass]="data.params.subMessageClass" *ngIf="data.params.subMessage">
           {{ data.params.subMessage | translate }}
-        </div>
+        </p>
       </div>
     </app-common-dialog>
 </div>

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-simple-confirmation-modal/common-simple-confirmation-modal.component.scss
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-simple-confirmation-modal/common-simple-confirmation-modal.component.scss
@@ -1,7 +1,25 @@
-.dialog {
+.confirm-modal-content {
     padding: 20px 0px;
 
     .subMessage {
         margin-top: 10px;
+    }
+
+    display: flex;
+    flex-direction: column;
+    row-gap: 16px;
+    padding: 40px 32px;
+  
+    &-text {
+      color: var(--dark-grey);
+      margin-bottom: 0;
+  
+      &.info {
+        color: var(--blue);
+      }
+  
+      &.warn {
+        color: var(--red-2);
+      }
     }
 }

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-simple-confirmation-modal/common-simple-confirmation-modal.component.ts
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-simple-confirmation-modal/common-simple-confirmation-modal.component.ts
@@ -14,27 +14,16 @@ import { CommonModalConfig, SimpleConfirmationModalParams } from '../common-moda
 @Component({
   selector: 'common-simple-confirmation-modal',
   standalone: true,
-  imports: [
-    CommonModalComponent,
-    MatDialogTitle,
-    MatDialogContent,
-    MatDialogClose,
-    TranslateModule,
-    CommonModule,
-  ],
+  imports: [CommonModalComponent, MatDialogTitle, MatDialogContent, MatDialogClose, TranslateModule, CommonModule],
   templateUrl: './common-simple-confirmation-modal.component.html',
   styleUrl: './common-simple-confirmation-modal.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class CommonSimpleConfirmationModal{
-  message: string = "";
-  subMessage: string = "";
-  subMessageColor: string = "";
-
+export class CommonSimpleConfirmationModalComponent {
   constructor(
     @Inject(MAT_DIALOG_DATA)
     public data: CommonModalConfig<SimpleConfirmationModalParams>,
-    public dialogRef: MatDialogRef<CommonSimpleConfirmationModal>
+    public dialogRef: MatDialogRef<CommonSimpleConfirmationModalComponent>
   ) {}
 
   onPrimaryActionBtnClicked() {

--- a/frontend/projects/upgrade/src/app/shared/services/common-dialog.service.ts
+++ b/frontend/projects/upgrade/src/app/shared/services/common-dialog.service.ts
@@ -1,7 +1,10 @@
 import { Injectable } from '@angular/core';
 import { MatDialog, MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
 import { MatConfirmDialogComponent } from '../components/mat-confirm-dialog/mat-confirm-dialog.component';
-import { CommonModalConfig } from '../../shared-standalone-component-lib/components/common-modal/common-modal-config';
+import {
+  CommonModalConfig,
+  SimpleConfirmationModalParams,
+} from '../../shared-standalone-component-lib/components/common-modal/common-modal-config';
 import { DeleteFeatureFlagModalComponent } from '../../features/dashboard/feature-flags/modals/delete-feature-flag-modal/delete-feature-flag-modal.component';
 
 import { ImportFeatureFlagModalComponent } from '../../features/dashboard/feature-flags/modals/import-feature-flag-modal/import-feature-flag-modal.component';
@@ -15,7 +18,7 @@ import {
   UpsertFeatureFlagParams,
 } from '../../core/feature-flags/store/feature-flags.model';
 import { UpsertFeatureFlagListModalComponent } from '../../features/dashboard/feature-flags/modals/upsert-feature-flag-list-modal/upsert-feature-flag-list-modal.component';
-import { CommonSimpleConfirmationModal } from '../../shared-standalone-component-lib/components/common-simple-confirmation-modal/common-simple-confirmation-modal.component';
+import { CommonSimpleConfirmationModalComponent } from '../../shared-standalone-component-lib/components/common-simple-confirmation-modal/common-simple-confirmation-modal.component';
 
 @Injectable({
   providedIn: 'root',
@@ -175,7 +178,9 @@ export class DialogService {
     return this.dialog.open(ImportFeatureFlagModalComponent, config);
   }
 
-  openCommonConfirmationModal(commonModalConfig: CommonModalConfig): MatDialogRef<CommonSimpleConfirmationModal, boolean> {
+  openSimpleCommonConfirmationModal(
+    commonModalConfig: CommonModalConfig
+  ): MatDialogRef<CommonSimpleConfirmationModalComponent, boolean> {
     const config: MatDialogConfig = {
       data: commonModalConfig,
       width: '656px',
@@ -183,6 +188,6 @@ export class DialogService {
       disableClose: true,
     };
 
-    return this.dialog.open(CommonSimpleConfirmationModal, config);
+    return this.dialog.open(CommonSimpleConfirmationModalComponent, config);
   }
 }


### PR DESCRIPTION
Simple modal had no styling, that was missed in PR. Changed subMessage `color` to `class` so we could use the exact styling from the "Update Feature Flag Status" modal, which should have been a simple modal like this in the first place.

A couple of linting and naming conventions needed a touch up also. 

<img width="673" alt="image" src="https://github.com/user-attachments/assets/91670fb5-f524-4c99-9357-2ad3c31331fc">
