### PR TITLE
Refine Section Card Expansion and FilterMode Handling

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-modal/upsert-feature-flag-modal.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-modal/upsert-feature-flag-modal.component.ts
@@ -184,7 +184,7 @@ export class UpsertFeatureFlagModalComponent {
       context: [appContext],
       tags,
       status: FEATURE_FLAG_STATUS.DISABLED,
-      filterMode: FILTER_MODE.INCLUDE_ALL,
+      filterMode: FILTER_MODE.EXCLUDE_ALL,
       featureFlagSegmentInclusion: [],
       featureFlagSegmentExclusion: [],
     };

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-inclusions-section-card/feature-flag-inclusions-section-card.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-inclusions-section-card/feature-flag-inclusions-section-card.component.html
@@ -20,6 +20,7 @@
       [menuButtonItems]="menuButtonItems"
       [isSectionCardExpanded]="isSectionCardExpanded"
       [primaryActionBtnDisabled]="flag.filterMode === FILTER_MODE.INCLUDE_ALL"
+      [sectionCardExpandBtnDisabled]="flag.filterMode === FILTER_MODE.INCLUDE_ALL"
       (primaryButtonClick)="addIncludeListClicked()"
       (slideToggleChange)="onSlideToggleChange($event, flag.id)"
       (menuButtonItemClick)="onMenuButtonItemClick($event)"
@@ -30,8 +31,7 @@
     <!-- content -->
     <app-feature-flag-inclusions-table
       content
-      *ngIf="isSectionCardExpanded && flag.filterMode !== FILTER_MODE.INCLUDE_ALL"
-      class="full-width"
+      *ngIf="isSectionCardExpanded"
     ></app-feature-flag-inclusions-table>
   </app-common-section-card>
 </ng-container>

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-inclusions-section-card/feature-flag-inclusions-section-card.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-inclusions-section-card/feature-flag-inclusions-section-card.component.ts
@@ -37,7 +37,7 @@ export class FeatureFlagInclusionsSectionCardComponent {
 
   rowCountWithInclude$: Observable<number> = combineLatest([this.tableRowCount$, this.selectedFlag$]).pipe(
     map(([tableRowCount, selectedFeatureFlag]) =>
-      selectedFeatureFlag.filterMode === FILTER_MODE.INCLUDE_ALL ? 0 : tableRowCount
+      selectedFeatureFlag?.filterMode === FILTER_MODE.INCLUDE_ALL ? 0 : tableRowCount
     )
   );
 
@@ -92,7 +92,12 @@ export class FeatureFlagInclusionsSectionCardComponent {
         flagId: flagId,
         filterMode: newFilterMode,
       });
+      this.updateSectionCardExpansion(newFilterMode);
     }
+  }
+
+  updateSectionCardExpansion(newFilterMode: FILTER_MODE): void {
+    this.isSectionCardExpanded = newFilterMode !== FILTER_MODE.INCLUDE_ALL;
   }
 
   onMenuButtonItemClick(event) {

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-action-buttons/common-section-card-action-buttons.component.html
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-action-buttons/common-section-card-action-buttons.component.html
@@ -35,7 +35,11 @@
       </button>
     </mat-menu>
 
-    <button mat-icon-button [disabled]="primaryActionBtnDisabled" (click)="onSectionCardExpandChange()">
+    <button
+      mat-icon-button
+      [disabled]="sectionCardExpandBtnDisabled"
+      (click)="onSectionCardExpandChange()"
+    >
       <mat-icon>{{ isSectionCardExpanded ? 'expand_less' : 'expand_more' }}</mat-icon>
     </button>
   </div>

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-action-buttons/common-section-card-action-buttons.component.scss
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-action-buttons/common-section-card-action-buttons.component.scss
@@ -23,7 +23,7 @@
     display: flex;
     column-gap: 4px;
 
-    ::ng-deep .mat-mdc-icon-button .mat-icon {
+    .mat-mdc-icon-button:not(.mat-mdc-button-disabled) .mat-icon {
       color: var(--dark-grey);
     }
   }

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-action-buttons/common-section-card-action-buttons.component.ts
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-action-buttons/common-section-card-action-buttons.component.ts
@@ -48,6 +48,7 @@ export class CommonSectionCardActionButtonsComponent {
   @Input() menuButtonItems?: IMenuButtonItem[] = [];
   @Input() isSectionCardExpanded?: boolean = true;
   @Input() primaryActionBtnDisabled?: boolean = false;
+  @Input() sectionCardExpandBtnDisabled?: boolean = false;
   @Output() slideToggleChange = new EventEmitter<MatSlideToggleChange>();
   @Output() primaryButtonClick = new EventEmitter<void>();
   @Output() menuButtonItemClick = new EventEmitter<string>();


### PR DESCRIPTION
This PR merges into the branch from the existing PR for adding the "Include All" toggle: https://github.com/CarnegieLearningWeb/UpGrade/pull/1781

The changes include:

- Updated the `isSectionCardExpanded` status to change when the `filterMode` changes.
- Set the default `filterMode` of the feature flag to `EXCLUDE_ALL`.
- Added the `sectionCardExpandBtnDisabled` input variable to the `CommonSectionCardActionButtonsComponent`.
- Updated the code to use `selectedFeatureFlag?.filterMode` to prevent an undefined type error.