### PR TITLE
Hide scrollbar for modal content, section card list, and tag input when not in use on Linux

### DIFF
--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-modal/common-modal.component.scss
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-modal/common-modal.component.scss
@@ -21,7 +21,7 @@
 
   .content-container {
     max-height: 480px;
-    overflow: scroll;
+    overflow: auto;
   }
 
   .footer-container {

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-list/common-section-card-list.component.scss
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-list/common-section-card-list.component.scss
@@ -3,5 +3,5 @@
   flex-direction: column;
   row-gap: 32px;
   padding-bottom: 32px;
-  overflow: scroll;
+  overflow: auto;
 }

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-tag-input/common-tag-input.component.scss
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-tag-input/common-tag-input.component.scss
@@ -8,7 +8,7 @@
     justify-content: space-between;
     align-items: flex-start;
     max-height: 64px;
-    overflow: scroll;
+    overflow: auto;
 
     .icon-button {
       background: none;


### PR DESCRIPTION
This PR fixes the issue of the scrollbar always being displayed, even when not in use, on Linux.

@Yagnik56 @RidhamShah @ppratikcr7 I would appreciate it if anyone using Linux could confirm that this issue is resolved with this PR.