### PR TITLE
filter out disabled lists from consideration

### DIFF
--- a/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
+++ b/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
@@ -274,12 +274,12 @@ export class FeatureFlagService {
       if (filterType === 'inclusion') {
         existingRecord = await this.featureFlagSegmentInclusionRepository.findOne({
           where: { featureFlag: { id: listInput.flagId }, segment: { id: listInput.list.id } },
-          relations: ['featureFlag', 'segment']
+          relations: ['featureFlag', 'segment'],
         });
       } else {
         existingRecord = await this.featureFlagSegmentExclusionRepository.findOne({
           where: { featureFlag: { id: listInput.flagId }, segment: { id: listInput.list.id } },
-          relations: ['featureFlag', 'segment']
+          relations: ['featureFlag', 'segment'],
         });
       }
 
@@ -372,8 +372,12 @@ export class FeatureFlagService {
   ): Promise<FeatureFlag[]> {
     const segmentObjMap = {};
     featureFlags.forEach((flag) => {
-      const includeIds = flag.featureFlagSegmentInclusion.map((segmentInclusion) => segmentInclusion.segment.id);
-      const excludeIds = flag.featureFlagSegmentExclusion.map((segmentExclusion) => segmentExclusion.segment.id);
+      const includeIds = flag.featureFlagSegmentInclusion
+        .filter((inclusion) => inclusion.enabled)
+        .map((segmentInclusion) => segmentInclusion.segment.id);
+      const excludeIds = flag.featureFlagSegmentExclusion
+        .filter((exclusion) => exclusion.enabled)
+        .map((segmentExclusion) => segmentExclusion.segment.id);
 
       segmentObjMap[flag.id] = {
         segmentIdsQueue: [...includeIds, ...excludeIds],


### PR DESCRIPTION
When applying the logic to return a list of feature flags for a given user, remove inclusion and exclusion lists that have `enabled` set to 'false' from the data.