### PR TITLE
Update getUserDoc to return requestedUserId even when userDoc is not found

### DIFF
--- a/backend/packages/Upgrade/src/api/services/ExperimentUserService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentUserService.ts
@@ -295,16 +295,12 @@ export class ExperimentUserService {
     return this.userRepository.save(newDocument);
   }
 
-  public async getUserDoc(experimentUserId, logger): Promise<RequestedExperimentUser> {
+  public async getUserDoc(experimentUserId: string, logger: UpgradeLogger): Promise<RequestedExperimentUser | null> {
     try {
       const experimentUserDoc = await this.getOriginalUserDoc(experimentUserId, logger);
-      if (experimentUserDoc) {
-        const userDoc = { ...experimentUserDoc, requestedUserId: experimentUserId };
-        logger.info({ message: 'Got the user doc', details: userDoc });
-        return userDoc;
-      } else {
-        return null;
-      }
+      const userDoc = { ...experimentUserDoc, requestedUserId: experimentUserId };
+      logger.info({ message: 'Got the user doc', details: userDoc });
+      return userDoc;
     } catch (error) {
       logger.error({ message: `Error in getting user doc for user => ${experimentUserId}`, error });
       return null;


### PR DESCRIPTION
This PR resolves the issue mentioned in the PR: https://github.com/CarnegieLearningWeb/UpGrade/pull/1805

Currently, we use `requestedUserId` to log the requested user ID in the functions like `getAllExperimentConditions` and `markExperimentPoint` when the user document was not found. However, currently, the `getUserDoc` function returns `null` when the user is not found, making the `requestedUserId` to be undefined. This PR updates the `getUserDoc` function to still return the `requestedUserId` so that the requested user ID can be logged when the user was not found.