### PR TITLE
Update default/fallback filter mode to EXCLUDE_ALL for experiments

### DIFF
--- a/backend/packages/Upgrade/src/api/models/Experiment.ts
+++ b/backend/packages/Upgrade/src/api/models/Experiment.ts
@@ -125,7 +125,7 @@ export class Experiment extends BaseModel {
   @Column({
     type: 'enum',
     enum: FILTER_MODE,
-    default: FILTER_MODE.INCLUDE_ALL,
+    default: FILTER_MODE.EXCLUDE_ALL,
   })
   public filterMode: FILTER_MODE;
 

--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -1629,7 +1629,7 @@ export class ExperimentService {
     return {
       ...experiment,
       backendVersion: experiment.backendVersion || this.backendVersion.toString(),
-      filterMode: experiment.filterMode || FILTER_MODE.INCLUDE_ALL,
+      filterMode: experiment.filterMode || FILTER_MODE.EXCLUDE_ALL,
     };
   }
 


### PR DESCRIPTION
This PR updates default/fallback filter mode to `EXCLUDE_ALL` for experiments.