### PR TITLE
Display warning icon when flag is enabled but no participants defined

### DIFF
--- a/backend/packages/Upgrade/src/api/repositories/FeatureFlagRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/FeatureFlagRepository.ts
@@ -1,8 +1,7 @@
 import { Repository, EntityRepository, EntityManager } from 'typeorm';
 import { FeatureFlag } from '../models/FeatureFlag';
 import repositoryError from './utils/repositoryError';
-import { FEATURE_FLAG_STATUS } from 'upgrade_types';
-import { FILTER_MODE } from 'types/src';
+import { FEATURE_FLAG_STATUS, FILTER_MODE } from 'upgrade_types';
 
 @EntityRepository(FeatureFlag)
 export class FeatureFlagRepository extends Repository<FeatureFlag> {

--- a/backend/packages/Upgrade/test/unit/services/FeatureFlagService.test.ts
+++ b/backend/packages/Upgrade/test/unit/services/FeatureFlagService.test.ts
@@ -16,10 +16,9 @@ import {
   FLAG_SEARCH_KEY,
   FLAG_SORT_KEY,
 } from '../../../src/api/controllers/validators/FeatureFlagsPaginatedParamsValidator';
-import { SEGMENT_TYPE, SORT_AS_DIRECTION } from '../../../../../../types/src';
+import { FEATURE_FLAG_STATUS, FILTER_MODE, SEGMENT_TYPE, SORT_AS_DIRECTION } from 'upgrade_types';
 import { isUUID } from 'class-validator';
 import { v4 as uuid } from 'uuid';
-import { FEATURE_FLAG_STATUS, FILTER_MODE } from 'upgrade_types';
 import { ExperimentAssignmentService } from '../../../src/api/services/ExperimentAssignmentService';
 import { FeatureFlagValidation } from '../../../src/api/controllers/validators/FeatureFlagValidator';
 import { FeatureFlagListValidator } from '../../../src/api/controllers/validators/FeatureFlagListValidator';

--- a/frontend/projects/upgrade/src/app/core/feature-flags/feature-flags.service.ts
+++ b/frontend/projects/upgrade/src/app/core/feature-flags/feature-flags.service.ts
@@ -23,6 +23,8 @@ import {
   selectSortAs,
   selectAppContexts,
   selectFeatureFlagIds,
+  selectShouldShowWarningForSelectedFlag,
+  selectWarningStatusForAllFlags,
 } from './store/feature-flags.selectors';
 import * as FeatureFlagsActions from './store/feature-flags.actions';
 import { actionFetchContextMetaData } from '../experiments/store/experiments.actions';
@@ -58,6 +60,8 @@ export class FeatureFlagsService {
   searchKey$ = this.store$.pipe(select(selectSearchKey));
   sortKey$ = this.store$.pipe(select(selectSortKey));
   sortAs$ = this.store$.pipe(select(selectSortAs));
+  shouldShowWarningForSelectedFlag$ = this.store$.pipe(select(selectShouldShowWarningForSelectedFlag));
+  warningStatusForAllFlags$ = this.store$.pipe(select(selectWarningStatusForAllFlags));
 
   hasFeatureFlagsCountChanged$ = this.allFeatureFlags$.pipe(
     pairwise(),

--- a/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.selectors.ts
+++ b/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.selectors.ts
@@ -3,6 +3,7 @@ import { FLAG_SEARCH_KEY, FeatureFlag, FeatureFlagState, ParticipantListTableRow
 import { selectRouterState } from '../../core.state';
 import { selectContextMetaData } from '../../experiments/store/experiments.selectors';
 import { selectAll, selectIds } from './feature-flags.reducer';
+import { FEATURE_FLAG_STATUS, FILTER_MODE } from 'upgrade_types';
 
 export const selectFeatureFlagsState = createFeatureSelector<FeatureFlagState>('featureFlags');
 
@@ -164,3 +165,25 @@ export const selectFeatureFlagExclusions = createSelector(
       });
   }
 );
+
+// Helper function to determine if warning should be shown for a given flag
+const shouldShowWarningForFlag = (flag: FeatureFlag) =>
+  flag?.status === FEATURE_FLAG_STATUS.ENABLED &&
+  flag?.filterMode !== FILTER_MODE.INCLUDE_ALL &&
+  !flag?.featureFlagSegmentInclusion?.length;
+
+// Selector for the selected feature flag
+export const selectShouldShowWarningForSelectedFlag = createSelector(selectSelectedFeatureFlag, (flag: FeatureFlag) =>
+  shouldShowWarningForFlag(flag)
+);
+
+// Selector for all feature flags
+export const selectWarningStatusForAllFlags = createSelector(selectFeatureFlagsState, (state: FeatureFlagState) => {
+  const warningStatus = {};
+  Object.values(state.entities).forEach((flag) => {
+    if (flag) {
+      warningStatus[flag.id] = shouldShowWarningForFlag(flag);
+    }
+  });
+  return warningStatus;
+});

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-modal/upsert-feature-flag-modal.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-modal/upsert-feature-flag-modal.component.ts
@@ -22,7 +22,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { FeatureFlagsService } from '../../../../../core/feature-flags/feature-flags.service';
 import { CommonFormHelpersService } from '../../../../../shared/services/common-form-helpers.service';
-import { FEATURE_FLAG_STATUS, FILTER_MODE } from '../../../../../../../../../../types/src';
+import { FEATURE_FLAG_STATUS, FILTER_MODE } from 'upgrade_types';
 import {
   AddFeatureFlagRequest,
   FeatureFlag,

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-overview-details-section-card/feature-flag-overview-details-section-card.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-overview-details-section-card/feature-flag-overview-details-section-card.component.html
@@ -7,6 +7,11 @@
     [updatedAt]="flag.updatedAt"
     [showViewLogs]="true"
     [chipClass]="flag.status"
+    [showWarning]="
+      flag.status === FEATURE_FLAG_STATUS.ENABLED &&
+      flag.filterMode !== FILTER_MODE.INCLUDE_ALL &&
+      !flag.featureFlagSegmentInclusion?.length
+    "
     (viewLogs)="viewLogsClicked($event)"
   ></app-common-section-card-title-header>
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-overview-details-section-card/feature-flag-overview-details-section-card.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-overview-details-section-card/feature-flag-overview-details-section-card.component.html
@@ -7,11 +7,7 @@
     [updatedAt]="flag.updatedAt"
     [showViewLogs]="true"
     [chipClass]="flag.status"
-    [showWarning]="
-      flag.status === FEATURE_FLAG_STATUS.ENABLED &&
-      flag.filterMode !== FILTER_MODE.INCLUDE_ALL &&
-      !flag.featureFlagSegmentInclusion?.length
-    "
+    [showWarning]="shouldShowWarning$ | async"
     (viewLogs)="viewLogsClicked($event)"
   ></app-common-section-card-title-header>
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-overview-details-section-card/feature-flag-overview-details-section-card.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-overview-details-section-card/feature-flag-overview-details-section-card.component.ts
@@ -42,6 +42,7 @@ export class FeatureFlagOverviewDetailsSectionCardComponent implements OnInit, O
   emailId = '';
   featureFlag$ = this.featureFlagService.selectedFeatureFlag$;
   flagOverviewDetails$ = this.featureFlagService.selectedFlagOverviewDetails;
+  shouldShowWarning$ = this.featureFlagService.shouldShowWarningForSelectedFlag$;
   subscriptions = new Subscription();
   confirmStatusChangeDialogRef: MatDialogRef<CommonSimpleConfirmationModalComponent>;
   menuButtonItems: IMenuButtonItem[] = [

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-overview-details-section-card/feature-flag-overview-details-section-card.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-overview-details-section-card/feature-flag-overview-details-section-card.component.ts
@@ -7,7 +7,7 @@ import {
 import { FeatureFlagOverviewDetailsFooterComponent } from './feature-flag-overview-details-footer/feature-flag-overview-details-footer.component';
 import { MatSlideToggleChange } from '@angular/material/slide-toggle';
 import { FeatureFlagsService } from '../../../../../../../core/feature-flags/feature-flags.service';
-import { FEATURE_FLAG_STATUS, IMenuButtonItem } from 'upgrade_types';
+import { FEATURE_FLAG_STATUS, FILTER_MODE, IMenuButtonItem } from 'upgrade_types';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 import { CommonSectionCardOverviewDetailsComponent } from '../../../../../../../shared-standalone-component-lib/components/common-section-card-overview-details/common-section-card-overview-details.component';
@@ -65,6 +65,10 @@ export class FeatureFlagOverviewDetailsSectionCardComponent implements OnInit, O
 
   get FEATURE_FLAG_STATUS() {
     return FEATURE_FLAG_STATUS;
+  }
+
+  get FILTER_MODE() {
+    return FILTER_MODE;
   }
 
   viewLogsClicked(event) {

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.html
@@ -35,11 +35,7 @@
       <td mat-cell *matCellDef="let flag" class="status-column ft-14-400">
         <app-common-status-indicator-chip
           [chipClass]="flag.status"
-          [showWarning]="
-            flag.status === FEATURE_FLAG_STATUS.ENABLED &&
-            flag.filterMode !== FILTER_MODE.INCLUDE_ALL &&
-            !flag.featureFlagSegmentInclusion?.length
-          "
+          [showWarning]="(warningStatusForAllFlags$ | async)[flag.id]"
         ></app-common-status-indicator-chip>
       </td>
     </ng-container>

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.html
@@ -33,7 +33,14 @@
         {{ FLAG_TRANSLATION_KEYS.STATUS | translate }}
       </th>
       <td mat-cell *matCellDef="let flag" class="status-column ft-14-400">
-        <app-common-status-indicator-chip [chipClass]="flag.status"></app-common-status-indicator-chip>
+        <app-common-status-indicator-chip
+          [chipClass]="flag.status"
+          [showWarning]="
+            flag.status === FEATURE_FLAG_STATUS.ENABLED &&
+            flag.filterMode !== FILTER_MODE.INCLUDE_ALL &&
+            !flag.featureFlagSegmentInclusion?.length
+          "
+        ></app-common-status-indicator-chip>
       </td>
     </ng-container>
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.ts
@@ -39,6 +39,7 @@ export class FeatureFlagRootSectionCardTableComponent implements OnInit {
   @Input() isLoading$: Observable<boolean>;
   flagSortKey$ = this.featureFlagsService.sortKey$;
   flagSortAs$ = this.featureFlagsService.sortAs$;
+  warningStatusForAllFlags$ = this.featureFlagsService.warningStatusForAllFlags$;
 
   @ViewChild(MatSort, { static: true }) sort: MatSort;
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.ts
@@ -15,6 +15,7 @@ import { MatSort } from '@angular/material/sort';
 import { CommonStatusIndicatorChipComponent } from '../../../../../../../../shared-standalone-component-lib/components';
 import { FeatureFlagsService } from '../../../../../../../../core/feature-flags/feature-flags.service';
 import { SharedModule } from '../../../../../../../../shared/shared.module';
+import { FEATURE_FLAG_STATUS, FILTER_MODE } from 'upgrade_types';
 
 @Component({
   selector: 'app-feature-flag-root-section-card-table',
@@ -28,7 +29,6 @@ import { SharedModule } from '../../../../../../../../shared/shared.module';
     UpperCasePipe,
     RouterModule,
     CommonStatusIndicatorChipComponent,
-    SharedModule,
   ],
   templateUrl: './feature-flag-root-section-card-table.component.html',
   styleUrl: './feature-flag-root-section-card-table.component.scss',
@@ -48,6 +48,14 @@ export class FeatureFlagRootSectionCardTableComponent implements OnInit {
     if (this.dataSource$?.data) {
       this.dataSource$.sort = this.sort;
     }
+  }
+
+  get FEATURE_FLAG_STATUS() {
+    return FEATURE_FLAG_STATUS;
+  }
+
+  get FILTER_MODE() {
+    return FILTER_MODE;
   }
 
   get displayedColumns(): string[] {

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-title-header/common-section-card-title-header.component.html
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-title-header/common-section-card-title-header.component.html
@@ -2,7 +2,11 @@
   <h5 class="title ft-18-700">
     {{ title | translate }} &nbsp;<span *ngIf="tableRowCount > 0"> ({{ tableRowCount }}) </span>
     <ng-container *ngIf="chipClass">
-      <app-common-status-indicator-chip class="status-chip" [chipClass]="chipClass"></app-common-status-indicator-chip>
+      <app-common-status-indicator-chip
+        [chipClass]="chipClass"
+        [showWarning]="showWarning"
+        class="status-chip"
+      ></app-common-status-indicator-chip>
     </ng-container>
   </h5>
   <p class="subtitle">

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-title-header/common-section-card-title-header.component.ts
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-title-header/common-section-card-title-header.component.ts
@@ -25,6 +25,7 @@ import { SharedModule } from '../../../shared/shared.module';
  *   [subtitle]="subtitle"
  *   [showViewLogs]="true"
  *   [chipClass]="STATUS_INDICATOR_CHIP_TYPE.ENROLLMENT_COMPLETE"
+ *   [showWarning]="false"
  *   (viewLogs)="viewLogsClicked($event)"
  * ></app-common-section-card-title-header>
  * ```
@@ -45,6 +46,7 @@ export class CommonSectionCardTitleHeaderComponent {
   @Input() createdAt?: string;
   @Input() updatedAt?: string;
   @Input() chipClass?: STATUS_INDICATOR_CHIP_TYPE;
+  @Input() showWarning?: boolean;
   @Input() showViewLogs?: boolean;
   @Output() viewLogs = new EventEmitter<{ clicked: boolean }>();
 

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-status-indicator-chip/common-status-indicator-chip.component.html
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-status-indicator-chip/common-status-indicator-chip.component.html
@@ -1,7 +1,13 @@
-<div class="chip-container dense-2">
+<div
+  [matTooltip]="'feature-flags.global-status-warning-tooltip.text' | translate"
+  [matTooltipDisabled]="!showWarning"
+  matTooltipPosition="above"
+  class="chip-container dense-2"
+>
   <mat-chip class="status-indicator" [ngClass]="chipClass">
     <span class="chip-label">
       {{ chipText }}
     </span>
   </mat-chip>
+  <mat-icon *ngIf="showWarning" class="warning-icon">warning_amber</mat-icon>
 </div>

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-status-indicator-chip/common-status-indicator-chip.component.scss
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-status-indicator-chip/common-status-indicator-chip.component.scss
@@ -1,9 +1,9 @@
 .chip-container {
   display: flex;
   align-items: center;
-  pointer-events: none;
 
   .status-indicator {
+    pointer-events: none;
     --mdc-chip-container-shape-radius: 4px;
 
     &.disabled {
@@ -71,5 +71,13 @@
       border: 1px solid var(--status-used);
       background-color: var(--status-used-alpha);
     }
+  }
+
+  .warning-icon {
+    margin-left: 6px;
+    font-size: 20px;
+    width: 20px;
+    height: 20px;
+    color: var(--status-disabled);
   }
 }

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-status-indicator-chip/common-status-indicator-chip.component.ts
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-status-indicator-chip/common-status-indicator-chip.component.ts
@@ -1,6 +1,8 @@
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Input, SimpleChanges } from '@angular/core';
 import { MatChipsModule } from '@angular/material/chips';
+import { MatIcon } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { TranslateModule } from '@ngx-translate/core';
 import { STATUS_INDICATOR_CHIP_TYPE } from 'upgrade_types';
 
@@ -10,7 +12,10 @@ import { STATUS_INDICATOR_CHIP_TYPE } from 'upgrade_types';
  * Example usage:
  *
  * ```
- * <app-common-status-indicator-chip chipClass='STATUS_INDICATOR_CHIP_TYPE.ENROLLMENT_COMPLETE'></app-common-status-indicator-chip>
+ * <app-common-status-indicator-chip
+ *  [chipClass]="STATUS_INDICATOR_CHIP_TYPE.ENROLLMENT_COMPLETE"
+ *  [showWarning]="false"
+ * ></app-common-status-indicator-chip>
  * ```
  */
 
@@ -19,11 +24,12 @@ import { STATUS_INDICATOR_CHIP_TYPE } from 'upgrade_types';
   selector: 'app-common-status-indicator-chip',
   templateUrl: './common-status-indicator-chip.component.html',
   styleUrls: ['./common-status-indicator-chip.component.scss'],
-  imports: [CommonModule, TranslateModule, MatChipsModule],
+  imports: [CommonModule, TranslateModule, MatChipsModule, MatIcon, MatTooltipModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CommonStatusIndicatorChipComponent {
   @Input() chipClass!: STATUS_INDICATOR_CHIP_TYPE;
+  @Input() showWarning!: boolean;
   chipText = '';
 
   ngOnInit() {

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-tabbed-section-card-footer/common-tabbed-section-card-footer.component.html
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-tabbed-section-card-footer/common-tabbed-section-card-footer.component.html
@@ -6,7 +6,7 @@
     (selectedTabChange)="onSelectedTabChange($event)"
     class="new-tab-group"
   >
-    <mat-tab *ngFor="let label of tabLabels">
+    <mat-tab *ngFor="let label of tabLabels" [disabled]="label === 'Data'">
       <ng-template mat-tab-label>
         <span class="ft-18-600">
           {{ label }}

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-tabbed-section-card-footer/common-tabbed-section-card-footer.component.scss
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-tabbed-section-card-footer/common-tabbed-section-card-footer.component.scss
@@ -1,4 +1,8 @@
 .footer-container {
   padding: 0 32px;
   border-top: 1px solid var(--light-grey-2);
+
+  ::ng-deep .mat-mdc-tab-disabled .mdc-tab__text-label {
+    opacity: 0.5; // Makes the disabled status more apparent
+  }
 }

--- a/frontend/projects/upgrade/src/app/shared/services/common-dialog.service.ts
+++ b/frontend/projects/upgrade/src/app/shared/services/common-dialog.service.ts
@@ -120,8 +120,7 @@ export class DialogService {
       cancelBtnLabel: 'Cancel',
       params: {
         message: 'Are you sure you want to disable "Include All"?',
-        subMessage:
-          '* Disabling this will revert to the previously defined include lists, if any. Ensure the lists are updated as needed.',
+        subMessage: '* Disabling this will revert to the previously defined include lists, if any.',
         subMessageClass: 'warn',
       },
     };
@@ -137,8 +136,7 @@ export class DialogService {
       cancelBtnLabel: 'Cancel',
       params: {
         message: 'Are you sure you want to enable "Include All"?',
-        subMessage:
-          '* Enabling this will include all participants. Any existing lists, if defined, will be ignored until this is turned off again.',
+        subMessage: '* Enabling this will include all participants except those explicitly excluded.',
         subMessageClass: 'info',
       },
     };

--- a/frontend/projects/upgrade/src/assets/i18n/en.json
+++ b/frontend/projects/upgrade/src/assets/i18n/en.json
@@ -342,6 +342,7 @@
   "feature-flags.details-updated-at.text": "Updated at: ",
   "feature-flags.global-name.text": "Name",
   "feature-flags.global-status.text": "Status",
+  "feature-flags.global-status-warning-tooltip.text": "No include lists defined",
   "feature-flags.global-updated-at.text": "Updated at",
   "feature-flags.global-app-context.text": "App Context",
   "feature-flags.global-tags.text": "Tags",


### PR DESCRIPTION
Resolves #1817, resolves #1815

Changes Include:
- Displayed a warning icon next to the "Enabled" status indicator when no include lists are defined.
- Implemented a tooltip saying "No include lists defined" when hovering over the "Enabled" status with the warning icon next to it.
- Updated messages for the "Enable Include All" and "Disable Include All" modals.
- Disabled the "Data" tab in the Feature Flag details page.
- Refined some import code (mostly importing from `upgrade_types`) for consistency.