### PR TITLE
hide disabled equal true menu item from common action buttons

### DIFF
--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-action-buttons/common-section-card-action-buttons.component.html
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-action-buttons/common-section-card-action-buttons.component.html
@@ -30,14 +30,15 @@
       <mat-icon>more_vert</mat-icon>
     </button>
     <mat-menu #menu="matMenu">
-      <button
-        *ngFor="let item of menuButtonItems"
-        mat-menu-item
-        [disabled]="item.disabled"
-        (click)="onMenuButtonItemClick(item.name)"
-      >
-        <span class="ft-14-400">{{ item.name }}</span>
-      </button>
+      <ng-container *ngFor="let item of menuButtonItems">
+        <button
+          *ngIf="!item.disabled"
+          mat-menu-item
+          (click)="onMenuButtonItemClick(item.name)"
+        >
+          <span class="ft-14-400">{{ item.name }}</span>
+        </button>
+      </ng-container>
     </mat-menu>
 
     <button


### PR DESCRIPTION
This PR hides `disabled = true` menu items from the action button component.
For example, here I kept email CSV options disabled so it's not visible.
![image](https://github.com/user-attachments/assets/3b43e9f5-8434-43b4-accc-f85e25486057)
