### PR TITLE
Centralize demo mode DB clearing logic in ExperimentUserService

### DIFF
--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
@@ -6,7 +6,7 @@ import {
   Req,
   InternalServerError,
   Delete,
-  OnUndefined,
+  Authorized,
 } from 'routing-controllers';
 import { ExperimentService } from '../services/ExperimentService';
 import { ExperimentAssignmentService } from '../services/ExperimentAssignmentService';
@@ -1098,8 +1098,8 @@ export class ExperimentClientController {
    *          '500':
    *            description: DEMO mode is disabled
    */
+  @Authorized()
   @Delete('clearDB')
-  @OnUndefined(204)
   public async clearDB(@Req() request: AppRequest): Promise<string> {
     return this.experimentUserService.clearDB(request.logger);
   }

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.ts
@@ -1,4 +1,13 @@
-import { JsonController, Post, Body, UseBefore, Req, InternalServerError, Delete } from 'routing-controllers';
+import {
+  JsonController,
+  Post,
+  Body,
+  UseBefore,
+  Req,
+  InternalServerError,
+  Delete,
+  OnUndefined,
+} from 'routing-controllers';
 import { ExperimentService } from '../services/ExperimentService';
 import { ExperimentAssignmentService } from '../services/ExperimentAssignmentService';
 import { MarkExperimentValidator } from './validators/MarkExperimentValidator';
@@ -19,7 +28,6 @@ import { ExperimentUserAliasesValidator } from './validators/ExperimentUserAlias
 import { Metric } from '../models/Metric';
 import * as express from 'express';
 import { AppRequest } from '../../types';
-import { env } from '../../env';
 import flatten from 'lodash.flatten';
 import { CaliperLogEnvelope } from './validators/CaliperLogEnvelope';
 import { ExperimentUserValidator } from './validators/ExperimentUserValidator';
@@ -1091,12 +1099,8 @@ export class ExperimentClientController {
    *            description: DEMO mode is disabled
    */
   @Delete('clearDB')
+  @OnUndefined(204)
   public async clearDB(@Req() request: AppRequest): Promise<string> {
-    // if DEMO mode is enabled, then clear the database:
-    if (env.app.demo) {
-      await this.experimentUserService.clearDB(request.logger);
-      return 'DB truncate successful';
-    }
-    return Promise.resolve('DEMO mode is disabled. You cannot clear DB.');
+    return this.experimentUserService.clearDB(request.logger);
   }
 }

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v1.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v1.ts
@@ -27,7 +27,6 @@ import { ExperimentUserAliasesValidator } from './validators/ExperimentUserAlias
 import { Metric } from '../models/Metric';
 import * as express from 'express';
 import { AppRequest } from '../../types';
-import { env } from '../../env';
 import { MonitoredDecisionPointLog } from '../models/MonitoredDecisionPointLog';
 import { Log } from '../models/Log';
 import flatten from 'lodash.flatten';
@@ -1026,12 +1025,6 @@ export class ExperimentClientController {
   @Delete('clearDB')
   @OnUndefined(204)
   public clearDB(@Req() request: AppRequest) {
-    // if DEMO mode is enabled, then clear the database:
-    if (!env.app.demo) {
-      this.experimentUserService.clearDB(request.logger);
-    } else {
-      request.logger.error({ message: 'DEMO mode is disabled. You cannot clear DB.' });
-    }
-    return;
+    return this.experimentUserService.clearDB(request.logger);
   }
 }

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v1.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v1.ts
@@ -7,7 +7,7 @@ import {
   InternalServerError,
   Delete,
   Patch,
-  OnUndefined,
+  Authorized,
 } from 'routing-controllers';
 import { ExperimentService } from '../services/ExperimentService';
 import { ExperimentAssignmentService } from '../services/ExperimentAssignmentService';
@@ -1022,9 +1022,9 @@ export class ExperimentClientController {
    *          '500':
    *            description: DEMO mode is disabled
    */
+  @Authorized()
   @Delete('clearDB')
-  @OnUndefined(204)
-  public clearDB(@Req() request: AppRequest) {
+  public async clearDB(@Req() request: AppRequest): Promise<string> {
     return this.experimentUserService.clearDB(request.logger);
   }
 }

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v4.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v4.ts
@@ -32,7 +32,6 @@ import { ExperimentUserAliasesValidator } from './validators/ExperimentUserAlias
 import { Metric } from '../models/Metric';
 import * as express from 'express';
 import { AppRequest } from '../../types';
-import { env } from '../../env';
 import { MonitoredDecisionPointLog } from '../models/MonitoredDecisionPointLog';
 import { MarkExperimentValidatorv4 } from './validators/MarkExperimentValidator.v4';
 import { Log } from '../models/Log';
@@ -982,12 +981,6 @@ export class ExperimentClientController {
   @Delete('clearDB')
   @OnUndefined(204)
   public clearDB(@Req() request: AppRequest) {
-    // if DEMO mode is enabled, then clear the database:
-    if (!env.app.demo) {
-      this.experimentUserService.clearDB(request.logger);
-    } else {
-      request.logger.error({ message: 'DEMO mode is disabled. You cannot clear DB.' });
-    }
-    return;
+    return this.experimentUserService.clearDB(request.logger);
   }
 }

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v4.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v4.ts
@@ -7,7 +7,7 @@ import {
   InternalServerError,
   Delete,
   Patch,
-  OnUndefined,
+  Authorized,
 } from 'routing-controllers';
 import { ExperimentService } from '../services/ExperimentService';
 import { ExperimentAssignmentService } from '../services/ExperimentAssignmentService';
@@ -978,9 +978,9 @@ export class ExperimentClientController {
    *          '500':
    *            description: DEMO mode is disabled
    */
+  @Authorized()
   @Delete('clearDB')
-  @OnUndefined(204)
-  public clearDB(@Req() request: AppRequest) {
+  public async clearDB(@Req() request: AppRequest): Promise<string> {
     return this.experimentUserService.clearDB(request.logger);
   }
 }

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v5.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v5.ts
@@ -31,7 +31,6 @@ import { MetricService } from '../services/MetricService';
 import { ExperimentUserAliasesValidator } from './validators/ExperimentUserAliasesValidator';
 import * as express from 'express';
 import { AppRequest } from '../../types';
-import { env } from '../../env';
 import { MonitoredDecisionPointLog } from '../models/MonitoredDecisionPointLog';
 import { MarkExperimentValidatorv5 } from './validators/MarkExperimentValidator.v5';
 import { Log } from '../models/Log';
@@ -891,12 +890,6 @@ export class ExperimentClientController {
   @Delete('clearDB')
   @OnUndefined(204)
   public clearDB(@Req() request: AppRequest) {
-    // if DEMO mode is enabled, then clear the database:
-    if (!env.app.demo) {
-      this.experimentUserService.clearDB(request.logger);
-    } else {
-      request.logger.error({ message: 'DEMO mode is disabled. You cannot clear DB.' });
-    }
-    return;
+    return this.experimentUserService.clearDB(request.logger);
   }
 }

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v5.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v5.ts
@@ -7,7 +7,7 @@ import {
   InternalServerError,
   Delete,
   Patch,
-  OnUndefined,
+  Authorized,
 } from 'routing-controllers';
 import { ExperimentService } from '../services/ExperimentService';
 import { ExperimentAssignmentService } from '../services/ExperimentAssignmentService';
@@ -887,9 +887,9 @@ export class ExperimentClientController {
    *          '500':
    *            description: DEMO mode is disabled
    */
+  @Authorized()
   @Delete('clearDB')
-  @OnUndefined(204)
-  public clearDB(@Req() request: AppRequest) {
+  public async clearDB(@Req() request: AppRequest): Promise<string> {
     return this.experimentUserService.clearDB(request.logger);
   }
 }

--- a/backend/packages/Upgrade/src/api/services/ExperimentUserService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentUserService.ts
@@ -12,6 +12,7 @@ import { GroupExclusionRepository } from '../repositories/GroupExclusionReposito
 import { Experiment } from '../models/Experiment';
 import isEqual from 'lodash/isEqual';
 import { RequestedExperimentUser } from '../controllers/validators/ExperimentUserValidator';
+import { env } from '../../env';
 
 @Service()
 export class ExperimentUserService {
@@ -345,10 +346,16 @@ export class ExperimentUserService {
     }
   }
 
-  public async clearDB(logger: UpgradeLogger): Promise<void> {
+  public async clearDB(logger: UpgradeLogger): Promise<string> {
+    if (!env.app.demo) {
+      return 'DEMO mode is disabled. You cannot clear DB.';
+    }
+
     await getConnection().transaction(async (transactionalEntityManager) => {
       await this.experimentRepository.clearDB(transactionalEntityManager, logger);
     });
+
+    return 'DB truncate successful';
   }
 
   /**


### PR DESCRIPTION
This PR centralizes the logic for clearing the database (`/clearDB`) in demo mode within the ExperimentUserService. 

Key changes:
- Moved the demo mode check from `ExperimentClientController` to `ExperimentUserService`
- Updated `clearDB` method in `ExperimentUserService` to include demo mode check
- Simplified `/clearDB` endpoints in all versions of `ExperimentClientController`

Benefits:
- Improves code maintainability by centralizing demo mode logic
- Reduces risk of inconsistencies across different controller versions

Testing:
- Verified that `clearDB` functionality works as expected in demo mode
- Confirmed that `clearDB` is properly restricted when not in demo mode
