### PR TITLE
Add default FetchHttpClient to lite versions for identical usage as non-lite version

### DIFF
--- a/clientlibs/js/jest.config.ts
+++ b/clientlibs/js/jest.config.ts
@@ -11,7 +11,7 @@ const config: Config.InitialOptions = {
       isolatedModules: true,
       diagnostics: false,
     },
-    USE_CUSTOM_HTTP_CLIENT: true,
+    USE_FETCH_DEFAULT_HTTP_CLIENT: true,
     IS_BROWSER: true,
     API_VERSION: 5,
   },

--- a/clientlibs/js/package.json
+++ b/clientlibs/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upgrade_client_lib",
-  "version": "6.0.0",
+  "version": "5.2.0",
   "description": "Client library to communicate with the Upgrade server",
   "files": [
     "dist/*"

--- a/clientlibs/js/src/ApiService/ApiService.ts
+++ b/clientlibs/js/src/ApiService/ApiService.ts
@@ -6,7 +6,7 @@ import { DataService } from 'DataService/DataService';
 import { IApiServiceRequestParams, IEndpoints } from './ApiService.types';
 import { IMarkDecisionPointParams } from 'UpGradeClient/UpGradeClient.types';
 
-// this variable is used by webpack to replace the value of USE_CUSTOM_HTTP_CLIENT with true or false to create two different builds
+// this variable is used by webpack to replace the value of USE_FETCH_DEFAULT_HTTP_CLIENT with true or false to create two different builds
 declare const USE_FETCH_DEFAULT_HTTP_CLIENT: boolean;
 declare const IS_BROWSER: boolean;
 

--- a/clientlibs/js/src/ApiService/ApiService.ts
+++ b/clientlibs/js/src/ApiService/ApiService.ts
@@ -1,12 +1,13 @@
 import { UpGradeClientEnums, UpGradeClientInterfaces, UpGradeClientRequests } from '../types';
 import { DefaultHttpClient } from '../DefaultHttpClient/DefaultHttpClient';
+import { FetchHttpClient } from '../DefaultHttpClient/FetchHttpClient';
 import { CaliperEnvelope, IExperimentAssignmentv5, ILogInput, IUserAliases, ILogRequestBody } from 'upgrade_types';
 import { DataService } from 'DataService/DataService';
 import { IApiServiceRequestParams, IEndpoints } from './ApiService.types';
 import { IMarkDecisionPointParams } from 'UpGradeClient/UpGradeClient.types';
 
 // this variable is used by webpack to replace the value of USE_CUSTOM_HTTP_CLIENT with true or false to create two different builds
-declare const USE_CUSTOM_HTTP_CLIENT: boolean;
+declare const USE_FETCH_DEFAULT_HTTP_CLIENT: boolean;
 declare const IS_BROWSER: boolean;
 
 export default class ApiService {
@@ -41,29 +42,18 @@ export default class ApiService {
   }
 
   private setHttpClient(httpClient: UpGradeClientInterfaces.IHttpClientWrapper) {
-    if (USE_CUSTOM_HTTP_CLIENT && !httpClient) {
-      throw new Error(
-        'Please provide valid httpClient, or use the default (non-"lite") version of the library to our default httpClient.'
-      );
-    }
-
-    if (!USE_CUSTOM_HTTP_CLIENT && httpClient) {
-      throw new Error('Please import "lite" version of the to use custom httpClient.');
-    }
-
-    if (USE_CUSTOM_HTTP_CLIENT && httpClient) {
+    if (httpClient) {
       return httpClient;
     }
 
-    if (!USE_CUSTOM_HTTP_CLIENT && !httpClient) {
-      return new DefaultHttpClient();
+    if (USE_FETCH_DEFAULT_HTTP_CLIENT) {
+      return new FetchHttpClient();
     }
+
+    return new DefaultHttpClient();
   }
 
   private validateClient() {
-    if (!USE_CUSTOM_HTTP_CLIENT && !this.hostUrl) {
-      throw new Error('Please set application host URL first.');
-    }
     if (!this.userId) {
       throw new Error('Please provide valid user id.');
     }

--- a/clientlibs/js/src/DefaultHttpClient/FetchHttpClient.ts
+++ b/clientlibs/js/src/DefaultHttpClient/FetchHttpClient.ts
@@ -1,0 +1,67 @@
+import { UpGradeClientInterfaces, UpGradeClientEnums } from '../types';
+
+export class FetchHttpClient implements UpGradeClientInterfaces.IHttpClientWrapper {
+  public config: UpGradeClientInterfaces.IHttpClientWrapperRequestConfig = null;
+
+  private convertHeaders(headers: { [key: string]: string | string[] }): HeadersInit {
+    const result: HeadersInit = {};
+    for (const [key, value] of Object.entries(headers)) {
+      if (Array.isArray(value)) {
+        result[key] = value.join(', ');
+      } else {
+        result[key] = value;
+      }
+    }
+    return result;
+  }
+
+  private async fetchWithRetry<T>(url: string, options: RequestInit, retries = 3, backoff = 300): Promise<T> {
+    try {
+      const response = await fetch(url, options);
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      return await response.json();
+    } catch (error) {
+      if (retries > 0) {
+        await new Promise((resolve) => setTimeout(resolve, backoff));
+        return this.fetchWithRetry<T>(url, options, retries - 1, backoff * 2);
+      }
+      throw error;
+    }
+  }
+
+  public async doGet<ResponseType>(
+    url: string,
+    options: UpGradeClientInterfaces.IHttpClientWrapperRequestConfig
+  ): Promise<ResponseType> {
+    return this.fetchWithRetry<ResponseType>(url, {
+      method: UpGradeClientEnums.REQUEST_METHOD.GET,
+      headers: this.convertHeaders(options.headers),
+    });
+  }
+
+  public async doPost<ResponseType, RequestBodyType>(
+    url: string,
+    body: RequestBodyType,
+    options: UpGradeClientInterfaces.IHttpClientWrapperRequestConfig
+  ): Promise<ResponseType> {
+    return this.fetchWithRetry<ResponseType>(url, {
+      method: UpGradeClientEnums.REQUEST_METHOD.POST,
+      headers: this.convertHeaders(options.headers),
+      body: JSON.stringify(body),
+    });
+  }
+
+  public async doPatch<ResponseType, RequestBodyType>(
+    url: string,
+    body: RequestBodyType,
+    options: UpGradeClientInterfaces.IHttpClientWrapperRequestConfig
+  ): Promise<ResponseType> {
+    return this.fetchWithRetry<ResponseType>(url, {
+      method: UpGradeClientEnums.REQUEST_METHOD.PATCH,
+      headers: this.convertHeaders(options.headers),
+      body: JSON.stringify(body),
+    });
+  }
+}

--- a/clientlibs/js/src/index.ts
+++ b/clientlibs/js/src/index.ts
@@ -2,11 +2,7 @@ import UpgradeClient from './UpGradeClient/UpgradeClient';
 import Assignment from './Assignment/Assignment';
 import { UpGradeClientEnums, UpGradeClientInterfaces, UpGradeClientRequests } from './types';
 import { MARKED_DECISION_POINT_STATUS } from 'upgrade_types';
-export {
-  UpgradeClient,
-  Assignment,
-  UpGradeClientEnums,
-  UpGradeClientInterfaces,
-  UpGradeClientRequests,
-  MARKED_DECISION_POINT_STATUS,
-};
+
+export default UpgradeClient;
+
+export { Assignment, UpGradeClientEnums, UpGradeClientInterfaces, UpGradeClientRequests, MARKED_DECISION_POINT_STATUS };

--- a/clientlibs/js/webpack.config.ts
+++ b/clientlibs/js/webpack.config.ts
@@ -29,80 +29,36 @@ const generalConfiguration = {
   ],
 };
 
-const browser = {
+const createConfig = (
+  target: string,
+  outputPath: string,
+  useFetchDefaultHttpClient: boolean,
+  isBrowser: boolean,
+  externals = {}
+) => ({
   ...generalConfiguration,
+  target,
   output: {
-    filename: 'index.js',
-    path: path.resolve(__dirname, 'dist/browser'),
+    library: 'UpgradeClient',
+    globalObject: 'this',
     libraryTarget: 'umd',
-    library: 'upgrade-client-lib',
+    libraryExport: 'default',
+    filename: 'index.js',
+    path: path.resolve(__dirname, outputPath),
   },
+  externals,
   plugins: [
     new webpack.DefinePlugin({
       API_VERSION: version,
-      USE_CUSTOM_HTTP_CLIENT: JSON.stringify(false),
-      IS_BROWSER: JSON.stringify(true),
+      USE_FETCH_DEFAULT_HTTP_CLIENT: JSON.stringify(useFetchDefaultHttpClient),
+      IS_BROWSER: JSON.stringify(isBrowser),
     }),
   ],
-};
+});
 
-const node = {
-  ...generalConfiguration,
-  target: 'node',
-  output: {
-    filename: 'index.js',
-    path: path.resolve(__dirname, 'dist/node'),
-    libraryTarget: 'umd',
-    library: 'upgrade-client-lib',
-  },
-  plugins: [
-    new webpack.DefinePlugin({
-      API_VERSION: version,
-      USE_CUSTOM_HTTP_CLIENT: JSON.stringify(false),
-      IS_BROWSER: JSON.stringify(false),
-    }),
-  ],
-};
-
-const browserLite = {
-  ...generalConfiguration,
-  output: {
-    filename: 'index.js',
-    path: path.resolve(__dirname, 'dist/browser-lite'),
-    libraryTarget: 'umd',
-    library: 'upgrade-client-lib',
-  },
-  externals: {
-    axios: 'axios',
-  },
-  plugins: [
-    new webpack.DefinePlugin({
-      API_VERSION: version,
-      USE_CUSTOM_HTTP_CLIENT: JSON.stringify(true),
-      IS_BROWSER: JSON.stringify(true),
-    }),
-  ],
-};
-
-const nodeLite = {
-  ...generalConfiguration,
-  target: 'node',
-  output: {
-    filename: 'index.js',
-    path: path.resolve(__dirname, 'dist/node-lite'),
-    libraryTarget: 'umd',
-    library: 'upgrade-client-lib',
-  },
-  externals: {
-    axios: 'axios',
-  },
-  plugins: [
-    new webpack.DefinePlugin({
-      API_VERSION: version,
-      USE_CUSTOM_HTTP_CLIENT: JSON.stringify(true),
-      IS_BROWSER: JSON.stringify(false),
-    }),
-  ],
-};
-
-module.exports = [browser, node, browserLite, nodeLite];
+module.exports = [
+  createConfig(undefined, 'dist/browser', false, true),
+  createConfig('node', 'dist/node', false, false),
+  createConfig(undefined, 'dist/browser-lite', true, true, { axios: 'axios' }),
+  createConfig('node', 'dist/node-lite', true, false, { axios: 'axios' }),
+];


### PR DESCRIPTION
## Context
This PR builds upon the work in #1565, which addresses #150 for importing clientlib without Webpack. The existing solution requires users to provide a custom HTTP client for the `browser-lite` version (as noted in [this comment](https://github.com/CarnegieLearningWeb/UpGrade/pull/1565#issuecomment-2302061297)). While this approach offers flexibility and further size optimization, I wanted to explore an alternative that might strike a different balance between ease of use and bundle size. 

This exploration aims to enable identical usage across all versions while maintaining a relatively small size for the lite version. I'm entirely open to closing this PR if the team prefers to maintain the current implementation.

## Summary
This PR adds a `FetchHttpClient` as the default for lite versions, enabling identical usage to non-lite versions without requiring a custom HTTP client. This change slightly increases bundle size (around 1KB) but significantly improves out-of-the-box functionality.

## Key Changes
- Implemented `FetchHttpClient` using native `fetch` API
- Set `FetchHttpClient` as default for lite versions (Custom HTTP clients can still be provided if needed)
- Updated webpack configuration and `ApiService` accordingly

## Benefits
- Identical usage between lite and non-lite versions
- No need to provide custom HTTP client for lite versions
- Maintained API consistency across all versions

## Trade-offs
Bundle size changes:
- Browser-lite: 41KB -> 42KB (+1KB, ~2.4% increase)
- Browser: 71KB -> 72KB (+1KB, ~1.4% increase)

The minor size increase is offset by improved user experience and ease of use.

## Usage
Both versions now work identically out-of-the-box:

```javascript
const upClient = new UpgradeClient(userId, hostUrl, context);
await upClient.init();
const assignment = await upClient.getDecisionPointAssignment(site, target);
```
