### PR TITLE
Rename 'list' to 'segment' in FeatureFlagListValidator and related files

### DIFF
--- a/backend/packages/Upgrade/src/api/controllers/FeatureFlagController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/FeatureFlagController.ts
@@ -547,10 +547,10 @@ export class FeatureFlagsController {
     @Body({ validate: true }) exclusionList: FeatureFlagListValidator,
     @Req() request: AppRequest
   ): Promise<FeatureFlagSegmentExclusion> {
-    if (id !== exclusionList.list.id) {
+    if (id !== exclusionList.segment.id) {
       return Promise.reject(
         new Error(
-          `${SERVER_ERROR.INCORRECT_PARAM_FORMAT}: The id in the URL (${id}) does not match the list id in the request body (${exclusionList.list.id}).`
+          `${SERVER_ERROR.INCORRECT_PARAM_FORMAT}: The id in the URL (${id}) does not match the list id in the request body (${exclusionList.segment.id}).`
         )
       );
     }
@@ -591,10 +591,10 @@ export class FeatureFlagsController {
     @Body({ validate: true }) inclusionList: FeatureFlagListValidator,
     @Req() request: AppRequest
   ): Promise<FeatureFlagSegmentInclusion> {
-    if (id !== inclusionList.list.id) {
+    if (id !== inclusionList.segment.id) {
       return Promise.reject(
         new Error(
-          `${SERVER_ERROR.INCORRECT_PARAM_FORMAT}: The id in the URL (${id}) does not match the list id in the request body (${inclusionList.list.id}).`
+          `${SERVER_ERROR.INCORRECT_PARAM_FORMAT}: The id in the URL (${id}) does not match the list id in the request body (${inclusionList.segment.id}).`
         )
       );
     }

--- a/backend/packages/Upgrade/src/api/controllers/validators/FeatureFlagListValidator.ts
+++ b/backend/packages/Upgrade/src/api/controllers/validators/FeatureFlagListValidator.ts
@@ -18,5 +18,5 @@ export class FeatureFlagListValidator {
 
   @ValidateNested()
   @Type(() => SegmentInputValidator)
-  public list: SegmentInputValidator;
+  public segment: SegmentInputValidator;
 }

--- a/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
+++ b/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
@@ -276,8 +276,8 @@ export class FeatureFlagService {
     const executeTransaction = async (manager: EntityManager) => {
       // create a new private segment
       const segmentsToCreate = listsInput.map((listInput) => {
-        listInput.list.type = SEGMENT_TYPE.PRIVATE;
-        return listInput.list;
+        listInput.segment.type = SEGMENT_TYPE.PRIVATE;
+        return listInput.segment;
       });
 
       let newSegments: Segment[];
@@ -303,7 +303,7 @@ export class FeatureFlagService {
         featureFlagSegmentInclusionOrExclusion.listType = listInput.listType;
         featureFlagSegmentInclusionOrExclusion.featureFlag = featureFlags.find((flag) => flag.id === listInput.flagId);
         featureFlagSegmentInclusionOrExclusion.segment = newSegments.find(
-          (segment) => segment.id === listInput.list.id
+          (segment) => segment.id === listInput.segment.id
         );
         return featureFlagSegmentInclusionOrExclusion;
       });
@@ -353,19 +353,19 @@ export class FeatureFlagService {
       let existingRecord: FeatureFlagSegmentInclusion | FeatureFlagSegmentExclusion;
       if (filterType === 'inclusion') {
         existingRecord = await this.featureFlagSegmentInclusionRepository.findOne({
-          where: { featureFlag: { id: listInput.flagId }, segment: { id: listInput.list.id } },
+          where: { featureFlag: { id: listInput.flagId }, segment: { id: listInput.segment.id } },
           relations: ['featureFlag', 'segment'],
         });
       } else {
         existingRecord = await this.featureFlagSegmentExclusionRepository.findOne({
-          where: { featureFlag: { id: listInput.flagId }, segment: { id: listInput.list.id } },
+          where: { featureFlag: { id: listInput.flagId }, segment: { id: listInput.segment.id } },
           relations: ['featureFlag', 'segment'],
         });
       }
 
       if (!existingRecord) {
         throw new Error(
-          `No existing ${filterType} record found for feature flag ${listInput.flagId} and segment ${listInput.list.id}`
+          `No existing ${filterType} record found for feature flag ${listInput.flagId} and segment ${listInput.segment.id}`
         );
       }
 
@@ -376,7 +376,7 @@ export class FeatureFlagService {
       // Update the segment
       try {
         const updatedSegment = await this.segmentService.upsertSegmentInPipeline(
-          listInput.list,
+          listInput.segment,
           logger,
           transactionalEntityManager
         );
@@ -517,13 +517,13 @@ export class FeatureFlagService {
         );
 
         const featureFlagSegmentInclusionList = featureFlag.featureFlagSegmentInclusion.map((segmentInclusionList) => {
-          segmentInclusionList.list.id = uuid();
+          segmentInclusionList.segment.id = uuid();
           segmentInclusionList.flagId = newFlag.id;
           return segmentInclusionList;
         });
 
         const featureFlagSegmentExclusionList = featureFlag.featureFlagSegmentExclusion.map((segmentExclusionList) => {
-          segmentExclusionList.list.id = uuid();
+          segmentExclusionList.segment.id = uuid();
           segmentExclusionList.flagId = newFlag.id;
           return segmentExclusionList;
         });
@@ -610,10 +610,10 @@ export class FeatureFlagService {
       } else {
         const segmentIds = [
           ...flag.featureFlagSegmentInclusion.flatMap((segmentInclusion) => {
-            return segmentInclusion.list.subSegmentIds;
+            return segmentInclusion.segment.subSegmentIds;
           }),
           ...flag.featureFlagSegmentExclusion.flatMap((segmentExclusion) => {
-            return segmentExclusion.list.subSegmentIds;
+            return segmentExclusion.segment.subSegmentIds;
           }),
         ];
 

--- a/backend/packages/Upgrade/test/integration/FeatureFlags/FeatureFlagInclusionExclusion.ts
+++ b/backend/packages/Upgrade/test/integration/FeatureFlags/FeatureFlagInclusionExclusion.ts
@@ -20,7 +20,7 @@ export default async function FeatureFlagInclusionExclusionLogic(): Promise<void
     flagId: flag.id,
     listType: 'group',
     enabled: true,
-    list: {
+    segment: {
       name: 'Feature Flag 1 Inclusion Segment',
       description: 'Feature Flag 1 Inclusion Segment',
       context: 'home',
@@ -35,7 +35,7 @@ export default async function FeatureFlagInclusionExclusionLogic(): Promise<void
     flagId: flag.id,
     listType: 'individual',
     enabled: true,
-    list: {
+    segment: {
       name: 'Feature Flag 1 Exclusion Segment',
       description: 'Feature Flag 1 Exclusion Segment',
       context: 'home',

--- a/backend/packages/Upgrade/test/unit/services/FeatureFlagService.test.ts
+++ b/backend/packages/Upgrade/test/unit/services/FeatureFlagService.test.ts
@@ -1,5 +1,5 @@
 import * as sinon from 'sinon';
-import { Connection, ConnectionManager, getRepository } from 'typeorm';
+import { Connection, ConnectionManager } from 'typeorm';
 import { Test, TestingModuleBuilder } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
@@ -58,7 +58,7 @@ describe('Feature Flag Service Testing', () => {
   mockList.enabled = true;
   mockList.flagId = mockFlag1.id;
   mockList.listType = 'individual';
-  mockList.list = {
+  mockList.segment = {
     name: 'name',
     id: uuid(),
     context: 'context',
@@ -363,7 +363,7 @@ describe('Feature Flag Service Testing', () => {
   });
 
   it('should delete an include list', async () => {
-    const result = await service.deleteList(mockList.list.id, logger);
+    const result = await service.deleteList(mockList.segment.id, logger);
 
     expect(result).toBeTruthy();
   });

--- a/frontend/projects/upgrade/src/app/core/feature-flags/feature-flags.data.service.ts
+++ b/frontend/projects/upgrade/src/app/core/feature-flags/feature-flags.data.service.ts
@@ -87,7 +87,7 @@ export class FeatureFlagsDataService {
   }
 
   updateInclusionList(list: EditPrivateSegmentListRequest): Observable<FeatureFlagSegmentListDetails> {
-    const url = `${this.environment.api.addFlagInclusionList}/${list.list.id}`;
+    const url = `${this.environment.api.addFlagInclusionList}/${list.segment.id}`;
     return this.http.put<FeatureFlagSegmentListDetails>(url, list);
   }
 
@@ -102,7 +102,7 @@ export class FeatureFlagsDataService {
   }
 
   updateExclusionList(list: EditPrivateSegmentListRequest): Observable<FeatureFlagSegmentListDetails> {
-    const url = `${this.environment.api.addFlagExclusionList}/${list.list.id}`;
+    const url = `${this.environment.api.addFlagExclusionList}/${list.segment.id}`;
     return this.http.put<FeatureFlagSegmentListDetails>(url, list);
   }
 

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.model.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.model.ts
@@ -196,13 +196,13 @@ export interface PrivateSegmentListRequest {
   flagId: string;
   enabled: boolean;
   listType: string;
-  list: AddPrivateSegmentListRequestDetails | EditPrivateSegmentListDetails;
+  segment: AddPrivateSegmentListRequestDetails | EditPrivateSegmentListDetails;
 }
 
 export interface AddPrivateSegmentListRequest extends PrivateSegmentListRequest {
-  list: AddPrivateSegmentListRequestDetails;
+  segment: AddPrivateSegmentListRequestDetails;
 }
 
 export interface EditPrivateSegmentListRequest extends PrivateSegmentListRequest {
-  list: EditPrivateSegmentListDetails;
+  segment: EditPrivateSegmentListDetails;
 }

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-modal/upsert-feature-flag-modal.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-modal/upsert-feature-flag-modal.component.ts
@@ -195,7 +195,7 @@ export class UpsertFeatureFlagModalComponent {
 
   createEditRequest(
     { name, key, description, appContext, tags }: FeatureFlagFormData,
-    { id, status, filterMode, featureFlagSegmentInclusion, featureFlagSegmentExclusion }: FeatureFlag
+    { id, status, filterMode }: FeatureFlag
   ): void {
     const flagRequest: UpdateFeatureFlagRequest = {
       id,
@@ -206,8 +206,8 @@ export class UpsertFeatureFlagModalComponent {
       tags,
       status,
       filterMode,
-      featureFlagSegmentInclusion,
-      featureFlagSegmentExclusion,
+      featureFlagSegmentInclusion: [],
+      featureFlagSegmentExclusion: [],
     };
 
     this.featureFlagsService.updateFeatureFlag(flagRequest);

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-modal/upsert-feature-flag-modal.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-modal/upsert-feature-flag-modal.component.ts
@@ -195,7 +195,7 @@ export class UpsertFeatureFlagModalComponent {
 
   createEditRequest(
     { name, key, description, appContext, tags }: FeatureFlagFormData,
-    { id, status, filterMode }: FeatureFlag
+    { id, status, filterMode, featureFlagSegmentInclusion, featureFlagSegmentExclusion }: FeatureFlag
   ): void {
     const flagRequest: UpdateFeatureFlagRequest = {
       id,
@@ -206,8 +206,8 @@ export class UpsertFeatureFlagModalComponent {
       tags,
       status,
       filterMode,
-      featureFlagSegmentInclusion: [],
-      featureFlagSegmentExclusion: [],
+      featureFlagSegmentInclusion,
+      featureFlagSegmentExclusion,
     };
 
     this.featureFlagsService.updateFeatureFlag(flagRequest);

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-inclusions-section-card/feature-flag-inclusions-section-card.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-inclusions-section-card/feature-flag-inclusions-section-card.component.ts
@@ -169,7 +169,7 @@ export class FeatureFlagInclusionsSectionCardComponent {
       flagId,
       enabled,
       listType,
-      list,
+      segment: list,
     };
 
     this.sendUpdateFeatureFlagInclusionRequest(listRequest);

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/modals/upsert-private-segment-list-modal/upsert-private-segment-list-modal.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/modals/upsert-private-segment-list-modal/upsert-private-segment-list-modal.component.ts
@@ -286,14 +286,14 @@ export class UpsertPrivateSegmentListModalComponent {
       flagId: this.config.params.flagId,
       enabled: this.config.params.sourceList?.enabled || isExcludeList, // Maintain existing status for edits, default to false for new include lists, true for all exclude lists
       listType,
-      list,
+      segment: list,
     };
 
     const addListRequest: AddPrivateSegmentListRequest = listRequest;
     const editRequest: EditPrivateSegmentListRequest = {
       ...listRequest,
-      list: {
-        ...listRequest.list,
+      segment: {
+        ...listRequest.segment,
         id: this.config.params.sourceList?.segment?.id,
       },
     };


### PR DESCRIPTION
In this PR solving the issue of renaming `list` to `Segment` for consistency between frontend and backend.

