### PR TITLE
Solve feature flag throwing error on update

### DIFF
--- a/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.actions.ts
+++ b/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.actions.ts
@@ -71,7 +71,6 @@ export const actionSetIsLoadingImportFeatureFlag = createAction(
   props<{ isLoadingImportFeatureFlag: boolean }>()
 );
 
-
 export const actionEmailFeatureFlagData = createAction(
   '[Feature Flags] Email Feature Flag Data',
   props<{ featureFlagId: string }>()

--- a/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.model.ts
+++ b/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.model.ts
@@ -10,8 +10,7 @@ export interface GeneralCRUDResponseFields {
   versionNumber: number;
 }
 
-// Fields belonging to the FeatureFlag entity itself that are not part of the CRUD response
-export interface BaseFeatureFlag {
+export interface CoreFeatureFlagDetails {
   id?: string;
   name: string;
   key: string;
@@ -20,6 +19,10 @@ export interface BaseFeatureFlag {
   tags: string[];
   status: FEATURE_FLAG_STATUS;
   filterMode: FILTER_MODE;
+}
+
+// Fields belonging to the FeatureFlag entity itself that are not part of the CRUD response
+export interface BaseFeatureFlag extends CoreFeatureFlagDetails {
   featureFlagSegmentInclusion: FeatureFlagSegmentListDetails[];
   featureFlagSegmentExclusion: FeatureFlagSegmentListDetails[];
 }
@@ -28,7 +31,7 @@ export interface BaseFeatureFlag {
 export type FeatureFlag = BaseFeatureFlag & GeneralCRUDResponseFields;
 
 // Currently there is no difference between these types, but they semantically different and could diverge later
-export type AddFeatureFlagRequest = BaseFeatureFlag;
+export type AddFeatureFlagRequest = CoreFeatureFlagDetails;
 
 // so that we can throw an error if we try to update the id
 export interface UpdateFeatureFlagRequest extends AddFeatureFlagRequest {

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-modal/upsert-feature-flag-modal.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-modal/upsert-feature-flag-modal.component.ts
@@ -186,8 +186,6 @@ export class UpsertFeatureFlagModalComponent {
       tags,
       status: FEATURE_FLAG_STATUS.DISABLED,
       filterMode: FILTER_MODE.EXCLUDE_ALL,
-      featureFlagSegmentInclusion: [],
-      featureFlagSegmentExclusion: [],
     };
 
     this.featureFlagsService.addFeatureFlag(flagRequest);
@@ -206,8 +204,6 @@ export class UpsertFeatureFlagModalComponent {
       tags,
       status,
       filterMode,
-      featureFlagSegmentInclusion: [],
-      featureFlagSegmentExclusion: [],
     };
 
     this.featureFlagsService.updateFeatureFlag(flagRequest);

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-modal/upsert-feature-flag-modal.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-modal/upsert-feature-flag-modal.component.ts
@@ -195,7 +195,7 @@ export class UpsertFeatureFlagModalComponent {
 
   createEditRequest(
     { name, key, description, appContext, tags }: FeatureFlagFormData,
-    { id, status, filterMode, featureFlagSegmentInclusion, featureFlagSegmentExclusion }: FeatureFlag
+    { id, status, filterMode }: FeatureFlag
   ): void {
     const flagRequest: UpdateFeatureFlagRequest = {
       id,
@@ -206,8 +206,8 @@ export class UpsertFeatureFlagModalComponent {
       tags,
       status,
       filterMode,
-      featureFlagSegmentInclusion,
-      featureFlagSegmentExclusion,
+      featureFlagSegmentInclusion: [],
+      featureFlagSegmentExclusion: [],
     };
 
     this.featureFlagsService.updateFeatureFlag(flagRequest);


### PR DESCRIPTION
On featureFlag update, it throws an error due to wrong validations and sending extra properties on an API call.
The validation part is resolved in import-validation-api PR, and the rest is updated on this PR