### PR TITLE
Display a warning icon when no enabled include lists defined

### DIFF
--- a/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.model.ts
+++ b/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.model.ts
@@ -22,6 +22,7 @@ export interface BaseFeatureFlag {
   filterMode: FILTER_MODE;
   featureFlagSegmentInclusion: FeatureFlagSegmentListDetails[];
   featureFlagSegmentExclusion: FeatureFlagSegmentListDetails[];
+  hasEnabledIncludeList?: boolean;
 }
 
 // Feature Flag entity = base + db-generated fields (we depend on createdOn for sorting, for instance, but it's not truly part of the feature flag base)

--- a/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.selectors.ts
+++ b/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.selectors.ts
@@ -166,24 +166,20 @@ export const selectFeatureFlagExclusions = createSelector(
   }
 );
 
-// Helper function to determine if warning should be shown for a given flag
-const shouldShowWarningForFlag = (flag: FeatureFlag) =>
-  flag?.status === FEATURE_FLAG_STATUS.ENABLED &&
-  flag?.filterMode !== FILTER_MODE.INCLUDE_ALL &&
-  !flag?.featureFlagSegmentInclusion?.length;
-
-// Selector for the selected feature flag
-export const selectShouldShowWarningForSelectedFlag = createSelector(selectSelectedFeatureFlag, (flag: FeatureFlag) =>
-  shouldShowWarningForFlag(flag)
-);
-
-// Selector for all feature flags
 export const selectWarningStatusForAllFlags = createSelector(selectFeatureFlagsState, (state: FeatureFlagState) => {
   const warningStatus = {};
   Object.values(state.entities).forEach((flag) => {
     if (flag) {
-      warningStatus[flag.id] = shouldShowWarningForFlag(flag);
+      warningStatus[flag.id] = flag?.status === FEATURE_FLAG_STATUS.ENABLED && !flag?.hasEnabledIncludeList;
     }
   });
   return warningStatus;
 });
+
+export const selectShouldShowWarningForSelectedFlag = createSelector(
+  selectSelectedFeatureFlag,
+  (flag: FeatureFlag) =>
+    flag?.status === FEATURE_FLAG_STATUS.ENABLED &&
+    flag?.filterMode !== FILTER_MODE.INCLUDE_ALL &&
+    !flag?.featureFlagSegmentInclusion?.some((inclusion) => inclusion.enabled)
+);

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card.component.ts
@@ -77,7 +77,7 @@ export class FeatureFlagRootSectionCardComponent {
   ) {}
 
   ngOnInit() {
-    this.featureFlagService.fetchFeatureFlags();
+    this.featureFlagService.fetchFeatureFlags(true);
   }
 
   ngAfterViewInit() {

--- a/frontend/projects/upgrade/src/assets/i18n/en.json
+++ b/frontend/projects/upgrade/src/assets/i18n/en.json
@@ -342,7 +342,7 @@
   "feature-flags.details-updated-at.text": "Updated at: ",
   "feature-flags.global-name.text": "Name",
   "feature-flags.global-status.text": "Status",
-  "feature-flags.global-status-warning-tooltip.text": "No include lists defined",
+  "feature-flags.global-status-warning-tooltip.text": "No include lists enabled",
   "feature-flags.global-updated-at.text": "Updated at",
   "feature-flags.global-app-context.text": "App Context",
   "feature-flags.global-tags.text": "Tags",


### PR DESCRIPTION
Resolves #1841, resolves #1838

This PR is for displaying a warning icon on the Feature Flags root page and details page when an enabled feature flag has no enabled include lists defined.

Changes made:

- Updated the `api/flags/paginated` endpoint to include `hasEnabledIncludeList` in the response.
- Updated the selectors for retrieving the warning state in `feature-flags.selector.ts`.
- Modified `this.featureFlagService.fetchFeatureFlags() `to `this.featureFlagService.fetchFeatureFlags(true)` in the `FeatureFlagRootSectionCardComponent`. This ensures that flags are re-fetched from `api/flags/paginated` whenever the user navigates back to the root page.