### PR TITLE
Display a warning icon when no enabled include lists defined 2

### DIFF
--- a/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
+++ b/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
@@ -146,6 +146,7 @@ export class FeatureFlagService {
 
     let queryBuilder = this.featureFlagRepository
       .createQueryBuilder('feature_flag')
+      .leftJoinAndSelect('feature_flag.featureFlagSegmentInclusion', 'featureFlagSegmentInclusion')
       .loadRelationCountAndMap('feature_flag.featureFlagExposures', 'feature_flag.featureFlagExposures');
     if (searchParams) {
       const customSearchString = searchParams.string.split(' ').join(`:*&`);

--- a/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.selectors.ts
+++ b/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.selectors.ts
@@ -170,7 +170,7 @@ export const selectFeatureFlagExclusions = createSelector(
 const shouldShowWarningForFlag = (flag: FeatureFlag) =>
   flag?.status === FEATURE_FLAG_STATUS.ENABLED &&
   flag?.filterMode !== FILTER_MODE.INCLUDE_ALL &&
-  !flag?.featureFlagSegmentInclusion?.length;
+  !flag?.featureFlagSegmentInclusion?.some((inclusion) => inclusion.enabled);
 
 // Selector for the selected feature flag
 export const selectShouldShowWarningForSelectedFlag = createSelector(selectSelectedFeatureFlag, (flag: FeatureFlag) =>

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card.component.ts
@@ -77,7 +77,7 @@ export class FeatureFlagRootSectionCardComponent {
   ) {}
 
   ngOnInit() {
-    this.featureFlagService.fetchFeatureFlags();
+    this.featureFlagService.fetchFeatureFlags(true);
   }
 
   ngAfterViewInit() {

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-details-participant-list-table/common-details-participant-list-table.component.html
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-details-participant-list-table/common-details-participant-list-table.component.html
@@ -22,7 +22,7 @@
         {{ PARTICIPANT_LIST_TRANSLATION_KEYS.VALUES | translate }}
       </th>
       <td mat-cell *matCellDef="let rowData" class="values-column ft-14-400">
-        <ng-container *ngIf="rowData.listType !== memberTypes.SEGMENT">
+        <ng-container *ngIf="rowData.listType !== memberTypes.SEGMENT && rowData.segment">
           {{
             (rowData.listType === memberTypes.INDIVIDUAL
               ? rowData.segment.individualForSegment.length
@@ -39,7 +39,7 @@
       </th>
       <!-- TODO this is placeholder logic, need to simplify -->
       <td mat-cell *matCellDef="let rowData" class="name-column ft-14-400">
-        {{ rowData.segment.name }}
+        {{ rowData.segment?.name }}
       </td>
     </ng-container>
 

--- a/frontend/projects/upgrade/src/assets/i18n/en.json
+++ b/frontend/projects/upgrade/src/assets/i18n/en.json
@@ -342,7 +342,7 @@
   "feature-flags.details-updated-at.text": "Updated at: ",
   "feature-flags.global-name.text": "Name",
   "feature-flags.global-status.text": "Status",
-  "feature-flags.global-status-warning-tooltip.text": "No include lists defined",
+  "feature-flags.global-status-warning-tooltip.text": "No include lists enabled",
   "feature-flags.global-updated-at.text": "Updated at",
   "feature-flags.global-app-context.text": "App Context",
   "feature-flags.global-tags.text": "Tags",


### PR DESCRIPTION
Resolves #1841, resolves #1838

This PR does the same thing as PR #1892 (will be closed if this is merged), but it includes `featureFlagSegmentInclusion` instead of `hasEnabledIncludeList` in the response from the `api/flags/paginated` endpoint. Also, this PR doesn't require updating the current test cases to avoid failures.


Changes made:

- Updated the `api/flags/paginated` endpoint to include `featureFlagSegmentInclusion` in the response.
- Updated the selector logic for determining the warning state in `feature-flags.selector.ts`.
- Modified `this.featureFlagService.fetchFeatureFlags()` to `this.featureFlagService.fetchFeatureFlags(true)` in the FeatureFlagRootSectionCardComponent to ensure that flags are re-fetched from `api/flags/paginated` whenever the user navigates back to the root page.
- Updated the warning tooltip message to "No include lists enabled."
- Updated `common-details-participant-list-table.component.html` to fix the `undefined` errors when navigating to the details page.