### PR TITLE
Fix undefined segment errors in Feature Flag Inclusion and Exclusion selectors

### DIFF
--- a/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.selectors.ts
+++ b/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.selectors.ts
@@ -139,35 +139,33 @@ export const selectIsLoadingFeatureFlagDelete = createSelector(
 export const selectFeatureFlagInclusions = createSelector(
   selectSelectedFeatureFlag,
   (featureFlag: FeatureFlag): ParticipantListTableRow[] => {
-    if (!featureFlag || !featureFlag.featureFlagSegmentInclusion) {
+    if (!featureFlag?.featureFlagSegmentInclusion?.length) {
       return [];
     }
-    return [...featureFlag.featureFlagSegmentInclusion]
+    return featureFlag.featureFlagSegmentInclusion
+      .filter((inclusion) => inclusion.segment)
       .sort((a, b) => new Date(a.segment.createdAt).getTime() - new Date(b.segment.createdAt).getTime())
-      .map((inclusion) => {
-        return {
-          segment: inclusion.segment,
-          listType: inclusion.listType,
-          enabled: inclusion.enabled,
-        };
-      });
+      .map((inclusion) => ({
+        segment: inclusion.segment,
+        listType: inclusion.listType,
+        enabled: inclusion.enabled,
+      }));
   }
 );
 
 export const selectFeatureFlagExclusions = createSelector(
   selectSelectedFeatureFlag,
   (featureFlag: FeatureFlag): ParticipantListTableRow[] => {
-    if (!featureFlag || !featureFlag.featureFlagSegmentExclusion) {
+    if (!featureFlag?.featureFlagSegmentExclusion?.length) {
       return [];
     }
-    return [...featureFlag.featureFlagSegmentExclusion]
+    return featureFlag.featureFlagSegmentExclusion
+      .filter((exclusion) => exclusion.segment)
       .sort((a, b) => new Date(a.segment.createdAt).getTime() - new Date(b.segment.createdAt).getTime())
-      .map((exclusion) => {
-        return {
-          segment: exclusion.segment,
-          listType: exclusion.listType,
-        };
-      });
+      .map((exclusion) => ({
+        segment: exclusion.segment,
+        listType: exclusion.listType,
+      }));
   }
 );
 


### PR DESCRIPTION
Resolves #1910 

This PR fixes the `TypeError: Cannot read properties of undefined (reading 'createdAt')` error that occurs when navigating to some Feature Flag details pages. This error is caused by attempting to access the `createdAt` property from `segment` when `segment` is not available from the store (This issue started happening after merging #1907 which included `featureFlagSegmentInclusion` in the `flags/paginated` response). The fix involves adding a filter step: `.filter((inclusion) => inclusion.segment)` to ensure segment exists before accessing its properties. This PR also simplifies the existing selector code.