### PR TITLE
Sort Segments and Groups in Alphabetical Order for Upsert List Modal

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/modals/upsert-private-segment-list-modal/upsert-private-segment-list-modal.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/modals/upsert-private-segment-list-modal/upsert-private-segment-list-modal.component.ts
@@ -204,6 +204,7 @@ export class UpsertPrivateSegmentListModalComponent {
 
   listenForSegmentsFilteredByUserInput(): void {
     this.segmentsOptions$ = this.segmentsFilteredByContext$.pipe(
+      map((segments) => segments.sort((a, b) => a.name.localeCompare(b.name))),
       combineLatestWith(
         this.privateSegmentListForm.get(PRIVATE_SEGMENT_LIST_FORM_FIELDS.SEGMENT).valueChanges.pipe(startWith(''))
       ),

--- a/frontend/projects/upgrade/src/app/shared/services/common-text-helpers.service.ts
+++ b/frontend/projects/upgrade/src/app/shared/services/common-text-helpers.service.ts
@@ -22,9 +22,12 @@ export class CommonTextHelpersService {
     if (!Array.isArray(groupTypes)) {
       return [];
     }
-    return groupTypes.map((groupType) => {
-      return { value: groupType, viewValue: CommonTextHelpersService.formatGroupTypeViewValue(groupType) };
-    });
+    return groupTypes
+      .map((groupType) => ({
+        value: groupType,
+        viewValue: CommonTextHelpersService.formatGroupTypeViewValue(groupType),
+      }))
+      .sort((a, b) => a.viewValue.localeCompare(b.viewValue));
   }
 
   /**
@@ -37,7 +40,7 @@ export class CommonTextHelpersService {
    * to create an instance of the service.
    */
   public static formatGroupTypeViewValue(groupType: string): string {
-    return 'Group: "' + groupType + '"';
+    return 'Group: ' + groupType;
   }
 
   /**


### PR DESCRIPTION
Closes #1749

This PR resolves the https://github.com/CarnegieLearningWeb/UpGrade/issues/1749#issuecomment-2328953258 so that the segments and group names appear in alphabetical order (ascending order) in the Add/Update Include/Exclude List modals.

<img width="1000" alt="Screenshot 2024-09-10 at 8 47 27 PM" src="https://github.com/user-attachments/assets/54d8ca9e-393d-40c2-a827-f5109649d465">

<img width="1000" alt="Screenshot 2024-09-10 at 8 47 06 PM" src="https://github.com/user-attachments/assets/7609d38c-8347-4c1a-9985-b5825a08ce44">