### PR TITLE
Add description under flag name with tooltip

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.html
@@ -18,12 +18,20 @@
       <td mat-cell *matCellDef="let flag" class="name-column ft-14-400">
         <a
           [routerLink]="['/featureflags', 'detail', flag.id]"
-          [matTooltip]="flag.name.length >= 30 ? flag.name : null"
+          [matTooltip]="flag.name.length > 24 ? flag.name : null"
           matTooltipPosition="above"
           class="flag-name"
         >
-          {{ flag.name | truncate: 30 }}
+          {{ flag.name | truncate: 24 }}
         </a>
+        <br />
+        <span
+          [matTooltip]="flag.description?.length > 35 ? flag.description : null"
+          matTooltipPosition="above"
+          class="flag-description ft-10-400"
+        >
+          {{ flag.description | truncate: 35 }}
+        </span>
       </td>
     </ng-container>
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.scss
@@ -67,6 +67,10 @@
       .flag-name {
         color: var(--black-2);
       }
+
+      .flag-description {
+        color: var(--grey-3);
+      }
     }
 
     .status-column {


### PR DESCRIPTION
Resolves #1704

This PR displays the description under flag name with a tooltip when the text is truncated (for both the name and description) just like how it works on the Experiments root page.

<img width="1000" alt="Screenshot 2024-09-12 at 5 31 36 PM" src="https://github.com/user-attachments/assets/ec077a37-8e9c-46bf-8a46-e1afcb3136c9">
