### PR TITLE
Remove hash from URL and fix redirecting to home on refresh

### DIFF
--- a/frontend/projects/upgrade/src/app/app-routing.module.ts
+++ b/frontend/projects/upgrade/src/app/app-routing.module.ts
@@ -28,7 +28,7 @@ const routes: Routes = [
   // useHash supports github.io demo page, remove in your app
   imports: [
     RouterModule.forRoot(routes, {
-      useHash: true,
+      useHash: false,
       scrollPositionRestoration: 'enabled',
     }),
   ],


### PR DESCRIPTION
Resolves #1926, resolves #1904

This PR removes the unnecessary `/#/` from URLs and fixes the issue of redirecting to `/home` on refresh.

I'm not sure why we previously set `useHash` to `true`. Setting this to `false` has fixed these issues.
