### PR TITLE
fix FF import validation

### DIFF
--- a/backend/packages/Upgrade/src/api/controllers/validators/FeatureFlagValidator.ts
+++ b/backend/packages/Upgrade/src/api/controllers/validators/FeatureFlagValidator.ts
@@ -90,7 +90,6 @@ class FeatureFlagFile {
   public fileName: string;
 
   @IsString()
-  @IsNotEmpty()
   @IsDefined()
   public fileContent: string;
 }

--- a/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
+++ b/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
@@ -852,11 +852,14 @@ export class FeatureFlagService {
     let compatibilityType = FF_COMPATIBILITY_TYPE.COMPATIBLE;
 
     flag = plainToClass(FeatureFlagImportDataValidation, flag);
-    await validate(flag).then((errors) => {
+    await validate(flag, { forbidUnknownValues: true, stopAtFirstError: true }).then((errors) => {
       if (errors.length > 0) {
         compatibilityType = FF_COMPATIBILITY_TYPE.INCOMPATIBLE;
       }
     });
+    if (!flag) {
+      compatibilityType = FF_COMPATIBILITY_TYPE.INCOMPATIBLE;
+    }
 
     if (compatibilityType === FF_COMPATIBILITY_TYPE.COMPATIBLE) {
       const keyExists = existingFeatureFlags.find((existingFlag) => existingFlag.key === flag.key);


### PR DESCRIPTION
Tested against an empty file, a file containing only '[]', and a file containing only '""', all of which had previously returned 'compatible'.