### PR TITLE
Closing the experiment stepper after clicking on save is not working as expected with other small edit bugs

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.html
@@ -1,44 +1,21 @@
 <div *ngIf="!(isLoadingContextMetaData$ | async); else loadingExperimentOverview" class="shared-modal--step-container">
   <section class="shared-modal--form-container">
     <form class="experiment-overview dense-3" [formGroup]="overviewForm">
-      <mat-form-field
-        class="name"
-        appearance="outline"
-        subscriptSizing="dynamic"
-      >
+      <mat-form-field class="name" appearance="outline" subscriptSizing="dynamic">
         <mat-label class="ft-14-400">
           {{ 'home.new-experiment.overview.name.placeHolder' | translate }}
         </mat-label>
-        <input
-          class="ft-14-400"
-          matInput
-          formControlName="experimentName"
-          autocomplete="off"
-          cdkFocusInitial
-        />
+        <input class="ft-14-400" matInput formControlName="experimentName" autocomplete="off" cdkFocusInitial />
       </mat-form-field>
 
-      <mat-form-field
-        class="description"
-        appearance="outline"
-        subscriptSizing="dynamic"
-      >
+      <mat-form-field class="description" appearance="outline" subscriptSizing="dynamic">
         <mat-label class="ft-14-400">
           {{ 'home.new-experiment.overview.description.placeHolder' | translate }}
         </mat-label>
-        <input
-          class="ft-14-400"
-          matInput
-          formControlName="description"
-          autocomplete="off"
-        />
+        <input class="ft-14-400" matInput formControlName="description" autocomplete="off" />
       </mat-form-field>
 
-      <mat-form-field
-        class="chips"
-        appearance="outline"
-        subscriptSizing="dynamic"
-      >
+      <mat-form-field class="chips" appearance="outline" subscriptSizing="dynamic">
         <mat-label class="ft-14-400">
           {{ 'home.new-experiment.overview.app-context.placeHolder' | translate }}
         </mat-label>
@@ -50,16 +27,16 @@
       </mat-form-field>
 
       <div class="property-container">
-        <mat-form-field
-          class="unit-of-assignment"
-          appearance="outline"
-          subscriptSizing="dynamic"
-        >
+        <mat-form-field class="unit-of-assignment" appearance="outline" subscriptSizing="dynamic">
           <mat-label class="ft-14-400">
             {{ 'home-global.unit-of-assignment.text' | translate }}
           </mat-label>
           <mat-select class="ft-14-400" formControlName="unitOfAssignment">
-            <mat-option class="ft-14-400" *ngFor="let unitOfAssignment of unitOfAssignments" [value]="unitOfAssignment.value">
+            <mat-option
+              class="ft-14-400"
+              *ngFor="let unitOfAssignment of unitOfAssignments"
+              [value]="unitOfAssignment.value"
+            >
               {{ unitOfAssignment.value | titlecase }}
             </mat-option>
           </mat-select>
@@ -75,7 +52,9 @@
             {{ 'home.new-experiment.overview.group-type.placeHolder' | translate }}
           </mat-label>
           <mat-select class="ft-14-400" formControlName="groupType" [disabled]="!isExperimentEditable">
-            <mat-option class="ft-14-400" *ngFor="let group of groupTypes" [value]="group.value">{{ group.value }}</mat-option>
+            <mat-option class="ft-14-400" *ngFor="let group of groupTypes" [value]="group.value">{{
+              group.value
+            }}</mat-option>
           </mat-select>
         </mat-form-field>
       </div>
@@ -90,7 +69,11 @@
           {{ 'home-global.consistency-rule.text' | translate }}
         </mat-label>
         <mat-select class="ft-14-400" formControlName="consistencyRule" [disabled]="!isExperimentEditable">
-          <mat-option class="ft-14-400" *ngFor="let consistencyRule of consistencyRules" [value]="consistencyRule.value">
+          <mat-option
+            class="ft-14-400"
+            *ngFor="let consistencyRule of consistencyRules"
+            [value]="consistencyRule.value"
+          >
             {{ consistencyRule.value | titlecase }}
           </mat-option>
         </mat-select>
@@ -112,11 +95,7 @@
         </mat-select>
       </mat-form-field>
 
-      <mat-form-field
-        class="design-type"
-        appearance="outline"
-        subscriptSizing="dynamic"
-      >
+      <mat-form-field class="design-type" appearance="outline" subscriptSizing="dynamic">
         <mat-label class="ft-14-400">
           {{ 'home-global.design-type.text' | translate }}
         </mat-label>
@@ -128,16 +107,16 @@
       </mat-form-field>
 
       <div class="stratification-container">
-        <mat-form-field
-          class="assignment-algorithm"
-          appearance="outline"
-          subscriptSizing="dynamic"
-        >
+        <mat-form-field class="assignment-algorithm" appearance="outline" subscriptSizing="dynamic">
           <mat-label class="ft-14-400">
             {{ 'home-global.assignment-algorithm.text' | translate }}
           </mat-label>
           <mat-select class="ft-14-400" formControlName="assignmentAlgorithm">
-            <mat-option class="ft-14-400" *ngFor="let assignmentAlgorithm of assignmentAlgorithms" [value]="assignmentAlgorithm.value">
+            <mat-option
+              class="ft-14-400"
+              *ngFor="let assignmentAlgorithm of assignmentAlgorithms"
+              [value]="assignmentAlgorithm.value"
+            >
               {{ assignmentAlgorithm.value | titlecase }}
             </mat-option>
           </mat-select>
@@ -153,18 +132,18 @@
             {{ 'home-global.stratification-factor.text' | translate }}
           </mat-label>
           <mat-select class="ft-14-400" formControlName="stratificationFactor" [disabled]="!isExperimentEditable">
-            <mat-option class="ft-14-400" *ngFor="let stratificationFactor of allStratificationFactors" [value]="stratificationFactor.factorName">
+            <mat-option
+              class="ft-14-400"
+              *ngFor="let stratificationFactor of allStratificationFactors"
+              [value]="stratificationFactor.factorName"
+            >
               {{ stratificationFactor.factorName }}
             </mat-option>
           </mat-select>
         </mat-form-field>
       </div>
 
-      <mat-form-field
-        class="tags"
-        appearance="outline"
-        subscriptSizing="dynamic"
-      >
+      <mat-form-field class="tags" appearance="outline" subscriptSizing="dynamic">
         <mat-label class="ft-14-400">
           {{ 'home.new-experiment.overview.tags.placeHolder' | translate }}
         </mat-label>
@@ -202,7 +181,7 @@
         [innerHTML]="stratificationFactorNotSelectedMsg | translate"
       ></span>
     </div>
-</section>
+  </section>
 
   <section class="shared-modal--buttons-container sticky">
     <span class="shared-modal--buttons-left">
@@ -234,9 +213,9 @@
         mat-raised-button
         class="shared-modal--modal-btn default-button"
         [ngClass]="{
-          'default-button--disabled': !isExperimentEditable
+          'default-button--disabled': !isExperimentEditable || isContextOrTypeChanged
         }"
-        [disabled]="!isExperimentEditable"
+        [disabled]="!isExperimentEditable || isContextOrTypeChanged"
         (click)="emitEvent(NewExperimentDialogEvents.SAVE_DATA)"
       >
         {{ 'global.save.text' | translate }}

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.html
@@ -168,19 +168,19 @@
           />
         </mat-chip-grid>
       </mat-form-field>
+      <div class="validation-container">
+        <span
+          class="ft-14-600 validation-message"
+          *ngIf="!isStratificationFactorSelected"
+          [innerHTML]="stratificationFactorNotSelectedMsg | translate"
+        ></span>
+      </div>
       <mat-checkbox color="primary" formControlName="logging">
         <span class="ft-13-700 checkbox-label">
           {{ 'home.view-experiment.logging.text' | translate }}
         </span>
       </mat-checkbox>
     </form>
-    <div class="validation-container">
-      <span
-        class="ft-14-600 validation-message"
-        *ngIf="!isStratificationFactorSelected"
-        [innerHTML]="stratificationFactorNotSelectedMsg | translate"
-      ></span>
-    </div>
   </section>
 
   <section class="shared-modal--buttons-container sticky">

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.html
@@ -168,19 +168,19 @@
           />
         </mat-chip-grid>
       </mat-form-field>
-      <div class="validation-container">
-        <span
-          class="ft-14-600 validation-message"
-          *ngIf="!isStratificationFactorSelected"
-          [innerHTML]="stratificationFactorNotSelectedMsg | translate"
-        ></span>
-      </div>
-      <mat-checkbox color="primary" formControlName="logging">
+      <mat-checkbox class="check-box" color="primary" formControlName="logging">
         <span class="ft-13-700 checkbox-label">
           {{ 'home.view-experiment.logging.text' | translate }}
         </span>
       </mat-checkbox>
     </form>
+    <div class="validation-container">
+      <span
+        class="ft-14-600 validation-message"
+        *ngIf="!isStratificationFactorSelected"
+        [innerHTML]="stratificationFactorNotSelectedMsg | translate"
+      ></span>
+    </div>
   </section>
 
   <section class="shared-modal--buttons-container sticky">

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.scss
@@ -50,7 +50,7 @@
   .mat-mdc-checkbox {
     z-index: 1;
     margin-top: -6px;
-    margin-left: -12px;
+    margin-left: -8px;
   }
 }
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.scss
@@ -49,8 +49,12 @@
 
   .mat-mdc-checkbox {
     z-index: 1;
-    margin-top: -6px;
+    margin-top: -15px;
     margin-left: -8px;
+  }
+
+  .checkbox-label {
+    margin-left: 2px;
   }
 }
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.ts
@@ -56,7 +56,6 @@ export class ExperimentOverviewComponent implements OnInit, OnDestroy {
   enableSave = true;
   allContexts = [];
   currentContext = null;
-  initialContext = null;
   initialDesignType = EXPERIMENT_TYPE.SIMPLE;
   isContextOrTypeChanged = false;
   consistencyRules = [{ value: CONSISTENCY_RULE.INDIVIDUAL }, { value: CONSISTENCY_RULE.GROUP }];
@@ -177,7 +176,7 @@ export class ExperimentOverviewComponent implements OnInit, OnDestroy {
       });
 
       this.overviewForm.get('context').valueChanges.subscribe((context) => {
-        this.isContextOrTypeChanged = this.initialContext !== context;
+        this.isContextOrTypeChanged = this.currentContext !== context;
         this.currentContext = context;
         this.experimentService.setCurrentContext(context);
         this.setGroupTypes();
@@ -185,6 +184,7 @@ export class ExperimentOverviewComponent implements OnInit, OnDestroy {
 
       this.overviewForm.get('designType').valueChanges.subscribe((type) => {
         this.isContextOrTypeChanged = this.initialDesignType !== type;
+        this.initialDesignType = type;
       });
 
       this.overviewForm.get('assignmentAlgorithm').valueChanges.subscribe((algo) => {
@@ -202,7 +202,6 @@ export class ExperimentOverviewComponent implements OnInit, OnDestroy {
           this.isExperimentEditable = false;
         }
         this.currentContext = this.experimentInfo.context[0];
-        this.initialContext = this.experimentInfo.context[0];
         this.initialDesignType = this.experimentInfo.type;
 
         this.overviewForm.setValue({

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.ts
@@ -56,6 +56,7 @@ export class ExperimentOverviewComponent implements OnInit, OnDestroy {
   enableSave = true;
   allContexts = [];
   currentContext = null;
+  initialContext = null;
   initialDesignType = EXPERIMENT_TYPE.SIMPLE;
   isContextOrTypeChanged = false;
   consistencyRules = [{ value: CONSISTENCY_RULE.INDIVIDUAL }, { value: CONSISTENCY_RULE.GROUP }];
@@ -176,7 +177,7 @@ export class ExperimentOverviewComponent implements OnInit, OnDestroy {
       });
 
       this.overviewForm.get('context').valueChanges.subscribe((context) => {
-        this.isContextOrTypeChanged = this.currentContext !== context;
+        this.isContextOrTypeChanged = this.initialContext !== context;
         this.currentContext = context;
         this.experimentService.setCurrentContext(context);
         this.setGroupTypes();
@@ -184,6 +185,11 @@ export class ExperimentOverviewComponent implements OnInit, OnDestroy {
 
       this.overviewForm.get('designType').valueChanges.subscribe((type) => {
         this.isContextOrTypeChanged = this.initialDesignType !== type;
+      });
+
+      this.overviewForm.get('assignmentAlgorithm').valueChanges.subscribe((algo) => {
+        this.isStratificationFactorSelected =
+          ASSIGNMENT_ALGORITHM.STRATIFIED_RANDOM_SAMPLING !== algo ? true : this.isStratificationFactorSelected;
       });
 
       // populate values in form to update experiment if experiment data is available
@@ -196,6 +202,7 @@ export class ExperimentOverviewComponent implements OnInit, OnDestroy {
           this.isExperimentEditable = false;
         }
         this.currentContext = this.experimentInfo.context[0];
+        this.initialContext = this.experimentInfo.context[0];
         this.initialDesignType = this.experimentInfo.type;
 
         this.overviewForm.setValue({
@@ -380,6 +387,7 @@ export class ExperimentOverviewComponent implements OnInit, OnDestroy {
         this.isStratificationFactorSelected = true;
       }
     } else {
+      this.isStratificationFactorSelected = true;
       stratificationFactorValueToSend = null;
     }
     return stratificationFactorValueToSend;

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.ts
@@ -16,6 +16,7 @@ import {
   CONDITION_ORDER,
   CONSISTENCY_RULE,
   EXPERIMENT_STATE,
+  EXPERIMENT_TYPE,
 } from 'upgrade_types';
 import {
   NewExperimentDialogEvents,
@@ -55,6 +56,8 @@ export class ExperimentOverviewComponent implements OnInit, OnDestroy {
   enableSave = true;
   allContexts = [];
   currentContext = null;
+  initialDesignType = EXPERIMENT_TYPE.SIMPLE;
+  isContextOrTypeChanged = false;
   consistencyRules = [{ value: CONSISTENCY_RULE.INDIVIDUAL }, { value: CONSISTENCY_RULE.GROUP }];
   conditionOrders = [
     { value: CONDITION_ORDER.RANDOM },
@@ -173,9 +176,14 @@ export class ExperimentOverviewComponent implements OnInit, OnDestroy {
       });
 
       this.overviewForm.get('context').valueChanges.subscribe((context) => {
+        this.isContextOrTypeChanged = this.currentContext !== context;
         this.currentContext = context;
         this.experimentService.setCurrentContext(context);
         this.setGroupTypes();
+      });
+
+      this.overviewForm.get('designType').valueChanges.subscribe((type) => {
+        this.isContextOrTypeChanged = this.initialDesignType !== type;
       });
 
       // populate values in form to update experiment if experiment data is available
@@ -188,6 +196,7 @@ export class ExperimentOverviewComponent implements OnInit, OnDestroy {
           this.isExperimentEditable = false;
         }
         this.currentContext = this.experimentInfo.context[0];
+        this.initialDesignType = this.experimentInfo.type;
 
         this.overviewForm.setValue({
           experimentName: this.experimentInfo.name,

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/new-experiment/new-experiment.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/new-experiment/new-experiment.component.ts
@@ -98,6 +98,7 @@ export class NewExperimentComponent implements OnInit {
         };
         this.checkPostExperimentRule();
         this.experimentService.updateExperiment(this.newExperimentData);
+        this.onNoClick();
         break;
     }
   }

--- a/frontend/projects/upgrade/src/app/shared/services/common-dialog.service.ts
+++ b/frontend/projects/upgrade/src/app/shared/services/common-dialog.service.ts
@@ -143,8 +143,7 @@ export class DialogService {
       cancelBtnLabel: 'Cancel',
       params: {
         message: 'Are you sure you want to disable "Include All"?',
-        subMessage:
-          '* Disabling this will revert to the previously defined include lists, if any.',
+        subMessage: '* Disabling this will revert to the previously defined include lists, if any.',
         subMessageClass: 'warn',
       },
     };


### PR DESCRIPTION
This PR will fix the issue of the experiment modal not closing after saving changes in edit.

The "Save" button on the overview stepper is not disabled on context/experimentType change, as we had earlier, this might have been changed in some commit. We need to ensure the experimenter moves to the design page to update the decision points and conditions according to the updated context/experimentType, or else the wrong design is mapped with the context or experimentType. The "Save" button should remain enabled for all other edits other than context/experimentType on the Overview page.

If we select the assignment algorithm as SRS but we don't have any factor to select from then clicking on next will throw an error but if it moves back to random it should allow the user to go next which was not happening. This PR fixes that issue by moving the assignment algorithm back to random.