### PR TITLE
return 'warning' compatibility when segments are not found

### DIFF
--- a/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
+++ b/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
@@ -888,11 +888,10 @@ export class FeatureFlagService {
         ];
 
         const segments = await this.segmentService.getSegmentByIds(segmentIds);
-        segments.forEach((segment) => {
-          if (segment == undefined) {
-            compatibilityType = FF_COMPATIBILITY_TYPE.WARNING;
-          }
-        });
+        if (segmentIds.length !== segments.length) {
+          // If any of the segments are not found then show the compatibility warning
+          compatibilityType = FF_COMPATIBILITY_TYPE.WARNING;
+        }
       }
     }
 


### PR DESCRIPTION
Send the 'warning' compatibility type when public segments in imported lists are not found.