### PR TITLE
Remove error snackbar for 401 errors that redirects to the login page

### DIFF
--- a/frontend/projects/upgrade/src/app/core/http-interceptors/http-error.interceptor.ts
+++ b/frontend/projects/upgrade/src/app/core/http-interceptors/http-error.interceptor.ts
@@ -30,9 +30,9 @@ export class HttpErrorInterceptor implements HttpInterceptor {
         if (err.status === 401) {
           // auto logout if 401 response returned from api
           this.authService.authLogout();
+        } else {
+          this.openPopup(err);
         }
-        this.openPopup(err);
-
         // re-throw to allow the error to be caught by the calling code
         throw err;
       })


### PR DESCRIPTION
Resolves #1846

This PR removes the error snackbar for 401 Unauthorized errors that redirects to the login page.