### PR TITLE
Make GOOGLE_SERVICE_ACCOUNT_ID optional

### DIFF
--- a/backend/packages/Upgrade/src/auth/AuthService.ts
+++ b/backend/packages/Upgrade/src/auth/AuthService.ts
@@ -20,8 +20,8 @@ export class AuthService {
   }
 
   public async validateUser(token: string, request: express.Request): Promise<User> {
-    // env.google.clientId can be a single client ID or multiple comma-separated client IDs
-    const clientIds = env.google.clientId.split(',');
+    // env.google.clientId is an array of client IDs
+    const clientIds = env.google.clientId;
     const client = new OAuth2Client(clientIds[0]);
     request.logger.info({ message: 'Validating token' });
 
@@ -37,8 +37,8 @@ export class AuthService {
     } catch (error) {
       // If ID token verification fails, try to verify it as an access token
       try {
-        // env.google.serviceAccountId can be a single service account ID or multiple comma-separated service account IDs
-        const serviceAccountIds = env.google.serviceAccountId.split(',');
+        // env.google.serviceAccountId is an array of service account IDs
+        const serviceAccountIds = env.google.serviceAccountId;
         const tokenInfo = await client.getTokenInfo(token);
 
         if (!tokenInfo || !serviceAccountIds.includes(tokenInfo.aud)) {

--- a/backend/packages/Upgrade/src/env.ts
+++ b/backend/packages/Upgrade/src/env.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import pkg from '../package.json';
 
 import { getOsEnv, getOsPath, getOsPaths, normalizePort, toBool } from './lib/env';
-import { getOsEnvOptional, toNumber, parseAdminUsers } from './lib/env/utils';
+import { getOsEnvOptional, toNumber, parseAdminUsers, getOsEnvArray } from './lib/env/utils';
 
 /**
  * Load .env file or for tests the .env.test file.
@@ -78,8 +78,8 @@ export const env = {
     emailBucket: getOsEnv('EMAIL_BUCKET'),
   },
   google: {
-    clientId: getOsEnv('GOOGLE_CLIENT_ID'),
-    serviceAccountId: getOsEnvOptional('GOOGLE_SERVICE_ACCOUNT_ID'),
+    clientId: getOsEnvArray('GOOGLE_CLIENT_ID'),
+    serviceAccountId: getOsEnvArray('GOOGLE_SERVICE_ACCOUNT_ID'),
     domainName: getOsEnvOptional('DOMAIN_NAME'),
   },
   scheduler: {

--- a/backend/packages/Upgrade/src/env.ts
+++ b/backend/packages/Upgrade/src/env.ts
@@ -79,7 +79,7 @@ export const env = {
   },
   google: {
     clientId: getOsEnv('GOOGLE_CLIENT_ID'),
-    serviceAccountId: getOsEnv('GOOGLE_SERVICE_ACCOUNT_ID'),
+    serviceAccountId: getOsEnvOptional('GOOGLE_SERVICE_ACCOUNT_ID'),
     domainName: getOsEnvOptional('DOMAIN_NAME'),
   },
   scheduler: {


### PR DESCRIPTION
This PR makes `GOOGLE_SERVICE_ACCOUNT_ID` optional environment variable.