### PR TITLE
Solved Error when clicking 'add-experiment-button'

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.ts
@@ -92,7 +92,7 @@ export class MonitoredMetricsComponent implements OnInit, OnChanges, OnDestroy {
         this.currentAssignmentUnit === ASSIGNMENT_UNIT.WITHIN_SUBJECTS
           ? this.allMetrics.filter((metric) => metric.children.length > 0)
           : this.allMetrics.filter((metric) =>
-              metric.context.includes(this.currentContext || this.experimentInfo?.context)
+              metric.context?.includes(this.currentContext || this.experimentInfo?.context)
             );
     });
   }


### PR DESCRIPTION
The error encountered when clicking the "Add Experiment" button was caused by an issue with the metric structure, likely due to an improper configuration in the `.env` file. As the metric structure has been updated, it now requires a context array as one of its properties. However, it was receiving null or undefined instead of an array, which prevented the application from reading the metric's context and resulted in the error.

The solution provided in this PR will address the immediate bug, but the primary focus should be on correcting the metric data configuration in the `.env` file.