### PR TITLE
Make Global Exclude row always appear at the top and fix sorting

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/components/segments-list/CustomMatTableSource.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/components/segments-list/CustomMatTableSource.ts
@@ -6,13 +6,40 @@ import { Segment } from '../../../../../core/segments/store/segments.model';
 class CustomMatTableSource extends MatTableDataSource<Segment> {
   sortData = (data: Segment[], sort: MatSort): Segment[] => {
     const globalIndex = data.findIndex((d: Segment) => d.type === SEGMENT_TYPE.GLOBAL_EXCLUDE);
-    const globalData = data.splice(globalIndex, 1);
-    const sortedData = data.sort();
-    if (sort.direction === 'desc') {
-      sortedData.reverse();
-    }
+    const globalData = globalIndex !== -1 ? data.splice(globalIndex, 1) : [];
+    const sortedData = data.sort((a, b) => {
+      const isAsc = sort.direction === 'asc';
+      switch (sort.active) {
+        case 'name':
+          return compare(a.name, b.name, isAsc);
+        case 'status':
+          return compare(a.status, b.status, isAsc);
+        case 'lastUpdate':
+          return compare(new Date(a.updatedAt), new Date(b.updatedAt), isAsc);
+        case 'context':
+          return compare(a.context, b.context, isAsc);
+        case 'description':
+          return compare(a.description, b.description, isAsc);
+        case 'membersCount':
+          return compare(getMembersCount(a), getMembersCount(b), isAsc);
+        default:
+          return 0;
+      }
+    });
     return [...globalData, ...sortedData];
   };
+}
+
+function getMembersCount(segment: Segment): number {
+  return (
+    (segment.groupForSegment?.length || 0) +
+    (segment.individualForSegment?.length || 0) +
+    (segment.subSegments?.length || 0)
+  );
+}
+
+function compare(a: any, b: any, isAsc: boolean) {
+  return (a < b ? -1 : 1) * (isAsc ? 1 : -1);
 }
 
 export { CustomMatTableSource };

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/components/segments-list/CustomMatTableSource.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/components/segments-list/CustomMatTableSource.ts
@@ -7,9 +7,18 @@ class CustomMatTableSource extends MatTableDataSource<Segment> {
   sortData = (data: Segment[], sort: MatSort): Segment[] => {
     const globalIndex = data.findIndex((d: Segment) => d.type === SEGMENT_TYPE.GLOBAL_EXCLUDE);
     const globalData = globalIndex !== -1 ? data.splice(globalIndex, 1) : [];
+
     const sortedData = data.sort((a, b) => {
-      const isAsc = sort.direction === 'asc';
-      switch (sort.active) {
+      let isAsc = sort.direction === 'asc';
+      let active = sort.active;
+
+      // Default to 'lastUpdate' in descending order when sort direction is empty
+      if (sort.direction === '') {
+        isAsc = false;
+        active = 'lastUpdate';
+      }
+
+      switch (active) {
         case 'name':
           return compare(a.name, b.name, isAsc);
         case 'status':
@@ -23,9 +32,10 @@ class CustomMatTableSource extends MatTableDataSource<Segment> {
         case 'membersCount':
           return compare(getMembersCount(a), getMembersCount(b), isAsc);
         default:
-          return 0;
+          return compare(new Date(a.updatedAt), new Date(b.updatedAt), false); // Default to lastUpdate desc
       }
     });
+
     return [...globalData, ...sortedData];
   };
 }

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/components/segments-list/segments-list.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/components/segments-list/segments-list.component.ts
@@ -23,6 +23,7 @@ import { MatTableDataSource } from '@angular/material/table';
 import { MatSort } from '@angular/material/sort';
 import { ExportSegmentComponent } from '../../components/modal/export-segment/export-segment.component';
 import { SEGMENT_SEARCH_KEY } from '../../../../../../../../../../types/src/Experiment/enums';
+import { CustomMatTableSource } from './CustomMatTableSource';
 
 @Component({
   selector: 'segments-list',
@@ -65,7 +66,7 @@ export class SegmentsListComponent implements OnInit, OnDestroy, AfterViewInit {
     this.permissions$ = this.authService.userPermissions$;
     this.allSegmentsSub = this.segmentsService.allSegments$.subscribe((segments) => {
       segments = segments.map((segment) => ({ ...segment, status: segment.status || SEGMENT_STATUS.UNUSED }));
-      this.allSegments = new MatTableDataSource();
+      this.allSegments = new CustomMatTableSource();
       this.allSegments.data = [...segments];
       this.allSegments.sort = this.sort;
       this.cdr.detectChanges();


### PR DESCRIPTION
Resolves #1916

The Global Exclude row always appears at the top regardless of sorting in Prod UpGrade (v5.2.1), but not in QA UpGrade (v6.0.0). I found that this is because `this.allSegments = new CustomMatTableSource();` was replaced by `this.allSegments = new MatTableDataSource();` in PR #1394. This PR reverts to using `CustomMatTableSource` and also updates the class to make sorting work properly.