### PR TITLE
Correct alphabetical order for feature flag inclusion list values on focus change

### DIFF
--- a/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
+++ b/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
@@ -128,6 +128,7 @@ export class FeatureFlagService {
       .leftJoinAndSelect('segmentExclusion.groupForSegment', 'groupForSegmentExclusion')
       .leftJoinAndSelect('segmentExclusion.subSegments', 'subSegmentExclusion')
       .where({ id })
+      .addOrderBy('LOWER(individualForSegment.userId)', 'ASC')
       .getOne();
 
     return featureFlag;

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/modals/upsert-private-segment-list-modal/upsert-private-segment-list-modal.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/modals/upsert-private-segment-list-modal/upsert-private-segment-list-modal.component.html
@@ -47,6 +47,7 @@
         [placeholder]="config.valuesPlaceholder"
         [forceValidation]="forceValidation"
         (downloadRequested)="onDownloadRequested($event)"
+        (blur)="onBlur()"
       ></app-common-tags-input>
       <mat-form-field appearance="outline">
         <mat-label class="ft-14-400">Name</mat-label>

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/modals/upsert-private-segment-list-modal/upsert-private-segment-list-modal.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/modals/upsert-private-segment-list-modal/upsert-private-segment-list-modal.component.ts
@@ -113,6 +113,18 @@ export class UpsertPrivateSegmentListModalComponent {
     return this.privateSegmentListForm?.get(PRIVATE_SEGMENT_LIST_FORM_FIELDS.VALUES);
   }
 
+  // Function to sort the values
+  sortValues() {
+    const currentValues = this.privateSegmentListForm?.get(PRIVATE_SEGMENT_LIST_FORM_FIELDS.VALUES).value;
+    const sortedValues = [...currentValues].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
+    this.privateSegmentListForm?.get(PRIVATE_SEGMENT_LIST_FORM_FIELDS.VALUES).setValue(sortedValues);
+  }
+
+  // onBlur handler
+  onBlur() {
+    this.sortValues();
+  }
+
   fetchData() {
     this.experimentService.fetchContextMetaData();
     this.segmentsService.fetchSegments();

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-tag-input/common-tag-input.component.ts
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-tag-input/common-tag-input.component.ts
@@ -63,6 +63,8 @@ export class CommonTagsInputComponent implements ControlValueAccessor, OnInit {
   @Input() placeholder = '';
   @Input() forceValidation = false;
   @Output() downloadRequested = new EventEmitter<string[]>();
+  // Add an EventEmitter for blur
+  @Output() blur: EventEmitter<void> = new EventEmitter<void>();
 
   tagsExist = false;
   isTouched = false;
@@ -90,6 +92,7 @@ export class CommonTagsInputComponent implements ControlValueAccessor, OnInit {
   onBlur() {
     this.isTouched = true;
     this.onTouched();
+    this.blur.emit(); // Emit the blur event
   }
 
   isInvalid(): boolean {


### PR DESCRIPTION
This resolves #1827 