### PR TITLE
Fix Global exclude for FeatureFlags

### DIFF
--- a/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
@@ -198,7 +198,7 @@ export class ExperimentAssignmentService {
     }
 
     // ============= check if user or group is excluded
-    const [userExcluded, groupExcluded] = await this.checkUserOrGroupIsGloballyExcluded(userDoc, experiments[0]?.group);
+    const [userExcluded, groupExcluded] = await this.checkUserOrGroupIsGloballyExcluded(userDoc);
 
     if (userExcluded || groupExcluded.length > 0) {
       // no experiments if the user or group is excluded from the experiment
@@ -371,10 +371,7 @@ export class ExperimentAssignmentService {
     }
     experiments = experiments.map((exp) => this.experimentService.formatingConditionPayload(exp));
 
-    const [userExcluded, groupExcluded] = await this.checkUserOrGroupIsGloballyExcluded(
-      experimentUser,
-      experiments[0]?.group
-    );
+    const [userExcluded, groupExcluded] = await this.checkUserOrGroupIsGloballyExcluded(experimentUser);
 
     if (userExcluded || groupExcluded.length > 0) {
       // return null if the user or group is excluded from the experiment
@@ -691,10 +688,7 @@ export class ExperimentAssignmentService {
     return pool;
   }
 
-  private async checkUserOrGroupIsGloballyExcluded(
-    experimentUser: ExperimentUser,
-    experimentGroup: string
-  ): Promise<[string, string[]]> {
+  public async checkUserOrGroupIsGloballyExcluded(experimentUser: ExperimentUser): Promise<[string, string[]]> {
     let userGroup = [];
     userGroup = Object.keys(experimentUser.workingGroup || {}).map((type: string) => {
       return `${type}_${experimentUser.workingGroup[type]}`;
@@ -722,11 +716,7 @@ export class ExperimentAssignmentService {
     updatedGlobalExcludeSegmentObj[globalExcludeSegment.id].allExcludedSegmentIds.forEach((segmentId) => {
       const foundSegment: Segment = updatedSegmentDetails.find((segment) => segment.id === segmentId);
       excludedUsers.push(...foundSegment.individualForSegment.map((individual) => individual.userId));
-      excludedGroups.push(
-        ...foundSegment.groupForSegment.filter((group) =>
-          group.type === experimentGroup ? `${group.type}_${group.groupId}` : false
-        )
-      );
+      excludedGroups.push(...foundSegment.groupForSegment.map((group) => `${group.type}_${group.groupId}`));
     });
 
     //users and groups excluded from GlobalExclude segment

--- a/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
+++ b/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
@@ -88,6 +88,14 @@ export class FeatureFlagService {
 
     const filteredFeatureFlags = await this.featureFlagRepository.getFlagsFromContext(context);
 
+    const [userExcluded, groupExcluded] = await this.experimentAssignmentService.checkUserOrGroupIsGloballyExcluded(
+      experimentUserDoc
+    );
+
+    if (userExcluded || groupExcluded.length > 0) {
+      return [];
+    }
+
     const includedFeatureFlags = await this.featureFlagLevelInclusionExclusion(filteredFeatureFlags, experimentUserDoc);
 
     // save exposures in db

--- a/backend/packages/Upgrade/test/unit/services/FeatureFlagService.test.ts
+++ b/backend/packages/Upgrade/test/unit/services/FeatureFlagService.test.ts
@@ -156,6 +156,7 @@ describe('Feature Flag Service Testing', () => {
           provide: ExperimentAssignmentService,
           useValue: {
             inclusionExclusionLogic: jest.fn().mockResolvedValue([[mockFlag1.id]]),
+            checkUserOrGroupIsGloballyExcluded: jest.fn().mockResolvedValue([null, []]),
           },
         },
         {


### PR DESCRIPTION
Solve the issue of globally excluded users not getting excluded for FeatureFlags.

Also, there were some errors in the old Global-Exclude code that it checks for experiment-group while excluding groups of GlobalExcludeSegment. I have reverted these changes.