### PR TITLE
Add 'System' Username to Audit Logs Generated with API Requests

### DIFF
--- a/backend/packages/Upgrade/src/auth/AuthService.ts
+++ b/backend/packages/Upgrade/src/auth/AuthService.ts
@@ -44,10 +44,11 @@ export class AuthService {
         if (!tokenInfo || !serviceAccountIds.includes(tokenInfo.aud)) {
           throw new Error('Invalid or unauthorized access token');
         }
+        payload = {
+          hd: env.google.domainName,
+          email: 'system@gmail.com',
+        };
         request.logger.info({ message: 'Access token validated' });
-        // For service account access tokens, we'll return null
-        // We might want to implement specific handling for service accounts here
-        return null;
       } catch (error) {
         request.logger.error(error);
         throw error;


### PR DESCRIPTION
Resolves #1983 

This PR adds 'System' username to audit logs generated with API requests. This was done by including system@gmail.com to the payload's email so that the existing [systemUserDoc](https://github.com/CarnegieLearningWeb/UpGrade/blob/dev/backend/packages/Upgrade/src/init/seed/systemUser.ts) can be used in this case. I had to also include `hd` to bypass the domain name checking.

```
payload = {
    hd: env.google.domainName,
    email: 'system@gmail.com',
};
```

Here's the screenshot of audit logs displaying the logs with 'System' username instead of empty username after this change:
<img width="1440" alt="Screenshot 2024-09-30 at 7 08 13 PM" src="https://github.com/user-attachments/assets/fb0b30dd-220b-4f83-97fc-aa75396f753b">
