### PR TITLE
Allow Context Chip Click and Search on Metrics Table

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/profile/components/metrics/metrics.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/profile/components/metrics/metrics.component.html
@@ -94,12 +94,17 @@
           <th mat-header-cell *matHeaderCellDef class="ft-12-700">
             {{ 'query.table-context.text' | translate }}
           </th>
-          <td class="ft-12-600" mat-cell *matCellDef="let element">
-            <mat-chip-row *ngFor="let contextTag of element.context" class="context-chip">
-              <span>
-                {{ contextTag }}
-              </span>
-            </mat-chip-row>
+          <td class="ft-12-600" mat-cell *matCellDef="let metric">
+            <mat-chip-listbox class="dense-2">
+              <mat-chip
+                *ngFor="let contextTag of metric.context"
+                (click)="filterMetricsByChips(contextTag, MetricSearchKey.CONTEXT)"
+              >
+                <span class="chip-label">
+                  {{ contextTag }}
+                </span>
+              </mat-chip>
+            </mat-chip-listbox>
           </td>
         </ng-container>
         <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>

--- a/frontend/projects/upgrade/src/app/features/dashboard/profile/components/metrics/metrics.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/profile/components/metrics/metrics.component.scss
@@ -18,9 +18,6 @@
     justify-content: center;
     font-size: 12px;
   }
-  .context-chip {
-    margin: 5px;
-  }
   .mat-nested-tree .mat-nested-tree-node div[role='group'] {
     padding-left: 40px;
   }

--- a/frontend/projects/upgrade/src/app/features/dashboard/profile/components/metrics/metrics.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/profile/components/metrics/metrics.component.ts
@@ -73,6 +73,10 @@ export class MetricsComponent implements OnInit, OnDestroy, AfterViewInit {
     this.applyFilter(this.searchValue);
   }
 
+  get MetricSearchKey() {
+    return METRIC_SEARCH_KEY;
+  }
+
   // Determine if a node has nested children (either loadable or already loaded)
   hasNestedChild = (_: number, node: LazyLoadingMetric): boolean =>
     !!node.loadChildren || (node.children && node.children.length > 0);
@@ -162,6 +166,12 @@ export class MetricsComponent implements OnInit, OnDestroy, AfterViewInit {
           return !!data.context?.filter((context) => context.toLocaleLowerCase().includes(filter)).length;
       }
     };
+  }
+
+  filterMetricsByChips(filterValue: string, searchKey: METRIC_SEARCH_KEY) {
+    this.selectedMetricFilterOption = searchKey;
+    this.searchValue = filterValue;
+    this.applyFilter(filterValue);
   }
 
   changeMetricMode(event) {


### PR DESCRIPTION
Resolves #1995

This PR allows clicking on a context chip to filter metrics with the searched context just like how Experiments and Segments pages work.