### PR TITLE
🐞 Bugfix: Init api call with stricter validation at api level to avoid userid in request body

### DIFF
--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v6.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v6.ts
@@ -171,7 +171,7 @@ export class ExperimentClientController {
   public async init(
     @Req()
     request: AppRequest,
-    @Body({ validate: true })
+    @Body({ validate: { whitelist: true, forbidNonWhitelisted: true } })
     experimentUser: ExperimentUserValidatorv6
   ): Promise<Pick<ExperimentUser, 'id' | 'group' | 'workingGroup'>> {
     request.logger.info({ message: 'Starting the init call for user' });


### PR DESCRIPTION
This resolves #1994 