### PR TITLE
Edit Feature Flag: Fix deleting lists when context is changed

### DIFF
--- a/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
+++ b/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
@@ -476,18 +476,12 @@ export class FeatureFlagService {
       let existingRecord: FeatureFlagSegmentInclusion | FeatureFlagSegmentExclusion;
 
       if (filterType === FEATURE_FLAG_LIST_FILTER_MODE.INCLUSION) {
-        const that = entityManager
-          ? entityManager.getRepository(FeatureFlagSegmentInclusion)
-          : this.featureFlagSegmentInclusionRepository;
-        existingRecord = await that.findOne({
+        existingRecord = await this.featureFlagSegmentInclusionRepository.findOne({
           where: { segment: { id: segmentId } },
           relations: ['featureFlag', 'segment'],
         });
       } else {
-        const that = entityManager
-          ? entityManager.getRepository(FeatureFlagSegmentExclusion)
-          : this.featureFlagSegmentExclusionRepository;
-        existingRecord = await that.findOne({
+        existingRecord = await this.featureFlagSegmentExclusionRepository.findOne({
           where: { segment: { id: segmentId } },
           relations: ['featureFlag', 'segment'],
         });


### PR DESCRIPTION
Removing select queries from the transaction. After the first select, nothing was being found. Also, it doesn't make sense to roll back a select. The audit entries are still rolled back if something goes wrong with any of the other mutating queries.