### PR TITLE
Align spinner and make font bold in feature flag name on ff deatils page

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-details-page-content.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-details-page-content.component.html
@@ -35,6 +35,8 @@
   </ng-container>
 
   <ng-template #loading>
-    <mat-spinner></mat-spinner>
+    <div class="mat-spinner-container">
+      <mat-spinner diameter="100"></mat-spinner>
+    </div>
   </ng-template>
 </div>

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-details-page-content.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-details-page-content.component.scss
@@ -1,0 +1,7 @@
+.mat-spinner-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  padding: 100px;
+}

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-details-page-header/common-details-page-header.component.html
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-details-page-header/common-details-page-header.component.html
@@ -2,6 +2,6 @@
   <span class="ft-14-400 breadcrumb">
     <a [routerLink]="['/', rootLink]" class="root-link">{{ rootName | translate }}</a>
     >
-    <span>{{ detailsName | translate }}</span>
+    <b>{{ detailsName | translate }}</b>
   </span>
 </div>


### PR DESCRIPTION
In this PR align the spinner in the center and make the feature flag name bold in the header on the details page