### PR TITLE
Disallow Importing Stratification Factors for Users with the 'Reader' Role

### DIFF
--- a/frontend/projects/upgrade/src/app/core/auth/auth.service.ts
+++ b/frontend/projects/upgrade/src/app/core/auth/auth.service.ts
@@ -174,6 +174,7 @@ export class AuthService {
       case UserRole.ADMIN:
         this.userPermissions$.next({
           experiments: { create: true, read: true, update: true, delete: true },
+          stratifications: { create: true, read: true, update: true, delete: true },
           users: { create: true, read: true, update: true, delete: true },
           logs: { create: true, read: true, update: true, delete: true },
           manageRoles: { create: true, read: true, update: true, delete: true },
@@ -185,6 +186,7 @@ export class AuthService {
       case UserRole.CREATOR:
         this.userPermissions$.next({
           experiments: { create: true, read: true, update: true, delete: true },
+          stratifications: { create: true, read: true, update: true, delete: true },
           users: { create: true, read: true, update: true, delete: true },
           logs: { create: false, read: true, update: false, delete: false },
           manageRoles: { create: false, read: true, update: false, delete: false },
@@ -196,6 +198,7 @@ export class AuthService {
       case UserRole.USER_MANAGER:
         this.userPermissions$.next({
           experiments: { create: false, read: true, update: false, delete: false },
+          stratifications: { create: false, read: true, update: false, delete: false },
           users: { create: true, read: true, update: true, delete: true },
           logs: { create: false, read: true, update: false, delete: false },
           manageRoles: { create: false, read: true, update: false, delete: false },
@@ -207,6 +210,7 @@ export class AuthService {
       case UserRole.READER:
         this.userPermissions$.next({
           experiments: { create: false, read: true, update: false, delete: false },
+          stratifications: { create: false, read: true, update: false, delete: false },
           users: { create: false, read: true, update: false, delete: false },
           logs: { create: false, read: true, update: false, delete: false },
           manageRoles: { create: false, read: true, update: false, delete: false },

--- a/frontend/projects/upgrade/src/app/core/auth/store/auth.models.ts
+++ b/frontend/projects/upgrade/src/app/core/auth/store/auth.models.ts
@@ -10,6 +10,7 @@ interface CRUD {
 
 export interface UserPermission {
   experiments: CRUD;
+  stratifications: CRUD;
   users: CRUD;
   logs: CRUD;
   manageRoles: CRUD;

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiment-users/components/stratification-factor-list/stratification-factor-list.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiment-users/components/stratification-factor-list/stratification-factor-list.component.html
@@ -5,6 +5,7 @@
     </div>
     <div>
       <button
+        *ngIf="(permissions$ | async)?.stratifications.create"
         (click)="openImportStratificationsDialog()"
         mat-flat-button
         color="primary"

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiment-users/components/stratification-factor-list/stratification-factor-list.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiment-users/components/stratification-factor-list/stratification-factor-list.component.ts
@@ -4,11 +4,13 @@ import { MatDialog } from '@angular/material/dialog';
 import * as clonedeep from 'lodash.clonedeep';
 import { DeleteStratificationComponent } from './delete-stratification/delete-stratification.component';
 import { StratificationFactor } from '../../../../../core/stratification-factors/store/stratification-factors.model';
-import { Subscription } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 import { StratificationFactorsService } from '../../../../../core/stratification-factors/stratification-factors.service';
 import { ExperimentService } from '../../../../../core/experiments/experiments.service';
 import { ExperimentNameVM } from '../../../../../core/experiments/store/experiments.model';
 import { MatTableDataSource } from '@angular/material/table';
+import { UserPermission } from '../../../../../core/auth/store/auth.models';
+import { AuthService } from '../../../../../core/auth/auth.service';
 
 interface StratificationFactorsTableRow {
   factor: string;
@@ -24,6 +26,7 @@ interface StratificationFactorsTableRow {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class StratificationComponent implements OnInit {
+  permissions$: Observable<UserPermission>;
   allStratificationFactors: StratificationFactor[];
   allStratificationFactorsSub: Subscription;
   isLoading$ = this.stratificationFactorsService.isLoading$;
@@ -36,10 +39,12 @@ export class StratificationComponent implements OnInit {
     private dialog: MatDialog,
     private stratificationFactorsService: StratificationFactorsService,
     private experimentService: ExperimentService,
-    private cdr: ChangeDetectorRef
+    private cdr: ChangeDetectorRef,
+    private authService: AuthService
   ) {}
 
   ngOnInit(): void {
+    this.permissions$ = this.authService.userPermissions$;
     this.experimentService.allExperimentNames$.subscribe((allExperimentNames) => {
       this.allExperimentsName = allExperimentNames;
     });


### PR DESCRIPTION
Resolves #2009

This PR hides the "Import CSV" button above the Stratifications table for users with the 'Reader' Role.

<img width="1000" alt="Screenshot 2024-10-03 at 9 24 01 PM" src="https://github.com/user-attachments/assets/0c8e1087-1ad9-4c65-9b5f-e43210017ba1">
