### PR TITLE
use wheel for scroll

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags-legacy/feature-flags-root/feature-flags-root.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags-legacy/feature-flags-root/feature-flags-root.component.ts
@@ -14,7 +14,7 @@ import { AuthService } from '../../../../core/auth/auth.service';
 })
 export class FeatureFlagsRootComponent implements OnInit {
   permissions$: Observable<UserPermission>;
-  isLoadingFeatureFlags$ = this.featureFlagsService.isInitialFeatureFlagsLoading();
+  isLoadingFeatureFlags$ = this.featureFlagsService.isInitialFeatureFlagsLoading$;
   featureFlags$ = this.featureFlagsService.allFeatureFlags$;
   constructor(
     private featureFlagsService: FeatureFlagsService,

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.html
@@ -1,4 +1,4 @@
-<div scroll (scrolled)="fetchFlagsOnScroll()" class="flag-list-table-container" #tableContainer>
+<div scroll (wheel)="fetchFlagsOnScroll()" class="flag-list-table-container" #tableContainer>
   <mat-progress-bar class="spinner" mode="indeterminate" *ngIf="isLoading$ | async"></mat-progress-bar>
   <table
     class="flag-list-table"

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.ts
@@ -1,6 +1,6 @@
 import { Observable } from 'rxjs';
 
-import { ChangeDetectionStrategy, Component, Input, OnInit, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
 
 import {
   FLAG_ROOT_COLUMN_NAMES,
@@ -43,6 +43,7 @@ export class FeatureFlagRootSectionCardTableComponent implements OnInit {
   warningStatusForAllFlags$ = this.featureFlagsService.warningStatusForAllFlags$;
 
   @ViewChild(MatSort, { static: true }) sort: MatSort;
+  @ViewChild('tableContainer') tableContainer: ElementRef;
 
   constructor(private featureFlagsService: FeatureFlagsService) {}
 
@@ -111,6 +112,10 @@ export class FeatureFlagRootSectionCardTableComponent implements OnInit {
       // When sorting is cleared, revert to default sorting
       this.featureFlagsService.setSortingType(null);
       this.featureFlagsService.setSortKey(null);
+      this.tableContainer.nativeElement.scroll({
+        top: 0,
+        behavior: 'smooth',
+      });
       this.dataSource$.data = this.dataSource$.data.sort(
         (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
       );


### PR DESCRIPTION
`SharedModule` should be giving us access to the `ScrollDirective`, which is how the `(scrolled)` directive is being used elsewhere in the app, but for some reason it is not working that way, possibly there is something about being a standalone that makes this work differently.

The `(wheel)` directive seems to work fine though in place of `scrolled`, and a few other pieces that work similarly from the experiment list table seem to need to be included... I don't 100% know why this works and `scrolled` doesn't, but it does.

This'll re-close [#1576](https://github.com/CarnegieLearningWeb/UpGrade/issues/1576)