### PR TITLE
Make the Feature Flags Root Section Card Scrollable

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.scss
@@ -3,6 +3,9 @@
   overflow: auto;
   width: 100%;
 
+  /* Subtract page header (112px), card header (96px), card content paddings (64px), and page bottom padding (32px) from vertical viewport (100vh) */
+  max-height: calc(100vh - 304px);
+
   .spinner {
     position: sticky;
     top: 0;
@@ -18,14 +21,13 @@
 
   .flag-list-table {
     ::ng-deep thead {
-      background-color: var(--zircon);
-
       tr.mat-mdc-header-row {
         height: 48px;
         border: 0;
 
         th {
           padding-left: 0;
+          background-color: var(--zircon);
           color: var(--darker-grey);
 
           &:first-child {


### PR DESCRIPTION
Resolves #2011

When the card doesn't reach the max-height:
<img width="1440" alt="Screenshot 2024-10-04 at 5 48 59 PM" src="https://github.com/user-attachments/assets/18ac0945-5082-4853-bcb9-21ce18a23b5b">

When the card exceeds the max-height:

https://github.com/user-attachments/assets/9e731bdd-9ba1-4386-974f-618c44903f3e

