### PR TITLE
Update Delete Feature Flag Modal Padding

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/delete-feature-flag-modal/delete-feature-flag-modal.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/delete-feature-flag-modal/delete-feature-flag-modal.component.scss
@@ -3,6 +3,6 @@
   flex-direction: column;
   row-gap: 16px;
   color: var(--dark-grey);
-  padding: 40px 32px 24px;
+  padding: 32px 32px 16px;
   margin: 0;
 }


### PR DESCRIPTION
This is a minor/small PR. I feel the "Delete Feature Flag" modal is a bit too large so I would like to reduce the vertical paddings by 8px. Here's the screenshot after change:

<img width="1000" alt="Screenshot 2024-10-04 at 6 13 50 PM" src="https://github.com/user-attachments/assets/e754e74d-4934-4376-9b99-472934212e2b">
