### PR TITLE
Refine Feature Flags Root Table Pagination on Scroll

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.html
@@ -1,4 +1,4 @@
-<div scroll (wheel)="fetchFlagsOnScroll()" class="flag-list-table-container" #tableContainer>
+<div class="flag-list-table-container" #tableContainer>
   <mat-progress-bar class="spinner" mode="indeterminate" *ngIf="isLoading$ | async"></mat-progress-bar>
   <table
     class="flag-list-table"
@@ -111,4 +111,5 @@
       </td>
     </tr>
   </table>
+  <div #bottomTrigger></div>
 </div>

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.ts
@@ -44,6 +44,9 @@ export class FeatureFlagRootSectionCardTableComponent implements OnInit {
 
   @ViewChild(MatSort, { static: true }) sort: MatSort;
   @ViewChild('tableContainer') tableContainer: ElementRef;
+  @ViewChild('bottomTrigger') bottomTrigger: ElementRef;
+
+  private observer: IntersectionObserver;
 
   constructor(private featureFlagsService: FeatureFlagsService) {}
 
@@ -51,8 +54,36 @@ export class FeatureFlagRootSectionCardTableComponent implements OnInit {
     this.sortTable();
   }
 
+  ngAfterViewInit() {
+    this.setupIntersectionObserver();
+  }
+
   ngOnChanges() {
     this.sortTable();
+  }
+
+  ngOnDestroy() {
+    if (this.observer) {
+      this.observer.disconnect();
+    }
+  }
+
+  private setupIntersectionObserver() {
+    const options = {
+      root: this.tableContainer.nativeElement,
+      rootMargin: '100px',
+      threshold: 0.1,
+    };
+
+    this.observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting) {
+        this.fetchFlagsOnScroll();
+      }
+    }, options);
+
+    if (this.bottomTrigger) {
+      this.observer.observe(this.bottomTrigger.nativeElement);
+    }
   }
 
   private sortTable() {


### PR DESCRIPTION
Reference: https://github.com/CarnegieLearningWeb/UpGrade/pull/2020#issuecomment-2393459616

This PR removes the use of the `(wheel)` directive, which was triggering the fetching of flags and displaying the loading spinner even with slight scrolling. Instead, this PR implements an `IntersectionObserver` to control when the `this.fetchFlagsOnScroll()` function is called.

Here's a screen recording demonstrating the changes:

https://github.com/user-attachments/assets/3c720baa-4e2a-44fe-8c06-12bc5312001c

