### PR TITLE
add var to turn off migrations for ECS

### DIFF
--- a/backend/packages/Upgrade/src/env.ts
+++ b/backend/packages/Upgrade/src/env.ts
@@ -21,6 +21,7 @@ export const env = {
   isTest: process.env.NODE_ENV === 'test',
   isDevelopment: process.env.NODE_ENV === 'development',
   useNewRelic: toBool(getOsEnvOptional('USE_NEW_RELIC')) || false,
+  isECS: toBool(getOsEnvOptional('IS_ECS')) || false,
   app: {
     name: getOsEnv('APP_NAME'),
     version: (pkg as any).version,

--- a/backend/packages/Upgrade/src/loaders/typeormLoader.ts
+++ b/backend/packages/Upgrade/src/loaders/typeormLoader.ts
@@ -73,9 +73,8 @@ export const typeormLoader: MicroframeworkLoader = async (settings: Microframewo
     tteContainer.setDataSource(CONNECTION_NAME.REPLICA, exportDataSourceInstance);
     await Promise.all([appDataSourceInstance.initialize(), exportDataSourceInstance.initialize()]);
 
-    if (!env.db.synchronize) {
+    if (!env.db.synchronize && !env.isECS) {
       await appDataSourceInstance.runMigrations();
-      await exportDataSourceInstance.runMigrations();
     }
 
     if (settings) {

--- a/cloudformation/backend/app-infrastructure.yml
+++ b/cloudformation/backend/app-infrastructure.yml
@@ -190,6 +190,8 @@ Resources:
               Value: '{{resolve:ssm:UPGRADE_TYPEORM_SYNCHRONIZE}}'
             - Name: USE_NEW_RELIC
               Value: '{{resolve:ssm:UPGRADE_USE_NEW_RELIC}}'  
+            - Name: IS_ECS
+              Value: '{{resolve:ssm:UPGRADE_IS_ECS}}'
             - Name: CONTEXT_METADATA
               Value: '{{resolve:ssm:UPGRADE_CONTEXT_METADATA}}'
             - Name: METRICS

--- a/cloudformation/backend/app-infrastructure.yml
+++ b/cloudformation/backend/app-infrastructure.yml
@@ -191,7 +191,7 @@ Resources:
             - Name: USE_NEW_RELIC
               Value: '{{resolve:ssm:UPGRADE_USE_NEW_RELIC}}'  
             - Name: IS_ECS
-              Value: '{{resolve:ssm:UPGRADE_IS_ECS}}'
+              Value: 'true'
             - Name: CONTEXT_METADATA
               Value: '{{resolve:ssm:UPGRADE_CONTEXT_METADATA}}'
             - Name: METRICS


### PR DESCRIPTION
- allows for an ENV VAR: 'IS_ECS': when true suppresses running migrations on deploy
- removes extraneous running of migrations on the read replica