### PR TITLE
close the modals if auth fails

### DIFF
--- a/frontend/projects/upgrade/src/app/core/auth/auth.service.ts
+++ b/frontend/projects/upgrade/src/app/core/auth/auth.service.ts
@@ -15,6 +15,7 @@ import { AUTH_CONSTANTS, GoogleAuthJWTPayload, User, UserRole } from '../users/s
 import { ENV, Environment } from '../../../environments/environment-types';
 import jwt_decode from 'jwt-decode';
 import { NavigationEnd, NavigationSkipped, Router } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
 
 @Injectable()
 export class AuthService {
@@ -28,6 +29,7 @@ export class AuthService {
     private store$: Store<AppState>,
     private router: Router,
     private ngZone: NgZone,
+    private dialog: MatDialog,
     private localStorageService: LocalStorageService,
     @Inject(ENV) private environment: Environment,
     @Inject(DOCUMENT) private DOMref: Document
@@ -162,6 +164,7 @@ export class AuthService {
 
   authLogout(): void {
     this.store$.dispatch(AuthActions.actionLogoutStart());
+    this.dialog.closeAll();
   }
 
   setRedirectionUrl(redirectUrl: string): void {


### PR DESCRIPTION
This PR will fix the issue of Modal staying open despite auth failure and UI moves to the login screen.