### PR TITLE
Make initial focus on name property on opening featureFlag modal

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-modal/upsert-feature-flag-modal.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-modal/upsert-feature-flag-modal.component.html
@@ -9,7 +9,7 @@
   <form [formGroup]="featureFlagForm" class="form-standard dense-3">
     <mat-form-field appearance="outline">
       <mat-label class="ft-14-400">Name</mat-label>
-      <input matInput formControlName="name" placeholder="e.g., My feature flag" class="ft-14-400" />
+      <input matInput formControlName="name" placeholder="e.g., My feature flag" class="ft-14-400" cdkFocusInitial/>
       <mat-hint class="form-hint ft-12-400">
         {{ 'feature-flags.upsert-flag-modal.name-hint.text' | translate }}
       </mat-hint>

--- a/frontend/projects/upgrade/src/app/shared/services/common-dialog.service.ts
+++ b/frontend/projects/upgrade/src/app/shared/services/common-dialog.service.ts
@@ -156,7 +156,6 @@ export class DialogService {
     const config: MatDialogConfig = {
       data: commonModalConfig,
       width: ModalSize.STANDARD,
-      autoFocus: 'first-heading',
       disableClose: true,
     };
     return this.dialog.open(UpsertFeatureFlagModalComponent, config);


### PR DESCRIPTION
In this PR, when the FeatureFlag modal is opened for create/edit, the name field is in focus, and the cursor appears in it.