### PR TITLE
Apply lighter disabled color for the expand icon on the Import Feature Flag modal

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/import-feature-flag-modal/import-feature-flag-modal.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/import-feature-flag-modal/import-feature-flag-modal.component.html
@@ -38,7 +38,7 @@
             <!-- Actions Column -->
             <ng-container matColumnDef="actions">
               <th mat-header-cell *matHeaderCellDef></th>
-              <td mat-cell class="ft-14-500" *matCellDef="let element">
+              <td mat-cell class="ft-14-500 dense-2" *matCellDef="let element">
                 <button
                   mat-icon-button
                   [ngClass]="{ 'expand-button--disabled': element.compatibilityType === 'compatible' }"

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/import-feature-flag-modal/import-feature-flag-modal.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/import-feature-flag-modal/import-feature-flag-modal.component.scss
@@ -62,17 +62,16 @@
       }
     }
 
-    &.disabled {
-      opacity: 0.5;
-      cursor: default;
-    }
-
     .cdk-column-actions {
-      width: 10%;
+      width: 15%;
+
+      .expand-button--disabled {
+        opacity: 0.5;
+      }
     }
 
     .cdk-column-fileName {
-      width: 60%;
+      width: 55%;
     }
 
     .cdk-column-compatibilityType {


### PR DESCRIPTION
Resolves #2110

This PR applies a lighter disabled color for the expand icon in the "Import Feature Flag" modal for better visibility. It also addresses an issue where the ripple effect was being trimmed due to a narrow column width.

## Before Change:

<img width="1000" alt="Screenshot 2024-11-14 at 7 44 44 PM" src="https://github.com/user-attachments/assets/8c819244-4602-410e-b81a-edeb35c0c086">

<img width="1000" alt="Screenshot 2024-11-14 at 7 45 04 PM" src="https://github.com/user-attachments/assets/73e09c07-773b-4652-92fb-99d7e7927ad3">


## After Change:

<img width="1000" alt="Screenshot 2024-11-14 at 7 43 49 PM" src="https://github.com/user-attachments/assets/774c3400-92c2-48cb-ab63-6b52d09da9ea">

<img width="1000" alt="Screenshot 2024-11-14 at 7 43 22 PM" src="https://github.com/user-attachments/assets/8d245e46-ae48-4d7e-9fd4-a24f27e0a1a5">
