### PR TITLE
Disallow Editing (Name, Key, App Context) or Deleting an Enabled Feature Flag

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-modal/upsert-feature-flag-modal.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-modal/upsert-feature-flag-modal.component.html
@@ -9,7 +9,13 @@
   <form [formGroup]="featureFlagForm" class="form-standard dense-3">
     <mat-form-field appearance="outline">
       <mat-label class="ft-14-400">Name</mat-label>
-      <input matInput formControlName="name" placeholder="e.g., My feature flag" class="ft-14-400"/>
+      <input
+        matInput
+        formControlName="name"
+        placeholder="e.g., My feature flag"
+        class="ft-14-400"
+        [disabled]="featureFlagForm.get('name')?.disabled"
+      />
       <mat-hint class="form-hint ft-12-400">
         {{ 'feature-flags.upsert-flag-modal.name-hint.text' | translate }}
       </mat-hint>
@@ -17,7 +23,13 @@
 
     <mat-form-field appearance="outline">
       <mat-label class="ft-14-400">Key</mat-label>
-      <input matInput formControlName="key" placeholder="Key for this feature flag" class="ft-14-400" />
+      <input
+        matInput
+        formControlName="key"
+        placeholder="Key for this feature flag"
+        class="ft-14-400"
+        [disabled]="featureFlagForm.get('key')?.disabled"
+      />
       <mat-hint class="form-hint ft-12-400">
         <ng-container *ngIf="!validationError; else duplicateError">
           <span class="key-hint">
@@ -42,7 +54,11 @@
 
     <mat-form-field appearance="outline">
       <mat-label class="ft-14-400">App Context</mat-label>
-      <mat-select formControlName="appContext" class="ft-14-400">
+      <mat-select
+        formControlName="appContext"
+        class="ft-14-400"
+        [disabled]="featureFlagForm.get('appContext')?.disabled"
+      >
         <mat-option *ngFor="let context of appContexts$ | async" [value]="context" class="ft-14-400">{{
           context
         }}</mat-option>

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-modal/upsert-feature-flag-modal.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-modal/upsert-feature-flag-modal.component.ts
@@ -106,6 +106,19 @@ export class UpsertFeatureFlagModalComponent {
     this.listenForPrimaryButtonDisabled();
     this.listenForDuplicateKey();
     this.listenOnContext();
+
+    if (
+      this.config.params.action === UPSERT_FEATURE_FLAG_ACTION.EDIT &&
+      this.config.params.sourceFlag?.status === FEATURE_FLAG_STATUS.ENABLED
+    ) {
+      this.disableRestrictedFields();
+    }
+  }
+
+  disableRestrictedFields(): void {
+    this.featureFlagForm.get('name')?.disable();
+    this.featureFlagForm.get('key')?.disable();
+    this.featureFlagForm.get('appContext')?.disable();
   }
 
   createFeatureFlagForm(): void {
@@ -234,10 +247,13 @@ export class UpsertFeatureFlagModalComponent {
     this.featureFlagsService.addFeatureFlag(flagRequest);
   }
 
-  createEditRequest(
-    { name, key, description, appContext, tags }: FeatureFlagFormData,
-    { id, status, filterMode }: FeatureFlag
-  ): void {
+  createEditRequest({ name, key, description, appContext, tags }: FeatureFlagFormData, sourceFlag: FeatureFlag): void {
+    const { id, status, filterMode } = sourceFlag;
+    if (sourceFlag.status === 'enabled') {
+      name = sourceFlag.name;
+      key = sourceFlag.key;
+      appContext = sourceFlag.context[0];
+    }
     const flagRequest: UpdateFeatureFlagRequest = {
       id,
       name,

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-overview-details-section-card/feature-flag-overview-details-section-card.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-overview-details-section-card/feature-flag-overview-details-section-card.component.ts
@@ -49,6 +49,8 @@ export class FeatureFlagOverviewDetailsSectionCardComponent implements OnInit, O
   subscriptions = new Subscription();
   confirmStatusChangeDialogRef: MatDialogRef<CommonSimpleConfirmationModalComponent>;
   menuButtonItems: IMenuButtonItem[];
+  featureFlag: FeatureFlag;
+  userPermissions: UserPermission;
 
   constructor(
     private dialogService: DialogService,
@@ -62,8 +64,16 @@ export class FeatureFlagOverviewDetailsSectionCardComponent implements OnInit, O
     this.subscriptions.add(this.featureFlagService.currentUserEmailAddress$.subscribe((id) => (this.emailId = id)));
 
     this.subscriptions.add(
+      this.featureFlag$.subscribe((flag) => {
+        this.featureFlag = flag;
+        this.updateMenuItems();
+      })
+    );
+
+    this.subscriptions.add(
       this.permissions$.subscribe((permissions) => {
-        this.updateMenuItems(permissions);
+        this.userPermissions = permissions;
+        this.updateMenuItems();
       })
     );
   }
@@ -76,14 +86,17 @@ export class FeatureFlagOverviewDetailsSectionCardComponent implements OnInit, O
     return FILTER_MODE;
   }
 
-  private updateMenuItems(permissions: UserPermission): void {
+  private updateMenuItems(): void {
     this.menuButtonItems = [
-      { name: FEATURE_FLAG_DETAILS_PAGE_ACTIONS.EDIT, disabled: !permissions?.featureFlags.update },
-      { name: FEATURE_FLAG_DETAILS_PAGE_ACTIONS.DUPLICATE, disabled: !permissions?.featureFlags.create },
+      { name: FEATURE_FLAG_DETAILS_PAGE_ACTIONS.EDIT, disabled: !this.userPermissions?.featureFlags.update },
+      { name: FEATURE_FLAG_DETAILS_PAGE_ACTIONS.DUPLICATE, disabled: !this.userPermissions?.featureFlags.create },
       { name: FEATURE_FLAG_DETAILS_PAGE_ACTIONS.EXPORT_DESIGN, disabled: false },
       { name: FEATURE_FLAG_DETAILS_PAGE_ACTIONS.EMAIL_DATA, disabled: true },
       { name: FEATURE_FLAG_DETAILS_PAGE_ACTIONS.ARCHIVE, disabled: true },
-      { name: FEATURE_FLAG_DETAILS_PAGE_ACTIONS.DELETE, disabled: !permissions?.featureFlags.delete },
+      {
+        name: FEATURE_FLAG_DETAILS_PAGE_ACTIONS.DELETE,
+        disabled: !this.userPermissions?.featureFlags.delete || this.featureFlag?.status === 'enabled',
+      },
     ];
   }
 


### PR DESCRIPTION
This PR disables name, key and context input fields for enabled feature flag and deletion of feature flag.

![image](https://github.com/user-attachments/assets/ab49e91d-6d4f-4fca-a88f-a83db114ee34)
![image](https://github.com/user-attachments/assets/6ead6fbe-f052-4d33-989a-701dac35678e)