### PR TITLE
update filter mode when ALL row is removed in include table

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-participants/experiment-participants.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-participants/experiment-participants.component.ts
@@ -304,6 +304,9 @@ export class ExperimentParticipantsComponent implements OnInit {
   }
 
   removeMember1(groupIndex: number) {
+    if (groupIndex === 0 && this.members1.controls.at(0).get('type').value === 'All') {
+      this.participantsForm.get('inclusionCriteria').setValue(INCLUSION_CRITERIA.INCLUDE_SPECIFIC);
+    }
     this.members1.removeAt(groupIndex);
     this.experimentDesignStepperService.experimentStepperDataChanged();
     this.updateView1();


### PR DESCRIPTION
This PR will fix the issue of filter mode not updating when the include ALL row is deleted in the include participants table.