### PR TITLE
match package version to build tags

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ab_testing_backend",
-  "version": "6.0.5",
+  "version": "6.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ab_testing_backend",
-      "version": "6.0.5",
+      "version": "6.0.7",
       "license": "ISC",
       "dependencies": {
         "dayjs": "^1.11.10",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ab_testing_backend",
-  "version": "6.0.5",
+  "version": "6.0.7",
   "description": "Backend for A/B Testing Project",
   "scripts": {
     "install:all": "npm ci && cd packages/Scheduler && npm ci && cd ../Upgrade && npm ci",

--- a/backend/packages/Scheduler/package-lock.json
+++ b/backend/packages/Scheduler/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppl-upgrade-serverless",
-  "version": "6.0.5",
+  "version": "6.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppl-upgrade-serverless",
-      "version": "6.0.5",
+      "version": "6.0.7",
       "license": "MIT",
       "dependencies": {
         "jsonwebtoken": "^9.0.0",

--- a/backend/packages/Scheduler/package.json
+++ b/backend/packages/Scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppl-upgrade-serverless",
-  "version": "6.0.5",
+  "version": "6.0.7",
   "description": "Serverless webpack example using Typescript",
   "main": "handler.js",
   "scripts": {

--- a/backend/packages/Upgrade/package-lock.json
+++ b/backend/packages/Upgrade/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ab_testing_backend",
-  "version": "6.0.5",
+  "version": "6.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ab_testing_backend",
-      "version": "6.0.5",
+      "version": "6.0.7",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.633.0",

--- a/backend/packages/Upgrade/package.json
+++ b/backend/packages/Upgrade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ab_testing_backend",
-  "version": "6.0.5",
+  "version": "6.0.7",
   "description": "Backend for A/B Testing Project",
   "main": "index.js",
   "scripts": {

--- a/clientlibs/java/pom.xml
+++ b/clientlibs/java/pom.xml
@@ -9,7 +9,7 @@
 		at the same time that happen to rev to the same new version will be caught 
 		by a merge conflict. -->
 
-	<version>6.0.5</version>
+	<version>6.0.7</version>
 	<build>
 		<plugins>
 			<plugin>

--- a/clientlibs/js/package-lock.json
+++ b/clientlibs/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "upgrade_client_lib",
-  "version": "6.0.5",
+  "version": "6.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "upgrade_client_lib",
-      "version": "6.0.5",
+      "version": "6.0.7",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.4.0",

--- a/clientlibs/js/package.json
+++ b/clientlibs/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upgrade_client_lib",
-  "version": "6.0.5",
+  "version": "6.0.7",
   "description": "Client library to communicate with the Upgrade server",
   "files": [
     "dist/*"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ab-testing",
-  "version": "6.0.5",
+  "version": "6.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ab-testing",
-      "version": "6.0.5",
+      "version": "6.0.7",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ab-testing",
-  "version": "6.0.5",
+  "version": "6.0.7",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "UpGrade",
-  "version": "6.0.5",
+  "version": "6.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "UpGrade",
-      "version": "6.0.5",
+      "version": "6.0.7",
       "license": "ISC",
       "devDependencies": {
         "@angular-eslint/eslint-plugin": "^14.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "UpGrade",
-  "version": "6.0.5",
+  "version": "6.0.7",
   "description": "This is a combined repository for UpGrade, an open-source platform to support large-scale A/B testing in educational applications.  Learn more at www.upgradeplatform.org",
   "main": "index.js",
   "devDependencies": {

--- a/types/package-lock.json
+++ b/types/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "upgrade_types",
-  "version": "6.0.5",
+  "version": "6.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "upgrade_types",
-      "version": "6.0.5",
+      "version": "6.0.7",
       "license": "ISC",
       "devDependencies": {
         "eslint": "^8.27.0",

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upgrade_types",
-  "version": "6.0.5",
+  "version": "6.0.7",
   "description": "",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
bumping the package.json version patch twice (for two bugfixes added) to match the version that the tags will say (6.0.7) when we redeploy.