### PR TITLE
Hotfix: fix export data

### DIFF
--- a/backend/packages/Upgrade/src/api/repositories/QueryRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/QueryRepository.ts
@@ -5,23 +5,6 @@ import repositoryError from './utils/repositoryError';
 
 @EntityRepository(Query)
 export class QueryRepository extends Repository<Query> {
-  public async findNamesByExperimentId(experimentId: string): Promise<string[]> {
-    const queries = await this.createQueryBuilder('query')
-      .select(['name'])
-      .where('"experimentId" = :experimentId', { experimentId })
-      .getRawMany()
-      .catch((errorMsg: any) => {
-        const errorMsgString = repositoryError(
-          'QueryRepository',
-          'findNamesByExperimentId',
-          { experimentId },
-          errorMsg
-        );
-        throw errorMsgString;
-      });
-    return queries.map((query) => query.name);
-  }
-
   public async deleteQuery(id: string, entityManager: EntityManager): Promise<void> {
     await entityManager
       .createQueryBuilder()

--- a/backend/packages/Upgrade/src/api/services/QueryService.ts
+++ b/backend/packages/Upgrade/src/api/services/QueryService.ts
@@ -38,11 +38,6 @@ export class QueryService {
     });
   }
 
-  public async findNamesbyExperimentId(experimentId: string, logger: UpgradeLogger): Promise<string[]> {
-    logger.info({ message: `Find all query names for experiment ${experimentId}` });
-    return await this.queryRepository.findNamesByExperimentId(experimentId);
-  }
-
   public async getArchivedStats(queryIds: string[], logger: UpgradeLogger): Promise<any> {
     logger.info({ message: `Get archivedStats of query with queryIds ${queryIds}` });
     const archiveData = await this.archivedStatsRepository.find({


### PR DESCRIPTION
This pr:
- removes the queries to 'monitored_decision_point' and 'monitored_decision_point_log' and replaces multiple rows with different `MarkExperimentPointTime` values with a single row with `MarkExperimentPointTime` coming from the enrollment table
- avoids including metrics columns that do not correspond to queries defined in the experiment
- fixes the display of metric keys