### PR TITLE
Allow importing experiments with old payload 

### DIFF
--- a/backend/packages/Upgrade/package-lock.json
+++ b/backend/packages/Upgrade/package-lock.json
@@ -24,6 +24,7 @@
                 "chalk": "^5.3.0",
                 "class-transformer": "^0.5.1",
                 "class-validator": "^0.14.0",
+                "compare-versions": "^6.1.1",
                 "compression": "^1.7.4",
                 "cors": "^2.8.5",
                 "csv-stringify": "^6.4.5",
@@ -5186,6 +5187,11 @@
             "engines": {
                 "node": ">=4.0.0"
             }
+        },
+        "node_modules/compare-versions": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+            "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg=="
         },
         "node_modules/component-emitter": {
             "version": "1.3.1",

--- a/backend/packages/Upgrade/package.json
+++ b/backend/packages/Upgrade/package.json
@@ -71,6 +71,7 @@
         "chalk": "^5.3.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
+        "compare-versions": "^6.1.1",
         "compression": "^1.7.4",
         "cors": "^2.8.5",
         "csv-stringify": "^6.4.5",

--- a/backend/packages/Upgrade/src/api/DTO/ExperimentDTO.ts
+++ b/backend/packages/Upgrade/src/api/DTO/ExperimentDTO.ts
@@ -182,7 +182,7 @@ export class PartitionValidator {
   public excludeIfReached: boolean;
 }
 
-class ConditionPayloadValidator {
+abstract class BaseConditionPayloadValidator {
   @IsNotEmpty()
   @IsString()
   public id: string;
@@ -191,7 +191,9 @@ class ConditionPayloadValidator {
   @ValidateNested()
   @Type(() => PayloadValidator)
   public payload: PayloadValidator;
+}
 
+export class ConditionPayloadValidator extends BaseConditionPayloadValidator {
   @IsNotEmpty()
   @IsString()
   public parentCondition: string;
@@ -201,16 +203,7 @@ class ConditionPayloadValidator {
   public decisionPoint?: string;
 }
 
-class OldConditionPayloadValidator {
-  @IsNotEmpty()
-  @IsString()
-  public id: string;
-
-  @IsNotEmpty()
-  @ValidateNested()
-  @Type(() => PayloadValidator)
-  public payload: PayloadValidator;
-
+class OldConditionPayloadValidator extends BaseConditionPayloadValidator {
   @IsNotEmpty()
   @IsString()
   public parentCondition: ConditionValidator;
@@ -341,7 +334,7 @@ class StratificationFactor {
   public stratificationFactorName: string;
 }
 
-export abstract class BaseExperimentWithoutPayload {
+abstract class BaseExperimentWithoutPayload {
   @IsString()
   @IsOptional()
   public id?: string;

--- a/backend/packages/Upgrade/src/api/DTO/ExperimentDTO.ts
+++ b/backend/packages/Upgrade/src/api/DTO/ExperimentDTO.ts
@@ -201,6 +201,25 @@ class ConditionPayloadValidator {
   public decisionPoint?: string;
 }
 
+class OldConditionPayloadValidator {
+  @IsNotEmpty()
+  @IsString()
+  public id: string;
+
+  @IsNotEmpty()
+  @ValidateNested()
+  @Type(() => PayloadValidator)
+  public payload: PayloadValidator;
+
+  @IsNotEmpty()
+  @IsString()
+  public parentCondition: ConditionValidator;
+
+  @IsOptional()
+  @IsString()
+  public decisionPoint?: PartitionValidator;
+}
+
 class MetricValidator {
   @IsNotEmpty()
   @IsString()
@@ -322,7 +341,7 @@ class StratificationFactor {
   public stratificationFactorName: string;
 }
 
-export class ExperimentDTO {
+export abstract class BaseExperimentWithoutPayload {
   @IsString()
   @IsOptional()
   public id?: string;
@@ -421,12 +440,6 @@ export class ExperimentDTO {
   @IsOptional()
   @IsArray()
   @ValidateNested({ each: true })
-  @Type(() => ConditionPayloadValidator)
-  public conditionPayloads?: ConditionPayloadValidator[];
-
-  @IsOptional()
-  @IsArray()
-  @ValidateNested({ each: true })
   @Type(() => QueryValidator)
   public queries?: QueryValidator[];
 
@@ -453,6 +466,22 @@ export class ExperimentDTO {
   @IsNotEmpty()
   @IsEnum(EXPERIMENT_TYPE)
   public type: EXPERIMENT_TYPE;
+}
+
+export class ExperimentDTO extends BaseExperimentWithoutPayload {
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ConditionPayloadValidator)
+  public conditionPayloads?: ConditionPayloadValidator[];
+}
+
+export class OldExperimentDTO extends BaseExperimentWithoutPayload {
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => OldConditionPayloadValidator)
+  public conditionPayloads?: OldConditionPayloadValidator[];
 }
 
 export class ExperimentIdValidator {

--- a/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
@@ -358,7 +358,7 @@ export class ExperimentAssignmentService {
     } else {
       experiments = await this.experimentService.getCachedValidExperiments(context);
     }
-    experiments = experiments.map((exp) => this.experimentService.formattingConditionPayload(exp));
+    experiments = experiments.map((exp) => this.experimentService.formatingConditionPayload(exp));
 
     const [userExcluded, groupExcluded] = await this.checkUserOrGroupIsGloballyExcluded(experimentUser);
 
@@ -562,7 +562,7 @@ export class ExperimentAssignmentService {
         const assignment = experimentAssignment[index];
         // const { state, name, id } = experiment;
         const { state, name, conditionPayloads, type, id, factors } =
-          this.experimentService.formattingPayload(experiment);
+          this.experimentService.formatingPayload(experiment);
         const decisionPoints = experiment.partitions.map((decisionPoint) => {
           const { target, site } = decisionPoint;
           const conditionAssigned = assignment;

--- a/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
@@ -358,7 +358,7 @@ export class ExperimentAssignmentService {
     } else {
       experiments = await this.experimentService.getCachedValidExperiments(context);
     }
-    experiments = experiments.map((exp) => this.experimentService.formatingConditionPayload(exp));
+    experiments = experiments.map((exp) => this.experimentService.formattingConditionPayload(exp));
 
     const [userExcluded, groupExcluded] = await this.checkUserOrGroupIsGloballyExcluded(experimentUser);
 
@@ -562,7 +562,7 @@ export class ExperimentAssignmentService {
         const assignment = experimentAssignment[index];
         // const { state, name, id } = experiment;
         const { state, name, conditionPayloads, type, id, factors } =
-          this.experimentService.formatingPayload(experiment);
+          this.experimentService.formattingPayload(experiment);
         const decisionPoints = experiment.partitions.map((decisionPoint) => {
           const { target, site } = decisionPoint;
           const conditionAssigned = assignment;

--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -135,7 +135,7 @@ export class ExperimentService {
     }
     const experiments = await this.experimentRepository.findAllExperiments();
     return experiments.map((experiment) => {
-      return this.reducedConditionPayload(this.formattingPayload(this.formattingConditionPayload(experiment)));
+      return this.reducedConditionPayload(this.formatingPayload(this.formatingConditionPayload(experiment)));
     });
   }
 
@@ -209,14 +209,14 @@ export class ExperimentService {
     }
     const experiments = await queryBuilderToReturn.getMany();
     return experiments.map((experiment) => {
-      return this.reducedConditionPayload(this.formattingPayload(this.formattingConditionPayload(experiment)));
+      return this.reducedConditionPayload(this.formatingPayload(this.formatingConditionPayload(experiment)));
     });
   }
 
   public async getSingleExperiment(id: string, logger?: UpgradeLogger): Promise<ExperimentDTO | undefined> {
     const experiment = await this.findOne(id, logger);
     if (experiment) {
-      return this.reducedConditionPayload(this.formattingPayload(experiment));
+      return this.reducedConditionPayload(this.formatingPayload(experiment));
     } else {
       return undefined;
     }
@@ -229,7 +229,7 @@ export class ExperimentService {
     const experiment = await this.experimentRepository.findOneExperiment(id);
 
     if (experiment) {
-      return this.formattingConditionPayload(experiment);
+      return this.formatingConditionPayload(experiment);
     } else {
       return undefined;
     }
@@ -591,7 +591,7 @@ export class ExperimentService {
         { experimentName: experiment.name },
         user
       );
-      return this.reducedConditionPayload(this.formattingPayload(this.formattingConditionPayload(experiment)));
+      return this.reducedConditionPayload(this.formatingPayload(this.formatingConditionPayload(experiment)));
     });
 
     return formattedExperiments;
@@ -1071,7 +1071,7 @@ export class ExperimentService {
           conditionPayloads: conditionPayloadDocToReturn as any,
           queries: (queryDocToReturn as any) || [],
         };
-        const updatedExperiment = this.formattingPayload(newExperiment);
+        const updatedExperiment = this.formatingPayload(newExperiment);
 
         // removing unwanted params for diff
         const oldExperimentClone: Experiment = JSON.parse(JSON.stringify(oldExperiment));
@@ -1510,7 +1510,7 @@ export class ExperimentService {
       experimentName: createdExperiment.name,
     };
     await this.experimentAuditLogRepository.saveRawJson(LOG_TYPE.EXPERIMENT_CREATED, createAuditLogData, user);
-    return this.reducedConditionPayload(this.formattingPayload(createdExperiment));
+    return this.reducedConditionPayload(this.formatingPayload(createdExperiment));
   }
 
   public async validateExperiments(
@@ -1827,7 +1827,7 @@ export class ExperimentService {
     return createdExperiments;
   }
 
-  public formattingConditionPayload(experiment: Experiment): Experiment {
+  public formatingConditionPayload(experiment: Experiment): Experiment {
     if (experiment.type === EXPERIMENT_TYPE.FACTORIAL) {
       const conditionPayload: ConditionPayload[] = [];
       experiment.conditions.forEach((condition) => {
@@ -1868,7 +1868,7 @@ export class ExperimentService {
     return { ...experiment, conditionPayloads: updatedCP };
   }
 
-  public formattingPayload(experiment: Experiment): any {
+  public formatingPayload(experiment: Experiment): any {
     const updatedConditionPayloads = experiment.conditionPayloads.map((conditionPayload) => {
       const { payloadType, payloadValue, ...rest } = conditionPayload;
       return {


### PR DESCRIPTION
This PR allows experiments with versions below 5.3.0 to be imported with older payload structures.