### PR TITLE
Update scroll event handling in pagination

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-list/experiment-list.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-list/experiment-list.component.html
@@ -80,7 +80,7 @@
     </div>
   </div>
 
-  <div scroll (scrolled)="fetchExperimentOnScroll()" class="experiment-list-table-container" #tableContainer>
+  <div (scroll)="onScroll()" class="experiment-list-table-container" #tableContainer>
     <mat-progress-bar class="spinner" mode="indeterminate" *ngIf="isLoadingExperiment$ | async"></mat-progress-bar>
     <table
       class="experiment-list"

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-list/experiment-list.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-list/experiment-list.component.ts
@@ -222,6 +222,15 @@ export class ExperimentListComponent implements OnInit, OnDestroy, AfterViewInit
       : '';
   }
 
+  onScroll(): void {
+    const element = this.experimentTableContainer.nativeElement;
+    const atBottom = element.scrollHeight - element.scrollTop === element.clientHeight;
+
+    if (atBottom) {
+      this.fetchExperimentOnScroll();
+    }
+  }
+
   fetchExperimentOnScroll() {
     if (!this.isAllExperimentsFetched) {
       this.experimentService.loadExperiments();


### PR DESCRIPTION
If the scroll reaches the end of the list, it should call pagination API to get the next set of experiments. But this was only happening 1 time, again reaching the end of the scroll it was not calling the next pagination API call.

Fix this issue by checking each scroll event and hitting pagination API if the scroll was at the end.