### PR TITLE
Feature/mooclet validator

### DIFF
--- a/backend/packages/Upgrade/src/api/DTO/ExperimentDTO.ts
+++ b/backend/packages/Upgrade/src/api/DTO/ExperimentDTO.ts
@@ -3,6 +3,7 @@ import {
   IsArray,
   IsBoolean,
   IsDateString,
+  IsDefined,
   IsEnum,
   IsInt,
   IsNotEmpty,
@@ -37,6 +38,7 @@ import {
   ASSIGNMENT_ALGORITHM,
 } from 'upgrade_types';
 import { Type } from 'class-transformer';
+import { MoocletPolicyParameters, MoocletTSConfigurablePolicyParameters } from '../../types/Mooclet';
 
 export {
   EXPERIMENT_SEARCH_KEY,
@@ -467,6 +469,28 @@ export class ExperimentDTO extends BaseExperimentWithoutPayload {
   @ValidateNested({ each: true })
   @Type(() => ConditionPayloadValidator)
   public conditionPayloads?: ConditionPayloadValidator[];
+
+  // This should be validated when assignmentAlgorithm is not RANDOM or STRATIFIED_RANDOM_SAMPLING
+  @ValidateIf(
+    (o) =>
+      o.assignmentAlgorithm &&
+      !(
+        o.assignmentAlgorithm === ASSIGNMENT_ALGORITHM.RANDOM ||
+        o.assignmentAlgorithm === ASSIGNMENT_ALGORITHM.STRATIFIED_RANDOM_SAMPLING
+      )
+  )
+  @IsDefined()
+  @ValidateNested()
+  @Type(() => MoocletPolicyParameters, {
+    discriminator: {
+      property: 'assignmentAlgorithm',
+      subTypes: [
+        { value: MoocletTSConfigurablePolicyParameters, name: ASSIGNMENT_ALGORITHM.MOOCLET_TS_CONFIGURABLE },
+        // Other policy types can be added here
+      ],
+    },
+  })
+  public moocletPolicyParameters?: MoocletPolicyParameters;
 }
 
 export class OldExperimentDTO extends BaseExperimentWithoutPayload {

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
@@ -955,7 +955,7 @@ export class ExperimentController {
   @Post()
   @UseBefore(ValidateMoocletPolicyParametersMiddleware)
   public create(
-    @Body({ validate: true }) experiment: ExperimentDTO | MoocletExperimentDTO,
+    @Body({ validate: true }) experiment: ExperimentDTO,
     @CurrentUser() currentUser: UserDTO,
     @Req() request: AppRequest
   ): Promise<ExperimentDTO | MoocletExperimentDTO> {
@@ -963,7 +963,7 @@ export class ExperimentController {
 
     if ('moocletPolicyParameters' in experiment) {
       return this.moocletExperimentService.syncCreate({
-        experimentDTO: experiment,
+        experimentDTO: experiment as MoocletExperimentDTO,
         currentUser,
         logger: request.logger,
       });

--- a/backend/packages/Upgrade/src/api/middlewares/ValidateMoocletPolicyParameters.ts
+++ b/backend/packages/Upgrade/src/api/middlewares/ValidateMoocletPolicyParameters.ts
@@ -1,8 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
-import { BadRequestError, ExpressMiddlewareInterface, Middleware } from 'routing-controllers';
+import { ExpressMiddlewareInterface, Middleware } from 'routing-controllers';
 import { env } from '../../env';
 import { UnprocessableEntityException } from '@nestjs/common';
-import { validateMoocletPolicyParameters } from '../validators/MoocletPolicyParametersFactory';
 
 @Middleware({ type: 'before' })
 export class ValidateMoocletPolicyParametersMiddleware implements ExpressMiddlewareInterface {
@@ -13,18 +12,6 @@ export class ValidateMoocletPolicyParametersMiddleware implements ExpressMiddlew
       throw new UnprocessableEntityException(
         'Failed to create Experiment: moocletPolicyParameters was provided but mooclets are not enabled on backend.'
       );
-    }
-    
-    if (env.mooclets?.enabled) {
-      try {
-        const policyParameters = await validateMoocletPolicyParameters(
-          experiment.assignmentAlgorithm,
-          experiment.moocletPolicyParameters
-        );
-        req.body.moocletPolicyParameters = policyParameters;
-      } catch (error) {
-        throw new BadRequestError(`Validation failed: ${error}`);
-      }
     }
 
     // else, if mooclets is not enabled, keep calm and carry on

--- a/backend/packages/Upgrade/src/types/Mooclet.ts
+++ b/backend/packages/Upgrade/src/types/Mooclet.ts
@@ -1,3 +1,6 @@
+import { IsDefined, IsNumber } from 'class-validator';
+import { ASSIGNMENT_ALGORITHM } from 'types/src';
+
 export interface MoocletProxyRequestParams {
     method: string;
     url: string;
@@ -83,7 +86,12 @@ export interface MoocletValueResponseDetails {
     timestamp: string;
 }
 
-export interface MoocletTSConfigurablePolicyParameters {
+// this will be a Union type of all possible policy parameters once more are introduced
+export abstract class MoocletPolicyParameters {
+    assignmentAlgorithm: ASSIGNMENT_ALGORITHM
+}
+
+export class MoocletTSConfigurablePolicyParameters extends MoocletPolicyParameters {
     prior: {
         failure: number; // use 1 as default
         success: number; // use 1 as default
@@ -91,6 +99,9 @@ export interface MoocletTSConfigurablePolicyParameters {
     // current_posteriors will show up after first reward is given
     // BUT if you wanted to set different priors for different arms, you could do that by setting current_posteriors manually
     current_posteriors?: MoocletTSConfigurableCurrentPosteriors;
+
+    @IsDefined()
+    @IsNumber()
     batch_size: number; // for now leave at 1
     max_rating: number; // leave at 1
     min_rating: number; // leave at 0
@@ -105,9 +116,6 @@ export interface MoocletTSConfigurableCurrentPosteriors {
         successes: number;
     };
 }
-
-// this will be a Union type of all possible policy parameters once more are introduced
-export type MoocletPolicyParameters = MoocletTSConfigurablePolicyParameters;
 
 export interface MoocletPolicyResponseDetails {
     id: number;

--- a/backend/packages/Upgrade/src/types/Mooclet.ts
+++ b/backend/packages/Upgrade/src/types/Mooclet.ts
@@ -1,4 +1,4 @@
-import { IsDefined, IsNumber } from 'class-validator';
+import { IsDefined, IsIn, IsNumber } from 'class-validator';
 import { ASSIGNMENT_ALGORITHM } from 'types/src';
 
 export interface MoocletProxyRequestParams {
@@ -88,6 +88,8 @@ export interface MoocletValueResponseDetails {
 
 // this will be a Union type of all possible policy parameters once more are introduced
 export abstract class MoocletPolicyParameters {
+    @IsDefined()
+    @IsIn(Object.values(ASSIGNMENT_ALGORITHM))
     assignmentAlgorithm: ASSIGNMENT_ALGORITHM
 }
 


### PR DESCRIPTION
To test this PR make a `Post` request to `/api/experiments` with `moocletPolicyParameters` for testing validation.

```
"assignmentAlgorithm": "ts_configurable",
"moocletPolicyParameters": {
    "assignmentAlgorithm": "ts_configurable",
    "batch_size": 1
}
```
Based on the type of `"moocletPolicyParameters"."assignmentAlgorithm"` the associated validator will run. The discriminator will already remove `"moocletPolicyParameters"."assignmentAlgorithm"` this property in the `moocletPolicyParameters`.
From frontend, we need to add `assignmentAlgorithm` inside `moocletPolicyParameters` for validator to work correclty.