### PR TITLE
Improve the log message for markExperimentPoint

### DIFF
--- a/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
@@ -160,7 +160,7 @@ export class ExperimentAssignmentService {
     const { workingGroup } = userDoc;
 
     logger.info({
-      message: `markExperimentPoint: Target: ${target}, Site: ${site} for User: ${userId}`,
+      message: `markExperimentPoint: Site: ${site}, Target: ${target}, Condition: ${condition}, Status: "${status}" for User: ${userId}`,
     });
 
     if (experiments.length) {


### PR DESCRIPTION
This is just my personal suggestion, but when testing how marking with a different condition affects the originally assigned condition using the UpGrade client library, I couldn't see what condition was sent to `/mark` from the logs. Adding the `condition` and `status` to the `markExperimentPoint` log message would be helpful for debugging UpGrade. Let me know what you think.