### PR TITLE
test token service for local testing

### DIFF
--- a/backend/packages/Upgrade/.env.example
+++ b/backend/packages/Upgrade/.env.example
@@ -65,6 +65,8 @@ SCHEDULER_STEP_FUNCTION=arn_name
 AWS_REGION=aws-region
 HOST_URL=function_url
 TOKEN_SECRET_KEY=carnegielearning
+ALLOW_SERVICE_ACCOUNT_TOKEN_SERVICE=false
+GOOGLE_SERVICE_ACCOUNT_CREDENTIAL_FILE=path/to/credential.json
 
 #
 # Email

--- a/backend/packages/Upgrade/src/api/controllers/TestTokenController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/TestTokenController.ts
@@ -1,0 +1,34 @@
+import { Get, JsonController, Res } from 'routing-controllers';
+import { Response } from 'express';
+import { GoogleAuth } from 'google-auth-library';
+import { env } from '../../env';
+import * as path from 'path';
+import * as os from 'os';
+
+@JsonController()
+export class TestTokenController {
+  @Get('/token')
+  async getToken(@Res() response: Response) {
+    if (!env.google.allowTestTokenService) {
+      return response.status(403).json({ error: 'Token service is not allowed' });
+    }
+
+    try {
+      // Resolve absolute path to credential.json file on server
+      const keyFilename = path.join(os.homedir(), env.google.keyFilename.replace(/^~\//, ''));
+
+      const auth = new GoogleAuth({
+        keyFilename,
+        scopes: 'https://www.googleapis.com/auth/cloud-platform',
+      });
+
+      const client = await auth.getClient();
+      const accessToken = await client.getAccessToken();
+
+      return response.json({ token: accessToken.token });
+    } catch (error) {
+      console.error('Error fetching token:', error);
+      return response.status(500).json({ error: 'Failed to fetch token' });
+    }
+  }
+}

--- a/backend/packages/Upgrade/src/env.ts
+++ b/backend/packages/Upgrade/src/env.ts
@@ -82,6 +82,8 @@ export const env = {
     clientId: getOsEnvArray('GOOGLE_CLIENT_ID'),
     serviceAccountId: getOsEnvArray('GOOGLE_SERVICE_ACCOUNT_ID'),
     domainName: getOsEnvOptional('DOMAIN_NAME'),
+    allowTestTokenService: toBool(getOsEnvOptional('ALLOW_SERVICE_ACCOUNT_TOKEN_SERVICE')),
+    keyFilename: getOsEnvOptional('GOOGLE_SERVICE_ACCOUNT_CREDENTIAL_FILE'),
   },
   scheduler: {
     stepFunctionArn: getOsEnv('SCHEDULER_STEP_FUNCTION'),


### PR DESCRIPTION
This is something i started using locally as a quick-and-dirty auth token server in order to use postman without needing to mess with auth tokens. It will use a pre-request script to fetch a valid token for authed endpoints. it would require a credential.json file path on your machine (this is something that comes from google cloud console) and toggling it on for environment. But it's useful for non-postman purposes also, just to quickly grab a token in local hit `curl http://localhost:3030/api/token` for a response that looks like this:

`{"token":"ya29.c.c0ASRK0GbeIt7k4dt8kWG8ucOa6PAsqgAkGapgpPa5lBh_cZB0rP2kWSoJSiiayx1s8WZl4gFclvSxAlpZEmpnwbr3Go143Jua5BMgSiQvwPj10sOMrQLqIoHt-hIPDjneBa8RQbOWcugPN8Q_GxM2XI59BLe1hzcq0ksOXAVGst9U5Di_L3SdtLCecbXi7A-MyLJkuBFk7HV9WHO5GaZWYWG3WWcltNCe9OjzcQ1jafqMF4vu72VnFk4-ViV0cwBcE63nXbr4mVqmw3gHOfPtV3rwXtPbsmhc3I0qHOTLbskuCQJSE4ntg60TO_PS3XxHbFjxUeb9M_Sx6urtCdGHDieeMV13DsdjJ3Y2yYQ7kS3VLIxiR2ALUYs-xX8H388KMawM4cJjWdhsyaWvcJs5pfe6qqqZhj6SXy-RkbdocMIBm6msl-Otnls8R1_lmFQuW9m5e1F6jvp4Jzb9febn86UORckgvt6yVtBihqlvUSlVlMS5-nWUXbhnqntJU8naMMity1FZVv8FclM6V-zl93Fwzrf-65X6sxO0fBw2RcsMquw4iOQfvZxzBFh0zt4rVa-0QzUXZRBQtwoJf4cMiYJ5rUJh-hOjXq3os_k28JXyo1ZM26QIY9yQYfx5R9bjORmn4sO_-rBJOefx996ROUusXt1XFaUMWnUqc55bxgquZ2vIlyU0UgWXjURsB2sVZbO14diIawnkcQvS87es0xmsn8cduf7ufM2WB798VUJyUaFIe3_qxz-YveahQ_i-9qQ6inuq2f-XxOfnJUxod4fgI_Srxpjdiah4W_orJel8a9R7XjeFxI_qzoFIaxS5uh--W3s37SSwSejYqmlxors29VgpmZf2cySqz21ndMl1nm0kp7MVz8iS436u9tQYp5X1ezf3qt1vhpujSrlRR2Z6615b8q-_1qya1wV6aUgb-QoB8d2YJXyWgSJ4JO2V20-vrIwiMBOucZfclY3ktl2Q4lBedFzMtd0S2YwR1Wv-O1O6F2eQOwU"}`


Just wanted to share it, this is intentionally a simple GET endpoint for local-dev convenience, but a more robust token server that could POST some credentials to exchange for a token would be a pretty handy thing to have if we wanted something like this this is what I use for the postman pre-request script.

```
pm.sendRequest('http://localhost:3030/api/token', function (err, response) {
  if (err) {
    console.error('Error fetching token:', err);
    throw err;
  }

  const jsonResponse = response.json();
  pm.request.headers.add({ key: 'Authorization', value: `Bearer ${jsonResponse.token}` });
});
```