### PR TITLE
add assign mooclet proxy to assignment service

### DIFF
--- a/backend/packages/Upgrade/README.md
+++ b/backend/packages/Upgrade/README.md
@@ -2,6 +2,6 @@ Backend Unit Test Coverage
 
 ![](https://img.shields.io/badge/Coverage-58%25-F2E96B.svg?style=flat&logo=jest&label=Statements&prefix=$statements$) ![](https://img.shields.io/badge/Coverage-31%25-F2C572.svg?style=flat&logo=jest&label=Branches&prefix=$branches$) ![](https://img.shields.io/badge/Coverage-50%25-F2C572.svg?style=flat&logo=jest&label=Functions&prefi x=$functions$) ![](https://img.shields.io/badge/Coverage-57%25-F2E96B.svg?style=flat&logo=jest&label=Lines&prefix=$lines$)
 
-Overall (average of all 4) Goal: 80% 
+Overall (average of all 4) Goal: 80%
 
 ![](https://img.shields.io/badge/Coverage-49%25-F2C572.svg?style=flat&logo=jest&label=Overall&prefix=$coverage$)

--- a/backend/packages/Upgrade/README.md
+++ b/backend/packages/Upgrade/README.md
@@ -2,6 +2,6 @@ Backend Unit Test Coverage
 
 ![](https://img.shields.io/badge/Coverage-58%25-F2E96B.svg?style=flat&logo=jest&label=Statements&prefix=$statements$) ![](https://img.shields.io/badge/Coverage-31%25-F2C572.svg?style=flat&logo=jest&label=Branches&prefix=$branches$) ![](https://img.shields.io/badge/Coverage-50%25-F2C572.svg?style=flat&logo=jest&label=Functions&prefi x=$functions$) ![](https://img.shields.io/badge/Coverage-57%25-F2E96B.svg?style=flat&logo=jest&label=Lines&prefix=$lines$)
 
-Overall (average of all 4) Goal: 80%
+Overall (average of all 4) Goal: 80% 
 
 ![](https://img.shields.io/badge/Coverage-49%25-F2C572.svg?style=flat&logo=jest&label=Overall&prefix=$coverage$)

--- a/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
@@ -1590,16 +1590,14 @@ export class ExperimentAssignmentService {
   private async getConditionFromMoocletProxy(experiment: Experiment, user: ExperimentUser) {
     const userId = user.id;
 
-    const condition = await this.moocletExperimentService.getConditionFromMoocletProxy(experiment, userId);
-
-    return condition;
+    return await this.moocletExperimentService.getConditionFromMoocletProxy(experiment, userId);
   }
 
   private assignRandom(
     experiment: Experiment,
     user: ExperimentUser,
     enrollmentCount?: { conditionId: string; userCount: number }[]
-  ) {
+  ): ExperimentCondition {
     const randomSeed =
       experiment.assignmentUnit === ASSIGNMENT_UNIT.INDIVIDUAL ||
       experiment.assignmentUnit === ASSIGNMENT_UNIT.WITHIN_SUBJECTS

--- a/backend/packages/Upgrade/src/api/services/MoocletDataService.ts
+++ b/backend/packages/Upgrade/src/api/services/MoocletDataService.ts
@@ -199,21 +199,19 @@ export class MoocletDataService {
     return response;
   }
 
-  /* not yet implemented */
+  public async getVersionForNewLearner(moocletId: number, userId: string) {
+    const endpoint = `/mooclet/${moocletId}/run?learner=${userId}`;
 
-  // public async getVersionForNewLearner(moocletId: number, userId: string) {
-  //   const endpoint = `/mooclet/${moocletId}/run?learner=${userId}`;
+    const requestParams: MoocletProxyRequestParams = {
+      method: 'GET',
+      url: this.apiUrl + endpoint,
+      apiToken: this.apiToken,
+    };
 
-  //   const requestParams: MoocletProxyRequestParams = {
-  //     method: 'GET',
-  //     url: this.apiUrl + endpoint,
-  //     apiToken: this.apiToken,
-  //   };
+    const response = await this.fetchExternalMoocletsData(requestParams);
 
-  //   const response = await this.fetchExternalMoocletsData(requestParams);
-
-  //   return response;
-  // }
+    return response;
+  }
 
   /**
    * Generic Requests to Mooclets API

--- a/backend/packages/Upgrade/src/api/services/MoocletDataService.ts
+++ b/backend/packages/Upgrade/src/api/services/MoocletDataService.ts
@@ -199,7 +199,7 @@ export class MoocletDataService {
     return response;
   }
 
-  public async getVersionForNewLearner(moocletId: number, userId: string) {
+  public async getVersionForNewLearner(moocletId: number, userId: string): Promise<MoocletVersionResponseDetails> {
     const endpoint = `/mooclet/${moocletId}/run?learner=${userId}`;
 
     const requestParams: MoocletProxyRequestParams = {

--- a/backend/packages/Upgrade/test/unit/services/ExperimentAssignmentService.test.ts
+++ b/backend/packages/Upgrade/test/unit/services/ExperimentAssignmentService.test.ts
@@ -33,6 +33,7 @@ import { MARKED_DECISION_POINT_STATUS } from 'upgrade_types';
 import { CacheService } from '../../../src/api/services/CacheService';
 import { UserStratificationFactorRepository } from '../../../src/api/repositories/UserStratificationRepository';
 import { configureLogger } from '../../utils/logger';
+import { MoocletExperimentService } from '../../../src/api/services/MoocletExperimentService';
 
 describe('Experiment Assignment Service Test', () => {
   let sandbox;
@@ -58,6 +59,7 @@ describe('Experiment Assignment Service Test', () => {
   const segmentServiceMock = sinon.createStubInstance(SegmentService);
   const experimentServiceMock = sinon.createStubInstance(ExperimentService);
   const cacheServiceMock = sinon.createStubInstance(CacheService);
+  const moocletExperimentService = sinon.createStubInstance(MoocletExperimentService);
   experimentServiceMock.formatingConditionPayload.restore();
   experimentServiceMock.formatingPayload.restore();
 
@@ -89,7 +91,8 @@ describe('Experiment Assignment Service Test', () => {
       settingServiceMock,
       segmentServiceMock,
       experimentServiceMock,
-      cacheServiceMock
+      cacheServiceMock,
+      moocletExperimentService
     );
     testedModule.cacheService.wrap.resolves([]);
     testedModule.segmentService.getSegmentByIds.withArgs(['77777777-7777-7777-7777-777777777777']).resolves([

--- a/backend/packages/Upgrade/test/unit/services/MoocletDataService.test.ts
+++ b/backend/packages/Upgrade/test/unit/services/MoocletDataService.test.ts
@@ -214,6 +214,7 @@ describe('#MoocletDataService', () => {
 
   describe('#postNewPolicyParameters', () => {
     const mockPolicyParameters: MoocletTSConfigurablePolicyParametersDTO = {
+      assignmentAlgorithm: ASSIGNMENT_ALGORITHM.MOOCLET_TS_CONFIGURABLE,
       prior: {
         failure: 1,
         success: 1,


### PR DESCRIPTION
This adds assignment proxy to experimentAssignmentService for Mooclet experiments.

Experiments that are created with a Mooclet assignment algorithm will generate two entities in the db to map the relationship between the Upgrade Experiment entities and its Mooclet counterparts, "MoocletExperimentRef" and "MoocletVersionConditionMap", which is joined to the MoocletExperimentRef document as an array of direct relationships between Mooclet "versions" and UpGrade "conditions".

On `/assign`, if a user has not already been enrolled in the mooclet experiment they have been assigned, a call will be proxied to the Mooclet API to be given a new "version" (condition).

When fetching a new version, the MoocletExperimentRef will be fetched via UpGrade experimentId to find the condition that this version is mapped to, which is what is returned in the response as normal Upgrade condition assignment.

When this assignment is marked, the user will be enrolled as normal in the UpGrade experiment and subsequent calls to /assign will not reach out to the Mooclet server.

Note! the assignment retrieved from Mooclet for ts_configurable is not constant like it is in upgrade, you could get any of the versions involved on each call until it is marked, so this is something we should discuss.