### PR TITLE
[no merge] leave open to retain review comments, backend changes for experiment details view w/ policyparams

### DIFF
--- a/backend/packages/Upgrade/.env.docker.local.example
+++ b/backend/packages/Upgrade/.env.docker.local.example
@@ -77,11 +77,10 @@ EMAIL_BUCKET="s3_bucket"
 #
 # Mooclets
 #
-
-MOOCLETS_ENABLED = true/false
-MOOCLETS_HOST_URL = mooclet_host_url
-MOOCLETS_API_ROUTE = /engine/api/v1
-MOOCLETS_API_TOKEN = some_token
+MOOCLETS_ENABLED=false
+MOOCLETS_HOST_URL=mooclet_host_url
+MOOCLETS_API_ROUTE=/engine/api/v1
+MOOCLETS_API_TOKEN=some_token
 
 #
 # Initialization

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
@@ -149,7 +149,7 @@ interface ExperimentPaginationInfo extends PaginationResponse {
  *         type: string
  *       assignmentAlgorithm:
  *         type: string
- *         enum: [random, stratified random sampling]
+ *         enum: [random, stratified_random_sampling]
  *       filterMode:
  *         type: string
  *         enum: [includeAll, excludeAll]

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
@@ -855,7 +855,7 @@ export class ExperimentController {
           if (policyParameters?.parameters) {
             experimentDTO = {
               ...experimentDTO,
-              moocletPolicyParameters: policyParameters.parameters
+              moocletPolicyParameters: policyParameters.parameters,
             };
           }
         }

--- a/backend/packages/Upgrade/src/api/services/MoocletDataService.ts
+++ b/backend/packages/Upgrade/src/api/services/MoocletDataService.ts
@@ -26,6 +26,25 @@ export class MoocletDataService {
    * EXTERNAL DATA FETCHING METHODS
    */
 
+  public async getPolicyParameters(policyParametersId: number): Promise<MoocletPolicyParametersResponseDetails> {
+    if (!policyParametersId) return null;
+    const logger = new UpgradeLogger('MoocletDataService');
+    const endpoint = `/policyparameters/${policyParametersId}`;
+    const requestParams: MoocletProxyRequestParams = {
+      method: 'GET',
+      url: this.apiUrl + endpoint,
+      apiToken: this.apiToken,
+    };
+
+    try {
+      const response = await this.fetchExternalMoocletsData(requestParams);
+      return response;
+    } catch (err) {
+      logger.error({ message: `Failed to fetch policy parameters from Mooclet: ${err}` });
+      return null;
+    }
+  }
+
   public async getMoocletIdByName(policyName: string): Promise<number> {
     const response: MoocletBatchResponse<MoocletPolicyResponseDetails> = await this.getPoliciesList();
     let matchedPolicy: MoocletPolicyResponseDetails = null;

--- a/backend/packages/Upgrade/src/api/services/MoocletExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/MoocletExperimentService.ts
@@ -506,6 +506,25 @@ export class MoocletExperimentService extends ExperimentService {
     return moocletExperimentRef;
   }
 
+  public async getPolicyParametersByMoocletRef(
+    moocletExperimentRef: MoocletExperimentRef
+  ): Promise<MoocletPolicyParametersResponseDetails | null> {
+    if (!moocletExperimentRef?.policyParametersId) {
+      return null;
+    }
+
+    try {
+      return await this.moocletDataService.getPolicyParameters(moocletExperimentRef.policyParametersId);
+    } catch (error) {
+      logger.error({
+        message: 'Error fetching mooclet policy parameters',
+        error,
+        moocletExperimentRef,
+      });
+      return null;
+    }
+  }
+
   // NOTE: will do mooclet condition assignment changes in follow-up PR
 
   // public async getConditionFromMoocletProxy(moocletExperimentRef: MoocletExperimentRef, userId: string): Promise<ExperimentCondition> {

--- a/backend/packages/Upgrade/src/database/migrations/1696498128121-stratificationFactorFeature.ts
+++ b/backend/packages/Upgrade/src/database/migrations/1696498128121-stratificationFactorFeature.ts
@@ -11,7 +11,7 @@ export class stratificationFactorFeature1696498128121 implements MigrationInterf
       `CREATE TABLE "user_stratification_factor" ("createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "versionNumber" integer NOT NULL, "stratificationFactorValue" character varying NOT NULL, "userId" character varying NOT NULL, "factorName" character varying NOT NULL, CONSTRAINT "PK_17c5f1a852052b6800e15febbd6" PRIMARY KEY ("userId", "factorName"))`
     );
     await queryRunner.query(
-      `CREATE TYPE "public"."experiment_assignmentalgorithm_enum" AS ENUM('random', 'stratified random sampling')`
+      `CREATE TYPE "public"."experiment_assignmentalgorithm_enum" AS ENUM('random', 'stratified_random_sampling')`
     );
     await queryRunner.query(
       `ALTER TABLE "public"."experiment" ADD "assignmentAlgorithm" "public"."experiment_assignmentalgorithm_enum" NOT NULL DEFAULT 'random'`

--- a/backend/packages/Upgrade/src/database/migrations/1729695689097-moocletEntities.ts
+++ b/backend/packages/Upgrade/src/database/migrations/1729695689097-moocletEntities.ts
@@ -7,7 +7,7 @@ export class MoocletEntities1729695689097 implements MigrationInterface {
         await queryRunner.query(`CREATE TABLE "mooclet_experiment_ref" ("id" uuid NOT NULL, "experimentId" uuid, "moocletId" integer NOT NULL, "policyParametersId" integer, "variableId" integer, CONSTRAINT "REL_df88beb64b5be102b4637ef375" UNIQUE ("experimentId"), CONSTRAINT "PK_4b09b92ba15f54e38b226a442c6" PRIMARY KEY ("id"))`);
         await queryRunner.query(`CREATE TABLE "mooclet_version_condition_map" ("id" SERIAL NOT NULL, "moocletExperimentRefId" uuid NOT NULL, "experimentConditionId" uuid NOT NULL, "moocletVersionId" integer NOT NULL, CONSTRAINT "PK_0723d7ad1cdc035f4adb5281727" PRIMARY KEY ("id"))`);
         await queryRunner.query(`ALTER TYPE "public"."experiment_assignmentalgorithm_enum" RENAME TO "experiment_assignmentalgorithm_enum_old"`);
-        await queryRunner.query(`CREATE TYPE "public"."experiment_assignmentalgorithm_enum" AS ENUM('random', 'stratified random sampling', 'uniform_random', 'ts_configurable')`);
+        await queryRunner.query(`CREATE TYPE "public"."experiment_assignmentalgorithm_enum" AS ENUM('random', 'stratified_random_sampling', 'uniform_random', 'ts_configurable')`);
         await queryRunner.query(`ALTER TABLE "experiment" ALTER COLUMN "assignmentAlgorithm" DROP DEFAULT`);
         await queryRunner.query(`ALTER TABLE "experiment" ALTER COLUMN "assignmentAlgorithm" TYPE "public"."experiment_assignmentalgorithm_enum" USING "assignmentAlgorithm"::"text"::"public"."experiment_assignmentalgorithm_enum"`);
         await queryRunner.query(`ALTER TABLE "experiment" ALTER COLUMN "assignmentAlgorithm" SET DEFAULT 'random'`);
@@ -21,7 +21,7 @@ export class MoocletEntities1729695689097 implements MigrationInterface {
         await queryRunner.query(`ALTER TABLE "mooclet_version_condition_map" DROP CONSTRAINT "FK_a813783ff9ff52828d7125bb3a1"`);
         await queryRunner.query(`ALTER TABLE "mooclet_version_condition_map" DROP CONSTRAINT "FK_ba85ae6b31045cef3bbcb8a5427"`);
         await queryRunner.query(`ALTER TABLE "mooclet_experiment_ref" DROP CONSTRAINT "FK_df88beb64b5be102b4637ef3756"`);
-        await queryRunner.query(`CREATE TYPE "public"."experiment_assignmentalgorithm_enum_old" AS ENUM('random', 'stratified random sampling')`);
+        await queryRunner.query(`CREATE TYPE "public"."experiment_assignmentalgorithm_enum_old" AS ENUM('random', 'stratified_random_sampling')`);
         await queryRunner.query(`ALTER TABLE "experiment" ALTER COLUMN "assignmentAlgorithm" DROP DEFAULT`);
         await queryRunner.query(`ALTER TABLE "experiment" ALTER COLUMN "assignmentAlgorithm" TYPE "public"."experiment_assignmentalgorithm_enum_old" USING "assignmentAlgorithm"::"text"::"public"."experiment_assignmentalgorithm_enum_old"`);
         await queryRunner.query(`ALTER TABLE "experiment" ALTER COLUMN "assignmentAlgorithm" SET DEFAULT 'random'`);

--- a/backend/packages/Upgrade/test/unit/controllers/ExperimentController.test.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/ExperimentController.test.ts
@@ -12,7 +12,17 @@ import ExperimentAssignmentServiceMock from './mocks/ExperimentAssignmentService
 import { MoocletExperimentService } from '../../../src/api/services/MoocletExperimentService';
 import MoocletExperimentServiceMock from './mocks/MoocletExperimentServiceMock';
 import { env } from './../../../src/env';
-import { ASSIGNMENT_ALGORITHM, ASSIGNMENT_UNIT, CONSISTENCY_RULE, EXPERIMENT_STATE, EXPERIMENT_TYPE, FILTER_MODE, MoocletTSConfigurablePolicyParametersDTO, POST_EXPERIMENT_RULE, SEGMENT_TYPE } from 'upgrade_types';
+import {
+  ASSIGNMENT_ALGORITHM,
+  ASSIGNMENT_UNIT,
+  CONSISTENCY_RULE,
+  EXPERIMENT_STATE,
+  EXPERIMENT_TYPE,
+  FILTER_MODE,
+  MoocletTSConfigurablePolicyParametersDTO,
+  POST_EXPERIMENT_RULE,
+  SEGMENT_TYPE,
+} from 'upgrade_types';
 import { ExperimentDTO } from './../../../src/api/DTO/ExperimentDTO';
 
 describe('Experiment Controller Testing', () => {
@@ -127,19 +137,12 @@ describe('Experiment Controller Testing', () => {
 
   test('Post request for /api/experiments with moocletPolicyParameters and mooclets enabled', () => {
     env.mooclets.enabled = true;
-    return request(app)
-      .post('/api/experiments')
-      .send(moocletExperimentData)
-      .expect('Content-Type', /json/)
-      .expect(200)
+    return request(app).post('/api/experiments').send(moocletExperimentData).expect('Content-Type', /json/).expect(200);
   });
 
   test('Post request for /api/experiments with moocletPolicyParameters and mooclets disabled', () => {
     env.mooclets.enabled = false;
-    return request(app)
-      .post('/api/experiments')
-      .send(moocletExperimentData)
-      .expect(500)
+    return request(app).post('/api/experiments').send(moocletExperimentData).expect(500);
   });
 
   test('Get request for /api/experiments/names', () => {

--- a/backend/packages/Upgrade/test/unit/services/MoocletDataService.test.ts
+++ b/backend/packages/Upgrade/test/unit/services/MoocletDataService.test.ts
@@ -1,10 +1,22 @@
-import { MoocletBatchResponse, MoocletPolicyParametersRequestBody, MoocletPolicyParametersResponseDetails, MoocletPolicyResponseDetails, MoocletProxyRequestParams, MoocletRequestBody, MoocletResponseDetails, MoocletVariableRequestBody, MoocletVariableResponseDetails, MoocletVersionRequestBody, MoocletVersionResponseDetails } from '../../../src/types/Mooclet';
+import {
+  MoocletBatchResponse,
+  MoocletPolicyParametersRequestBody,
+  MoocletPolicyParametersResponseDetails,
+  MoocletPolicyResponseDetails,
+  MoocletProxyRequestParams,
+  MoocletRequestBody,
+  MoocletResponseDetails,
+  MoocletVariableRequestBody,
+  MoocletVariableResponseDetails,
+  MoocletVersionRequestBody,
+  MoocletVersionResponseDetails,
+} from '../../../src/types/Mooclet';
 import { MoocletDataService } from '../../../src/api/services/MoocletDataService';
 import { Container } from 'typedi';
 import axios from 'axios';
 import { UpgradeLogger } from '../../../src/lib/logger/UpgradeLogger';
 import { ASSIGNMENT_ALGORITHM } from '../../../../../../types/src';
-import { MoocletTSConfigurablePolicyParametersDTO } from 'types/src';
+import { MoocletTSConfigurablePolicyParametersDTO } from 'upgrade_types';
 
 jest.mock('axios');
 
@@ -21,57 +33,57 @@ describe('#MoocletDataService', () => {
 
   describe('#getMoocletIdByName', () => {
     it('should return the correct Mooclet ID when the policy name matches', async () => {
-        const mockPoliciesList: MoocletBatchResponse<MoocletPolicyResponseDetails> = {
-            count: 2,
-            next: null,
-            previous: null,
-            results: [
-                { id: 1, name: 'Policy1' },
-                { id: 2, name: 'Policy2' },
-            ],
-        };
-    
-        jest.spyOn(moocletDataService, 'getPoliciesList').mockResolvedValue(mockPoliciesList);
-    
-        const moocletId = await moocletDataService.getMoocletIdByName('Policy2');
-        expect(moocletId).toBe(2);
-      });
-
-    it('should return null when the policy name does not match', async () => {
-        const mockPoliciesList: MoocletBatchResponse<MoocletPolicyResponseDetails> = {
+      const mockPoliciesList: MoocletBatchResponse<MoocletPolicyResponseDetails> = {
         count: 2,
         next: null,
         previous: null,
         results: [
-            { id: 1, name: 'Policy1' },
-            { id: 2, name: 'Policy2' },
+          { id: 1, name: 'Policy1' },
+          { id: 2, name: 'Policy2' },
         ],
-        };
+      };
 
-        jest.spyOn(moocletDataService, 'getPoliciesList').mockResolvedValue(mockPoliciesList);
+      jest.spyOn(moocletDataService, 'getPoliciesList').mockResolvedValue(mockPoliciesList);
 
-        const moocletId = await moocletDataService.getMoocletIdByName('Policy3');
-        expect(moocletId).toBeNull();
+      const moocletId = await moocletDataService.getMoocletIdByName('Policy2');
+      expect(moocletId).toBe(2);
+    });
+
+    it('should return null when the policy name does not match', async () => {
+      const mockPoliciesList: MoocletBatchResponse<MoocletPolicyResponseDetails> = {
+        count: 2,
+        next: null,
+        previous: null,
+        results: [
+          { id: 1, name: 'Policy1' },
+          { id: 2, name: 'Policy2' },
+        ],
+      };
+
+      jest.spyOn(moocletDataService, 'getPoliciesList').mockResolvedValue(mockPoliciesList);
+
+      const moocletId = await moocletDataService.getMoocletIdByName('Policy3');
+      expect(moocletId).toBeNull();
     });
 
     it('should return null when the policies list is empty', async () => {
-        const mockPoliciesList: MoocletBatchResponse<MoocletPolicyResponseDetails> = {
+      const mockPoliciesList: MoocletBatchResponse<MoocletPolicyResponseDetails> = {
         count: 0,
         next: null,
         previous: null,
         results: [],
-        };
+      };
 
-        jest.spyOn(moocletDataService, 'getPoliciesList').mockResolvedValue(mockPoliciesList);
+      jest.spyOn(moocletDataService, 'getPoliciesList').mockResolvedValue(mockPoliciesList);
 
-        const moocletId = await moocletDataService.getMoocletIdByName('Policy1');
-        expect(moocletId).toBeNull();
+      const moocletId = await moocletDataService.getMoocletIdByName('Policy1');
+      expect(moocletId).toBeNull();
     });
 
     it('should throw an error when getPoliciesList fails', async () => {
-        jest.spyOn(moocletDataService, 'getPoliciesList').mockRejectedValue(new Error('Failed to fetch policies'));
+      jest.spyOn(moocletDataService, 'getPoliciesList').mockRejectedValue(new Error('Failed to fetch policies'));
 
-        await expect(moocletDataService.getMoocletIdByName('Policy1')).rejects.toThrow('Failed to fetch policies');
+      await expect(moocletDataService.getMoocletIdByName('Policy1')).rejects.toThrow('Failed to fetch policies');
     });
 
     afterAll(() => {
@@ -98,7 +110,9 @@ describe('#MoocletDataService', () => {
     });
 
     it('should throw an error when fetchExternalMoocletsData fails', async () => {
-      jest.spyOn(moocletDataService, 'fetchExternalMoocletsData').mockRejectedValue(new Error('Failed to fetch policies'));
+      jest
+        .spyOn(moocletDataService, 'fetchExternalMoocletsData')
+        .mockRejectedValue(new Error('Failed to fetch policies'));
 
       await expect(moocletDataService.getPoliciesList()).rejects.toThrow('Failed to fetch policies');
     });
@@ -129,7 +143,9 @@ describe('#MoocletDataService', () => {
         policy: 3,
       };
 
-      jest.spyOn(moocletDataService, 'fetchExternalMoocletsData').mockRejectedValue(new Error('Failed to create mooclet'));
+      jest
+        .spyOn(moocletDataService, 'fetchExternalMoocletsData')
+        .mockRejectedValue(new Error('Failed to create mooclet'));
 
       await expect(moocletDataService.postNewMooclet(mockRequestBody)).rejects.toThrow('Failed to create mooclet');
     });
@@ -139,18 +155,20 @@ describe('#MoocletDataService', () => {
     it('should return the response when the delete request is successful', async () => {
       const moocletId = 1;
       const mockResponse = { success: true };
-  
+
       jest.spyOn(moocletDataService, 'fetchExternalMoocletsData').mockResolvedValue(mockResponse);
-  
+
       const response = await moocletDataService.deleteMooclet(moocletId);
       expect(response).toEqual(mockResponse);
     });
-  
+
     it('should throw an error when the delete request fails', async () => {
       const moocletId = 1;
-  
-      jest.spyOn(moocletDataService, 'fetchExternalMoocletsData').mockRejectedValue(new Error('Failed to delete mooclet'));
-  
+
+      jest
+        .spyOn(moocletDataService, 'fetchExternalMoocletsData')
+        .mockRejectedValue(new Error('Failed to delete mooclet'));
+
       await expect(moocletDataService.deleteMooclet(moocletId)).rejects.toThrow('Failed to delete mooclet');
     });
   });
@@ -161,33 +179,35 @@ describe('#MoocletDataService', () => {
         mooclet: 1,
         name: 'Version 1',
         text: 'This is version 1',
-        version_json: { 'key': 1 },
+        version_json: { key: 1 },
       };
-  
+
       const mockResponseDetails: MoocletVersionResponseDetails = {
         id: 1,
         mooclet: 1,
         name: 'Version 1',
         text: 'This is version 1',
-        version_json: { 'key': 1 },
+        version_json: { key: 1 },
       };
-  
+
       jest.spyOn(moocletDataService, 'fetchExternalMoocletsData').mockResolvedValue(mockResponseDetails);
-  
+
       const response = await moocletDataService.postNewVersion(mockRequestBody);
       expect(response).toEqual(mockResponseDetails);
     });
-  
+
     it('should throw an error when the request fails', async () => {
       const mockRequestBody: MoocletVersionRequestBody = {
         mooclet: 1,
         name: 'Version 1',
         text: 'This is version 1',
-        version_json: { 'key': 1 },
+        version_json: { key: 1 },
       };
-  
-      jest.spyOn(moocletDataService, 'fetchExternalMoocletsData').mockRejectedValue(new Error('Failed to create version'));
-  
+
+      jest
+        .spyOn(moocletDataService, 'fetchExternalMoocletsData')
+        .mockRejectedValue(new Error('Failed to create version'));
+
       await expect(moocletDataService.postNewVersion(mockRequestBody)).rejects.toThrow('Failed to create version');
     });
   });
@@ -196,18 +216,20 @@ describe('#MoocletDataService', () => {
     it('should return the response when the delete request is successful', async () => {
       const versionId = 1;
       const mockResponse = { success: true };
-  
+
       jest.spyOn(moocletDataService, 'fetchExternalMoocletsData').mockResolvedValue(mockResponse);
-  
+
       const response = await moocletDataService.deleteVersion(versionId);
       expect(response).toEqual(mockResponse);
     });
-  
+
     it('should throw an error when the delete request fails', async () => {
       const versionId = 1;
-  
-      jest.spyOn(moocletDataService, 'fetchExternalMoocletsData').mockRejectedValue(new Error('Failed to delete version'));
-  
+
+      jest
+        .spyOn(moocletDataService, 'fetchExternalMoocletsData')
+        .mockRejectedValue(new Error('Failed to delete version'));
+
       await expect(moocletDataService.deleteVersion(versionId)).rejects.toThrow('Failed to delete version');
     });
   });
@@ -224,47 +246,51 @@ describe('#MoocletDataService', () => {
       uniform_threshold: 0,
       tspostdiff_thresh: 0,
       outcome_variable_name: 'example_reward_var',
+      assignmentAlgorithm: ASSIGNMENT_ALGORITHM.MOOCLET_TS_CONFIGURABLE,
     };
     it('should return the new policy parameters details when the request is successful', async () => {
-      
       const mockRequestBody: MoocletPolicyParametersRequestBody = {
         mooclet: 1,
         policy: 2,
-        parameters: { 
+        parameters: {
           ...mockPolicyParameters,
           assignmentAlgorithm: ASSIGNMENT_ALGORITHM.MOOCLET_TS_CONFIGURABLE,
         },
       };
-  
+
       const mockResponseDetails: MoocletPolicyParametersResponseDetails = {
         id: 1,
         mooclet: 1,
         policy: 2,
-        parameters: { 
+        parameters: {
           ...mockPolicyParameters,
           assignmentAlgorithm: ASSIGNMENT_ALGORITHM.MOOCLET_TS_CONFIGURABLE,
         },
       };
-  
+
       jest.spyOn(moocletDataService, 'fetchExternalMoocletsData').mockResolvedValue(mockResponseDetails);
-  
+
       const response = await moocletDataService.postNewPolicyParameters(mockRequestBody);
       expect(response).toEqual(mockResponseDetails);
     });
-  
+
     it('should throw an error when the request fails', async () => {
       const mockRequestBody: MoocletPolicyParametersRequestBody = {
         mooclet: 1,
         policy: 2,
-        parameters: { 
+        parameters: {
           ...mockPolicyParameters,
           assignmentAlgorithm: ASSIGNMENT_ALGORITHM.MOOCLET_TS_CONFIGURABLE,
         },
       };
-  
-      jest.spyOn(moocletDataService, 'fetchExternalMoocletsData').mockRejectedValue(new Error('Failed to create policy parameters'));
-  
-      await expect(moocletDataService.postNewPolicyParameters(mockRequestBody)).rejects.toThrow('Failed to create policy parameters');
+
+      jest
+        .spyOn(moocletDataService, 'fetchExternalMoocletsData')
+        .mockRejectedValue(new Error('Failed to create policy parameters'));
+
+      await expect(moocletDataService.postNewPolicyParameters(mockRequestBody)).rejects.toThrow(
+        'Failed to create policy parameters'
+      );
     });
   });
 
@@ -272,19 +298,23 @@ describe('#MoocletDataService', () => {
     it('should return the response when the delete request is successful', async () => {
       const policyParametersId = 1;
       const mockResponse = { success: true };
-  
+
       jest.spyOn(moocletDataService, 'fetchExternalMoocletsData').mockResolvedValue(mockResponse);
-  
+
       const response = await moocletDataService.deletePolicyParameters(policyParametersId);
       expect(response).toEqual(mockResponse);
     });
-  
+
     it('should throw an error when the delete request fails', async () => {
       const policyParametersId = 1;
-  
-      jest.spyOn(moocletDataService, 'fetchExternalMoocletsData').mockRejectedValue(new Error('Failed to delete policy parameters'));
-  
-      await expect(moocletDataService.deletePolicyParameters(policyParametersId)).rejects.toThrow('Failed to delete policy parameters');
+
+      jest
+        .spyOn(moocletDataService, 'fetchExternalMoocletsData')
+        .mockRejectedValue(new Error('Failed to delete policy parameters'));
+
+      await expect(moocletDataService.deletePolicyParameters(policyParametersId)).rejects.toThrow(
+        'Failed to delete policy parameters'
+      );
     });
   });
 
@@ -293,7 +323,7 @@ describe('#MoocletDataService', () => {
       const mockRequestBody: MoocletVariableRequestBody = {
         name: 'New Variable',
       };
-  
+
       const mockResponseDetails: MoocletVariableResponseDetails = {
         id: 1,
         environment: null,
@@ -304,20 +334,22 @@ describe('#MoocletDataService', () => {
         value_type: 'BIN',
         sample_thres: 1,
       };
-  
+
       jest.spyOn(moocletDataService, 'fetchExternalMoocletsData').mockResolvedValue(mockResponseDetails);
-  
+
       const response = await moocletDataService.postNewVariable(mockRequestBody);
       expect(response).toEqual(mockResponseDetails);
     });
-  
+
     it('should throw an error when the request fails', async () => {
       const mockRequestBody: MoocletVariableRequestBody = {
         name: 'New Variable',
       };
-  
-      jest.spyOn(moocletDataService, 'fetchExternalMoocletsData').mockRejectedValue(new Error('Failed to create variable'));
-  
+
+      jest
+        .spyOn(moocletDataService, 'fetchExternalMoocletsData')
+        .mockRejectedValue(new Error('Failed to create variable'));
+
       await expect(moocletDataService.postNewVariable(mockRequestBody)).rejects.toThrow('Failed to create variable');
     });
   });
@@ -330,18 +362,20 @@ describe('#MoocletDataService', () => {
     it('should return the response when the delete request is successful', async () => {
       const variableId = 1;
       const mockResponse = { success: true };
-  
+
       jest.spyOn(moocletDataService, 'fetchExternalMoocletsData').mockResolvedValue(mockResponse);
-  
+
       const response = await moocletDataService.deleteVariable(variableId);
       expect(response).toEqual(mockResponse);
     });
-  
+
     it('should throw an error when the delete request fails', async () => {
       const variableId = 1;
-  
-      jest.spyOn(moocletDataService, 'fetchExternalMoocletsData').mockRejectedValue(new Error('Failed to delete variable'));
-  
+
+      jest
+        .spyOn(moocletDataService, 'fetchExternalMoocletsData')
+        .mockRejectedValue(new Error('Failed to delete variable'));
+
       await expect(moocletDataService.deleteVariable(variableId)).rejects.toThrow('Failed to delete variable');
     });
 
@@ -354,13 +388,13 @@ describe('#MoocletDataService', () => {
     const mockRequest: MoocletRequestBody = {
       name: 'New Mooclet',
       policy: 3,
-    }
+    };
     it('should return the response data when the request is successful', async () => {
       const mockRequestParams: MoocletProxyRequestParams = {
         method: 'POST',
         url: 'https://api.example.com/mooclet',
         apiToken: 'test-token',
-        body: { ...mockRequest},
+        body: { ...mockRequest },
       };
 
       const mockResponse = {
@@ -379,7 +413,7 @@ describe('#MoocletDataService', () => {
         method: 'POST',
         url: 'https://api.example.com/mooclet',
         apiToken: 'test-token',
-        body: { ...mockRequest},
+        body: { ...mockRequest },
       };
 
       const mockErrorResponse = {
@@ -398,7 +432,7 @@ describe('#MoocletDataService', () => {
         method: 'POST',
         url: 'https://api.example.com/mooclet',
         apiToken: 'test-token',
-        body: { ...mockRequest},
+        body: { ...mockRequest },
       };
 
       const mockError = new Error('Mock Network Error');

--- a/backend/packages/Upgrade/test/unit/services/MoocletExperimentService.test.ts
+++ b/backend/packages/Upgrade/test/unit/services/MoocletExperimentService.test.ts
@@ -31,7 +31,17 @@ import { QueryService } from '../../../src/api/services/QueryService';
 import { ScheduledJobService } from '../../../src/api/services/ScheduledJobService';
 import { SegmentService } from '../../../src/api/services/SegmentService';
 import { DataSource, EntityManager } from 'typeorm';
-import { ASSIGNMENT_ALGORITHM, ASSIGNMENT_UNIT, CONSISTENCY_RULE, EXPERIMENT_STATE, EXPERIMENT_TYPE, FILTER_MODE, PAYLOAD_TYPE, POST_EXPERIMENT_RULE, SEGMENT_TYPE } from 'upgrade_types';
+import {
+  ASSIGNMENT_ALGORITHM,
+  ASSIGNMENT_UNIT,
+  CONSISTENCY_RULE,
+  EXPERIMENT_STATE,
+  EXPERIMENT_TYPE,
+  FILTER_MODE,
+  PAYLOAD_TYPE,
+  POST_EXPERIMENT_RULE,
+  SEGMENT_TYPE,
+} from 'upgrade_types';
 
 const mockDataSource = {
   initialize: jest.fn(),
@@ -86,107 +96,106 @@ const mockTSConfigMoocletPolicyParameters = {
   assignmentAlgorithm: ASSIGNMENT_ALGORITHM.MOOCLET_TS_CONFIGURABLE,
   prior: {
     success: 1,
-    failure: 1
+    failure: 1,
   },
   batch_size: 1,
   max_rating: 1,
   min_rating: 0,
   uniform_threshold: 0,
   tspostdiff_thresh: 0,
-  outcome_variable_name: "TS_CONFIG_TEST"
+  outcome_variable_name: 'TS_CONFIG_TEST',
 };
 
 const moocletExperimentDataTSConfigurable = {
-    id: 'test-exp-123',
-    name: "test",
-    description: "",
-    consistencyRule: CONSISTENCY_RULE.INDIVIDUAL,
-    assignmentUnit: ASSIGNMENT_UNIT.INDIVIDUAL,
-    type: EXPERIMENT_TYPE.SIMPLE,
-    context: ["mathstream"],
-    assignmentAlgorithm: ASSIGNMENT_ALGORITHM.MOOCLET_TS_CONFIGURABLE,
-    stratificationFactor: null,
-    tags: [],
-    conditions: [
-      {
-        id: "A",
-        conditionCode: "question-hint-default",
-        assignmentWeight: 50,
-        description: null,
-        order: 1,
-        name: ""
-      },
-      {
-        id: "B",
-        conditionCode: "question-hint-tutorbot",
-        assignmentWeight: 50,
-        description: null,
-        order: 2,
-        name: ""
-      }
-    ],
-    conditionPayloads: [
-      {
-        id: "E",
-        payload: {
-          type: PAYLOAD_TYPE.STRING,
-          value: "question-hint-default"
-        },
-        parentCondition: "A",
-        decisionPoint: "C"
-      },
-      {
-        id: "F",
-        payload: {
-          type: PAYLOAD_TYPE.STRING,
-          value: "question-hint-tutorbot"
-        },
-        parentCondition: "B",
-        decisionPoint: "C"
-      }
-    ],
-    partitions: [
-      {
-        id: "C",
-        site: "lesson-stream",
-        target: "question-hint",
-        description: "",
-        order: 1,
-        excludeIfReached: false
-      }
-    ],
-    experimentSegmentInclusion: {
-      segment: {
-        individualForSegment: [],
-        groupForSegment: [
-          {
-            type: "All",
-            groupId: "All"
-          }
-        ],
-        subSegments: [],
-        type: SEGMENT_TYPE.PRIVATE
-      }
+  id: 'test-exp-123',
+  name: 'test',
+  description: '',
+  consistencyRule: CONSISTENCY_RULE.INDIVIDUAL,
+  assignmentUnit: ASSIGNMENT_UNIT.INDIVIDUAL,
+  type: EXPERIMENT_TYPE.SIMPLE,
+  context: ['mathstream'],
+  assignmentAlgorithm: ASSIGNMENT_ALGORITHM.MOOCLET_TS_CONFIGURABLE,
+  stratificationFactor: null,
+  tags: [],
+  conditions: [
+    {
+      id: 'A',
+      conditionCode: 'question-hint-default',
+      assignmentWeight: 50,
+      description: null,
+      order: 1,
+      name: '',
     },
-    experimentSegmentExclusion: {
-      segment: {
-        individualForSegment: [],
-        groupForSegment: [],
-        subSegments: [],
-        type: SEGMENT_TYPE.PRIVATE
-      }
+    {
+      id: 'B',
+      conditionCode: 'question-hint-tutorbot',
+      assignmentWeight: 50,
+      description: null,
+      order: 2,
+      name: '',
     },
-    filterMode: FILTER_MODE.EXCLUDE_ALL,
-    queries: [],
-    endOn: null,
-    enrollmentCompleteCondition: null,
-    startOn: null,
-    state: EXPERIMENT_STATE.ENROLLING,
-    postExperimentRule: POST_EXPERIMENT_RULE.CONTINUE,
-    revertTo: null,
-    moocletPolicyParameters: mockTSConfigMoocletPolicyParameters
-  };
-
+  ],
+  conditionPayloads: [
+    {
+      id: 'E',
+      payload: {
+        type: PAYLOAD_TYPE.STRING,
+        value: 'question-hint-default',
+      },
+      parentCondition: 'A',
+      decisionPoint: 'C',
+    },
+    {
+      id: 'F',
+      payload: {
+        type: PAYLOAD_TYPE.STRING,
+        value: 'question-hint-tutorbot',
+      },
+      parentCondition: 'B',
+      decisionPoint: 'C',
+    },
+  ],
+  partitions: [
+    {
+      id: 'C',
+      site: 'lesson-stream',
+      target: 'question-hint',
+      description: '',
+      order: 1,
+      excludeIfReached: false,
+    },
+  ],
+  experimentSegmentInclusion: {
+    segment: {
+      individualForSegment: [],
+      groupForSegment: [
+        {
+          type: 'All',
+          groupId: 'All',
+        },
+      ],
+      subSegments: [],
+      type: SEGMENT_TYPE.PRIVATE,
+    },
+  },
+  experimentSegmentExclusion: {
+    segment: {
+      individualForSegment: [],
+      groupForSegment: [],
+      subSegments: [],
+      type: SEGMENT_TYPE.PRIVATE,
+    },
+  },
+  filterMode: FILTER_MODE.EXCLUDE_ALL,
+  queries: [],
+  endOn: null,
+  enrollmentCompleteCondition: null,
+  startOn: null,
+  state: EXPERIMENT_STATE.ENROLLING,
+  postExperimentRule: POST_EXPERIMENT_RULE.CONTINUE,
+  revertTo: null,
+  moocletPolicyParameters: mockTSConfigMoocletPolicyParameters,
+};
 
 describe('#MoocletExperimentService', () => {
   let moocletExperimentService: MoocletExperimentService;
@@ -262,12 +271,12 @@ describe('#MoocletExperimentService', () => {
     let params: SyncCreateParams;
     let mockExperimentResponse: ExperimentDTO;
     let mockMoocletExperimentRefResponse: MoocletExperimentRef;
-  
+
     beforeEach(() => {
       mockExperimentResponse = {
         id: 'exp-123',
       } as ExperimentDTO;
-  
+
       mockMoocletExperimentRefResponse = {
         id: 'moocletRef-123',
       } as MoocletExperimentRef;
@@ -275,107 +284,95 @@ describe('#MoocletExperimentService', () => {
       manager = mockDataSource.manager as EntityManager;
       params = {
         experimentDTO: moocletExperimentDataTSConfigurable,
-        currentUser: {} as UserDTO
+        currentUser: {} as UserDTO,
       };
-  
+
       // Spy on class methods
       jest.spyOn(moocletExperimentService as any, 'createExperiment').mockResolvedValue(mockExperimentResponse);
-      jest.spyOn(moocletExperimentService as any, 'orchestrateMoocletCreation').mockResolvedValue(mockMoocletExperimentRefResponse);
+      jest
+        .spyOn(moocletExperimentService as any, 'orchestrateMoocletCreation')
+        .mockResolvedValue(mockMoocletExperimentRefResponse);
       jest.spyOn(moocletExperimentService as any, 'saveMoocletExperimentRef').mockResolvedValue(undefined);
       jest.spyOn(moocletExperimentService as any, 'createAndSaveVersionConditionMaps').mockResolvedValue(undefined);
       jest.spyOn(moocletExperimentService as any, 'orchestrateDeleteMoocletResources').mockResolvedValue(undefined);
     });
-  
+
     afterEach(() => {
       jest.clearAllMocks();
     });
-  
+
     it('should successfully create a mooclet experiment with all required resources', async () => {
-      const result = await moocletExperimentService['handleCreateMoocletTransaction'](
-        manager,
-        params
-      );
-  
+      const result = await moocletExperimentService['handleCreateMoocletTransaction'](manager, params);
+
       // Verify all methods were called with correct parameters
-      expect(moocletExperimentService['createExperiment']).toHaveBeenCalledWith(
-        manager,
-        params
-      );
-  
+      expect(moocletExperimentService['createExperiment']).toHaveBeenCalledWith(manager, params);
+
       expect(moocletExperimentService['orchestrateMoocletCreation']).toHaveBeenCalledWith(
         mockExperimentResponse,
         params.experimentDTO.moocletPolicyParameters
       );
-  
+
       expect(moocletExperimentService['saveMoocletExperimentRef']).toHaveBeenCalledWith(
         manager,
         mockMoocletExperimentRefResponse
       );
-  
+
       expect(moocletExperimentService['createAndSaveVersionConditionMaps']).toHaveBeenCalledWith(
         manager,
         mockMoocletExperimentRefResponse
       );
-  
+
       // Verify the result
       expect(result).toEqual({
         ...mockExperimentResponse,
-        moocletPolicyParameters: params.experimentDTO.moocletPolicyParameters
+        moocletPolicyParameters: params.experimentDTO.moocletPolicyParameters,
       });
-  
+
       // Verify orchestrateDeleteMoocletResources was not called
       expect(moocletExperimentService['orchestrateDeleteMoocletResources']).not.toHaveBeenCalled();
     });
-  
+
     it('should handle failure during createExperiment and throw error', async () => {
       const error = new Error('Failed to create experiment');
       jest.spyOn(moocletExperimentService as any, 'createExperiment').mockRejectedValue(error);
-  
-      await expect(
-        moocletExperimentService['handleCreateMoocletTransaction'](manager, params)
-      ).rejects.toThrow(error);
-  
+
+      await expect(moocletExperimentService['handleCreateMoocletTransaction'](manager, params)).rejects.toThrow(error);
+
       // Verify subsequent methods were not called
       expect(moocletExperimentService['orchestrateMoocletCreation']).not.toHaveBeenCalled();
       expect(moocletExperimentService['saveMoocletExperimentRef']).not.toHaveBeenCalled();
       expect(moocletExperimentService['createAndSaveVersionConditionMaps']).not.toHaveBeenCalled();
     });
-  
+
     it('should handle failure during orchestrateMoocletCreation and throw error', async () => {
       const error = new Error('Failed to create mooclet resources');
       jest.spyOn(moocletExperimentService as any, 'orchestrateMoocletCreation').mockRejectedValue(error);
-  
-      await expect(
-        moocletExperimentService['handleCreateMoocletTransaction'](manager, params)
-      ).rejects.toThrow(error);
-  
+
+      await expect(moocletExperimentService['handleCreateMoocletTransaction'](manager, params)).rejects.toThrow(error);
+
       // Verify subsequent methods were not called
       expect(moocletExperimentService['saveMoocletExperimentRef']).not.toHaveBeenCalled();
       expect(moocletExperimentService['createAndSaveVersionConditionMaps']).not.toHaveBeenCalled();
     });
-  
+
     it('should handle failure during saveMoocletExperimentRef and cleanup resources', async () => {
       const error = new Error('Failed to save mooclet ref');
       jest.spyOn(moocletExperimentService as any, 'saveMoocletExperimentRef').mockRejectedValue(error);
-  
-      await expect(
-        moocletExperimentService['handleCreateMoocletTransaction'](manager, params)
-      ).rejects.toThrow(error);
-  
+
+      await expect(moocletExperimentService['handleCreateMoocletTransaction'](manager, params)).rejects.toThrow(error);
+
       // Verify cleanup was called
       expect(moocletExperimentService['orchestrateDeleteMoocletResources']).toHaveBeenCalledWith(
         mockMoocletExperimentRefResponse
       );
     });
-  
+
     it('should handle failure during createAndSaveVersionConditionMaps and cleanup resources', async () => {
       const error = new Error('Failed to save version condition maps');
       jest.spyOn(moocletExperimentService as any, 'createAndSaveVersionConditionMaps').mockRejectedValue(error);
-  
-      await expect(
-        moocletExperimentService['handleCreateMoocletTransaction'](manager, params)
-      ).rejects.toThrow(error);
-  
+
+      await expect(moocletExperimentService['handleCreateMoocletTransaction'](manager, params)).rejects.toThrow(error);
+
       // Verify cleanup was called
       expect(moocletExperimentService['orchestrateDeleteMoocletResources']).toHaveBeenCalledWith(
         mockMoocletExperimentRefResponse
@@ -383,8 +380,7 @@ describe('#MoocletExperimentService', () => {
     });
   });
 
-  describe("#orchestrateMoocletCreation", ()=> {
-
+  describe('#orchestrateMoocletCreation', () => {
     afterEach(() => {
       jest.clearAllMocks();
     });
@@ -398,13 +394,22 @@ describe('#MoocletExperimentService', () => {
 
       jest.spyOn(moocletExperimentService as any, 'getMoocletPolicy').mockResolvedValue(mockMoocletPolicy);
       jest.spyOn(moocletExperimentService as any, 'createMooclet').mockResolvedValue(mockMoocletResponse);
-      jest.spyOn(moocletExperimentService as any, 'createMoocletVersions').mockResolvedValue(mockMoocletVersionsResponse);
+      jest
+        .spyOn(moocletExperimentService as any, 'createMoocletVersions')
+        .mockResolvedValue(mockMoocletVersionsResponse);
       jest.spyOn(moocletExperimentService as any, 'createMoocletVersionConditionMaps').mockReturnValue([]);
-      jest.spyOn(moocletExperimentService as any, 'createPolicyParameters').mockResolvedValue(mockMoocletPolicyParametersResponse);
-      jest.spyOn(moocletExperimentService as any, 'createVariableIfNeeded').mockResolvedValue(mockMoocletVariableResponse);
+      jest
+        .spyOn(moocletExperimentService as any, 'createPolicyParameters')
+        .mockResolvedValue(mockMoocletPolicyParametersResponse);
+      jest
+        .spyOn(moocletExperimentService as any, 'createVariableIfNeeded')
+        .mockResolvedValue(mockMoocletVariableResponse);
       jest.spyOn(moocletExperimentService as any, 'orchestrateDeleteMoocletResources').mockResolvedValue(undefined);
 
-      const result = await moocletExperimentService.orchestrateMoocletCreation(moocletExperimentDataTSConfigurable, mockTSConfigMoocletPolicyParameters);
+      const result = await moocletExperimentService.orchestrateMoocletCreation(
+        moocletExperimentDataTSConfigurable,
+        mockTSConfigMoocletPolicyParameters
+      );
 
       expect(result).toBeDefined();
       expect(result?.experimentId).toBe(moocletExperimentDataTSConfigurable.id);
@@ -420,19 +425,24 @@ describe('#MoocletExperimentService', () => {
       jest.spyOn(moocletExperimentService as any, 'getMoocletPolicy').mockRejectedValue(mockError);
       jest.spyOn(moocletExperimentService as any, 'orchestrateDeleteMoocletResources').mockRejectedValue(mockError);
 
-      await expect(moocletExperimentService.orchestrateMoocletCreation(moocletExperimentDataTSConfigurable, mockTSConfigMoocletPolicyParameters)).rejects.toThrow(mockError);
+      await expect(
+        moocletExperimentService.orchestrateMoocletCreation(
+          moocletExperimentDataTSConfigurable,
+          mockTSConfigMoocletPolicyParameters
+        )
+      ).rejects.toThrow(mockError);
       expect(moocletExperimentService.orchestrateDeleteMoocletResources).toHaveBeenCalled();
     });
   });
 
-  describe("#orchestrateDeleteMoocletResources", ()=> {
+  describe('#orchestrateDeleteMoocletResources', () => {
     const mockMoocletExperimentRef = new MoocletExperimentRef();
     mockMoocletExperimentRef.moocletId = 1;
     mockMoocletExperimentRef.policyParametersId = 2;
     mockMoocletExperimentRef.variableId = 3;
     mockMoocletExperimentRef.id = 'mockMoocletExperimentRef123';
     mockMoocletExperimentRef.versionConditionMaps = [];
-      
+
     afterEach(() => {
       jest.clearAllMocks();
     });
@@ -441,11 +451,13 @@ describe('#MoocletExperimentService', () => {
       jest.spyOn(moocletDataService, 'deleteMooclet').mockResolvedValue(undefined);
       jest.spyOn(moocletDataService, 'deletePolicyParameters').mockResolvedValue(undefined);
       jest.spyOn(moocletDataService, 'deleteVariable').mockResolvedValue(undefined);
-  
+
       await moocletExperimentService.orchestrateDeleteMoocletResources(mockMoocletExperimentRef);
-  
+
       expect(moocletDataService.deleteMooclet).toHaveBeenCalledWith(mockMoocletExperimentRef.moocletId);
-      expect(moocletDataService.deletePolicyParameters).toHaveBeenCalledWith(mockMoocletExperimentRef.policyParametersId);
+      expect(moocletDataService.deletePolicyParameters).toHaveBeenCalledWith(
+        mockMoocletExperimentRef.policyParametersId
+      );
       expect(moocletDataService.deleteVariable).toHaveBeenCalledWith(mockMoocletExperimentRef.variableId);
     });
     it('should handle errors and log them', async () => {
@@ -454,9 +466,11 @@ describe('#MoocletExperimentService', () => {
       jest.spyOn(moocletExperimentService as any, 'deleteMoocletVersions').mockResolvedValue(undefined);
       jest.spyOn(moocletDataService, 'deletePolicyParameters').mockResolvedValue(undefined);
       jest.spyOn(moocletDataService, 'deleteVariable').mockResolvedValue(undefined);
-  
-      await expect(moocletExperimentService.orchestrateDeleteMoocletResources(mockMoocletExperimentRef)).rejects.toThrow(mockError);
-  
+
+      await expect(
+        moocletExperimentService.orchestrateDeleteMoocletResources(mockMoocletExperimentRef)
+      ).rejects.toThrow(mockError);
+
       expect(moocletDataService.deleteMooclet).toHaveBeenCalledWith(mockMoocletExperimentRef.moocletId);
       expect(moocletDataService.deletePolicyParameters).not.toHaveBeenCalled();
       expect(moocletDataService.deleteVariable).not.toHaveBeenCalled();

--- a/frontend/projects/upgrade/src/app/core/experiment-design-stepper/experiment-design-stepper.service.ts
+++ b/frontend/projects/upgrade/src/app/core/experiment-design-stepper/experiment-design-stepper.service.ts
@@ -83,7 +83,7 @@ export class ExperimentDesignStepperService {
   currentAssignmentAlgorithm$ = new BehaviorSubject<ASSIGNMENT_ALGORITHM>(ASSIGNMENT_ALGORITHM.RANDOM);
   isMoocletExperimentDesign$ = this.currentAssignmentAlgorithm$.pipe(
     map((algorithm) => {
-      return environment.moocletToggle && Object.keys(MOOCLET_POLICY_SCHEMA_MAP).includes(algorithm)
+      return environment.moocletToggle && Object.keys(MOOCLET_POLICY_SCHEMA_MAP).includes(algorithm);
     })
   );
 

--- a/frontend/projects/upgrade/src/app/core/experiment-design-stepper/experiment-design-stepper.service.ts
+++ b/frontend/projects/upgrade/src/app/core/experiment-design-stepper/experiment-design-stepper.service.ts
@@ -75,6 +75,10 @@ export class ExperimentDesignStepperService {
   );
   factorialExperimentDesignData$ = this.store$.pipe(select(selectFactorialDesignData), distinctUntilChanged(isEqual));
 
+  // Name:
+  private experimentNameSource = new BehaviorSubject<string>('');
+  currentExperimentName$ = this.experimentNameSource.asObservable();
+
   // Unit of Assignment:
   private assignmentUnitSource = new BehaviorSubject<ASSIGNMENT_UNIT>(ASSIGNMENT_UNIT.INDIVIDUAL);
   currentAssignmentUnit$ = this.assignmentUnitSource.asObservable();
@@ -141,6 +145,10 @@ export class ExperimentDesignStepperService {
     this.simpleExperimentPayloadTableData$.subscribe(this.simpleExperimentPayloadTableDataBehaviorSubject$);
     this.factorialFactorTableData$.subscribe(this.factorialFactorTableDataBehaviorSubject$);
     this.factorialLevelsTableData$.subscribe(this.factorialLevelTableDataBehaviorSubject$);
+  }
+
+  changeExperimentName(name: string) {
+    this.experimentNameSource.next(name);
   }
 
   changeAssignmentUnit(unit: ASSIGNMENT_UNIT) {

--- a/frontend/projects/upgrade/src/app/core/experiment-design-stepper/experiment-design-stepper.service.ts
+++ b/frontend/projects/upgrade/src/app/core/experiment-design-stepper/experiment-design-stepper.service.ts
@@ -670,6 +670,10 @@ export class ExperimentDesignStepperService {
     );
   }
 
+  clearAssignmentAlgorithm(): void {
+    this.currentAssignmentAlgorithm$.next(ASSIGNMENT_ALGORITHM.RANDOM);
+  }
+
   clearDecisionPointTableEditModeDetails(): void {
     this.store$.dispatch(experimentDesignStepperAction.actionClearDecisionPointTableEditDetails());
   }
@@ -692,9 +696,11 @@ export class ExperimentDesignStepperService {
 
   clearFactorialDesignStepperData(): void {
     this.store$.dispatch(experimentDesignStepperAction.clearFactorialDesignStepperData());
+    this.clearAssignmentAlgorithm();
   }
 
   clearSimpleExperimentDesignStepperData(): void {
     this.store$.dispatch(experimentDesignStepperAction.clearSimpleExperimentDesignStepperData());
+    this.clearAssignmentAlgorithm();
   }
 }

--- a/frontend/projects/upgrade/src/app/core/experiments/store/experiments.model.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/store/experiments.model.ts
@@ -19,6 +19,7 @@ import {
   PAYLOAD_TYPE,
   CONDITION_ORDER,
   ASSIGNMENT_ALGORITHM,
+  MoocletTSConfigurablePolicyParametersDTO,
 } from 'upgrade_types';
 import { Segment } from '../../segments/store/segments.model';
 
@@ -256,6 +257,7 @@ export interface Experiment {
   experimentSegmentExclusion: SegmentNew;
   groupSatisfied?: number;
   backendVersion: string;
+  moocletPolicyParameters?: MoocletTSConfigurablePolicyParametersDTO;
 }
 
 export interface ParticipantsMember {

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.html
@@ -440,20 +440,13 @@
 
           <div *ngIf="decisionPoints.length && conditions.length">
             <app-payloads-table [experimentInfo]="experimentInfo"> </app-payloads-table>
-
-            <div *ngIf="isMoocletExperimentDesign$ | async" class="json-editor-container">
-              <span class="title">{{ 'home.new-experiment.design.mooclet-policy-parameters.header.text' | translate }}</span>
-              <json-editor
-                #policyEditor
-                [options]="options"
-                [data]="defaultPolicyParametersForAlgorithm"
-              ></json-editor>
-              <span
-                class="ft-14-600 validation-message"
-                *ngIf="moocletPolicyParametersErrors$ | async as errors"
-                [innerHTML]="errors"
-              ></span>
-            </div>
+            <app-mooclet-policy-editor
+              *ngIf="isMoocletExperimentDesign$ | async"
+              [experimentInfo]="experimentInfo"
+              [experimentName]="experimentName"
+              [currentAssignmentAlgorithm]="currentAssignmentAlgorithm$.value"
+              #policyEditor
+            ></app-mooclet-policy-editor>
           </div>
         </section>
       </form>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.scss
@@ -140,13 +140,6 @@
         color: var(--light-blue);
       }
     }
-
-    .json-editor-container {
-      display: flex;
-      flex-direction: column;
-      row-gap: 8px;
-      margin-bottom: 32px;
-    }
   }
 
   .validation-container {

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
@@ -11,16 +11,8 @@ import {
   SimpleChanges,
   OnDestroy,
 } from '@angular/core';
-import {
-  UntypedFormBuilder,
-  UntypedFormGroup,
-  Validators,
-  UntypedFormArray,
-  AbstractControl,
-  FormArray,
-  FormControl,
-} from '@angular/forms';
-import { BehaviorSubject, from, Observable, of, Subject, Subscription } from 'rxjs';
+import { UntypedFormBuilder, UntypedFormGroup, Validators, UntypedFormArray, AbstractControl } from '@angular/forms';
+import { BehaviorSubject, from, Observable, Subject, Subscription } from 'rxjs';
 import {
   NewExperimentDialogEvents,
   NewExperimentDialogData,
@@ -45,7 +37,7 @@ import {
 } from '../../../../../core/experiment-design-stepper/store/experiment-design-stepper.model';
 import { SIMPLE_EXP_CONSTANTS } from './experiment-design.constants';
 import { JsonEditorComponent, JsonEditorOptions } from 'ang-jsoneditor';
-import { MOOCLET_POLICY_SCHEMA_MAP, MoocletPolicyParametersDTO, MoocletTSConfigurablePolicyParametersDTO } from '../../../../../../../../../../types/src';
+import { MOOCLET_POLICY_SCHEMA_MAP, MoocletPolicyParametersDTO } from '../../../../../../../../../../types/src';
 import { validate, ValidationError } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
 import { environment } from '../../../../../../environments/environment';
@@ -131,7 +123,7 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
 
   // Used for displaying the Mooclet Policy Parameters JSON editor
   currentAssignmentAlgorithm$ = this.experimentDesignStepperService.currentAssignmentAlgorithm$;
-  isMoocletExperimentDesign$ = this.experimentDesignStepperService.isMoocletExperimentDesign$
+  isMoocletExperimentDesign$ = this.experimentDesignStepperService.isMoocletExperimentDesign$;
   defaultPolicyParametersForAlgorithm: MoocletPolicyParametersDTO;
   moocletPolicyParametersErrors$: BehaviorSubject<ValidationError[]> = new BehaviorSubject([]);
   editorValue$ = new Subject<any>();
@@ -288,19 +280,21 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
     };
 
     // Set up validation pipeline for feedback while typing
-    this.editorValue$.pipe(
-      debounceTime(300),
-      switchMap((jsonValue) => this.validateMoocletPolicyParameters(jsonValue))
-    ).subscribe((errors) => {
+    this.editorValue$
+      .pipe(
+        debounceTime(300),
+        switchMap((jsonValue) => this.validateMoocletPolicyParameters(jsonValue))
+      )
+      .subscribe((errors) => {
         this.moocletPolicyParametersErrors$.next(errors);
-    });
+      });
   }
 
   validateMoocletPolicyParameters(jsonValue: any) {
     const ValidatorClass = MOOCLET_POLICY_SCHEMA_MAP[this.currentAssignmentAlgorithm$.value];
     const plainDTO = {
       assignmentAlgorithm: this.currentAssignmentAlgorithm$.value,
-      ...jsonValue
+      ...jsonValue,
     };
     const DTOInstance = plainToInstance(ValidatorClass, plainDTO);
     return from(validate(DTOInstance));
@@ -783,8 +777,8 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
       if (environment.moocletToggle && this.policyEditor) {
         experimentDesignFormData.moocletPolicyParameters = {
           assignmentAlgorithm: this.currentAssignmentAlgorithm$.value,
-          ...this.policyEditor.get()
-        }
+          ...this.policyEditor.get(),
+        };
       }
       this.emitExperimentDialogEvent.emit({
         type: eventType,
@@ -794,7 +788,7 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
       if (eventType == NewExperimentDialogEvents.SAVE_DATA) {
         this.experimentDesignStepperService.experimentStepperDataReset();
         this.experimentDesignForm.markAsPristine();
-      }  
+      }
     }
   }
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
@@ -64,7 +64,7 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
   @ViewChild(SIMPLE_EXP_CONSTANTS.VIEW_CHILD.CONDITION_CODE) conditionCode: ElementRef;
 
   options = new JsonEditorOptions();
-  policyEditorError = false;
+
   experimentName: string;
 
   @ViewChild('policyEditor', { static: false }) policyEditor: JsonEditorComponent;
@@ -305,9 +305,8 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
       try {
         const value = this.policyEditor.get();
         this.editorValue$.next(value);
-        this.policyEditorError = false;
-      } catch (e) {
-        this.policyEditorError = true;
+      } catch {
+        // Invalid JSON in editor (The [x] icon will be displayed in the editor)
       }
     };
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
@@ -64,9 +64,7 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
   @ViewChild(SIMPLE_EXP_CONSTANTS.VIEW_CHILD.CONDITION_CODE) conditionCode: ElementRef;
 
   options = new JsonEditorOptions();
-
   experimentName: string;
-
   @ViewChild('policyEditor', { static: false }) policyEditor: JsonEditorComponent;
 
   subscriptionHandler: Subscription;
@@ -177,6 +175,11 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
         this.experimentInfo.partitions = [];
         this.experimentInfo.conditions = [];
         this.experimentInfo.conditionPayloads = [];
+
+        if (this.experimentInfo.moocletPolicyParameters) {
+          this.experimentInfo.moocletPolicyParameters = null;
+          this.setupMoocletPolicyParameterJsonEditor(this.experimentName);
+        }
       }
     }
 
@@ -291,10 +294,19 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   setupMoocletPolicyParameterJsonEditor(experimentName: string) {
-    this.defaultPolicyParametersForAlgorithm = new MOOCLET_POLICY_SCHEMA_MAP[this.currentAssignmentAlgorithm$.value]();
-    this.defaultPolicyParametersForAlgorithm.outcome_variable_name = `${experimentName
-      .toUpperCase()
-      .replace(/ /g, '_')}_REWARD_VARIABLE`;
+    // Only create default parameters if we don't have existing ones
+    if (!this.experimentInfo?.moocletPolicyParameters) {
+      this.defaultPolicyParametersForAlgorithm = new MOOCLET_POLICY_SCHEMA_MAP[
+        this.currentAssignmentAlgorithm$.value
+      ]();
+      this.defaultPolicyParametersForAlgorithm.outcome_variable_name = `${experimentName
+        .toUpperCase()
+        .replace(/ /g, '_')}_REWARD_VARIABLE`;
+    } else {
+      // Use existing parameters from backend (When editing)
+      this.defaultPolicyParametersForAlgorithm = this.experimentInfo.moocletPolicyParameters;
+    }
+
     this.options = new JsonEditorOptions();
     this.options.mode = 'code';
     this.options.statusBar = false;

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
@@ -170,7 +170,6 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
         this.experimentInfo.conditionPayloads = [];
 
         if (this.experimentInfo.moocletPolicyParameters) {
-          this.experimentInfo.moocletPolicyParameters = null;
           if (this.policyEditor) {
             this.policyEditor.resetPolicyParameters();
           }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
@@ -311,6 +311,7 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
     };
 
     // Set up validation pipeline for feedback while typing
+    // TODO: Enforce stricter validation (disallow missing props) and improve errors
     this.editorValue$
       .pipe(
         debounceTime(300),

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/mooclet-policy-editor/mooclet-policy-editor.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/mooclet-policy-editor/mooclet-policy-editor.component.html
@@ -1,0 +1,13 @@
+<div class="json-editor-container">
+  <span class="title">{{ 'home.new-experiment.design.mooclet-policy-parameters.header.text' | translate }}</span>
+  <json-editor
+    #policyEditor
+    [options]="options"
+    [data]="defaultPolicyParametersForAlgorithm"
+  ></json-editor>
+  <span
+    class="ft-14-600 validation-message"
+    *ngIf="moocletPolicyParametersErrors$ | async as errors"
+    [innerHTML]="errors"
+  ></span>
+</div>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/mooclet-policy-editor/mooclet-policy-editor.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/mooclet-policy-editor/mooclet-policy-editor.component.scss
@@ -1,0 +1,11 @@
+.json-editor-container {
+  display: flex;
+  flex-direction: column;
+  row-gap: 8px;
+  margin-bottom: 32px;
+
+  .title {
+    font-size: 18px;
+    font-weight: bold;
+  }
+}

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/mooclet-policy-editor/mooclet-policy-editor.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/mooclet-policy-editor/mooclet-policy-editor.component.ts
@@ -1,0 +1,100 @@
+import { ChangeDetectionStrategy, Component, Input, OnInit, ViewChild } from '@angular/core';
+import { JsonEditorComponent, JsonEditorOptions } from 'ang-jsoneditor';
+import { BehaviorSubject, Subject, from } from 'rxjs';
+import { debounceTime, switchMap } from 'rxjs/operators';
+import { validate, ValidationError } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { MOOCLET_POLICY_SCHEMA_MAP, MoocletTSConfigurablePolicyParametersDTO } from 'upgrade_types';
+import { ExperimentVM } from '../../../../../../core/experiments/store/experiments.model';
+
+@Component({
+  selector: 'app-mooclet-policy-editor',
+  templateUrl: './mooclet-policy-editor.component.html',
+  styleUrls: ['./mooclet-policy-editor.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MoocletPolicyEditorComponent implements OnInit {
+  @Input() experimentInfo: ExperimentVM;
+  @Input() experimentName: string;
+  @Input() currentAssignmentAlgorithm: string;
+
+  @ViewChild('policyEditor', { static: false }) policyEditor: JsonEditorComponent;
+
+  options = new JsonEditorOptions();
+  defaultPolicyParametersForAlgorithm: MoocletTSConfigurablePolicyParametersDTO;
+  moocletPolicyParametersErrors$ = new BehaviorSubject<ValidationError[]>([]);
+  editorValue$ = new Subject<any>();
+
+  ngOnInit() {
+    this.setupEditor();
+  }
+
+  setupEditor() {
+    // Only create default parameters if we don't have existing ones
+    if (!this.experimentInfo?.moocletPolicyParameters) {
+      this.defaultPolicyParametersForAlgorithm = new MOOCLET_POLICY_SCHEMA_MAP[this.currentAssignmentAlgorithm]();
+      this.defaultPolicyParametersForAlgorithm.outcome_variable_name = `${this.experimentName
+        .toUpperCase()
+        .replace(/ /g, '_')}_REWARD_VARIABLE`;
+    } else {
+      // Use existing parameters from backend (When editing)
+      this.defaultPolicyParametersForAlgorithm = this.experimentInfo.moocletPolicyParameters;
+    }
+
+    this.options.mode = 'code';
+    this.options.statusBar = false;
+
+    // set up value change listener for the editor value
+    this.options.onChange = () => {
+      try {
+        const value = this.policyEditor.get();
+        this.editorValue$.next(value);
+      } catch {
+        // Invalid JSON in editor (The [x] icon will be displayed in the editor)
+      }
+    };
+
+    // Set up validation pipeline for feedback while typing
+    this.editorValue$
+      .pipe(
+        debounceTime(300),
+        switchMap((jsonValue) => this.validateMoocletPolicyParameters(jsonValue))
+      )
+      .subscribe((errors) => {
+        this.moocletPolicyParametersErrors$.next(errors);
+      });
+  }
+
+  resetPolicyParameters() {
+    this.defaultPolicyParametersForAlgorithm = new MOOCLET_POLICY_SCHEMA_MAP[this.currentAssignmentAlgorithm]();
+    this.defaultPolicyParametersForAlgorithm.outcome_variable_name = `${this.experimentName
+      .toUpperCase()
+      .replace(/ /g, '_')}_REWARD_VARIABLE`;
+
+    // Force editor to update with new default values
+    if (this.policyEditor) {
+      const jsonValue = JSON.parse(JSON.stringify(this.defaultPolicyParametersForAlgorithm));
+      this.policyEditor.set(jsonValue);
+    }
+  }
+
+  validateMoocletPolicyParameters(jsonValue: any) {
+    const ValidatorClass = MOOCLET_POLICY_SCHEMA_MAP[this.currentAssignmentAlgorithm];
+    const plainDTO = {
+      assignmentAlgorithm: this.currentAssignmentAlgorithm,
+      ...jsonValue,
+    };
+    const DTOInstance = plainToInstance(ValidatorClass, plainDTO);
+    return from(validate(DTOInstance));
+  }
+
+  // Method to get current editor value for parent components
+  getPolicyEditorValue() {
+    return this.policyEditor?.get();
+  }
+
+  // Method to get current validation errors for parent components
+  getPolicyEditorErrors() {
+    return this.moocletPolicyParametersErrors$.value;
+  }
+}

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/mooclet-policy-editor/mooclet-policy-editor.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/mooclet-policy-editor/mooclet-policy-editor.component.ts
@@ -34,6 +34,7 @@ export class MoocletPolicyEditorComponent implements OnInit {
     if (!this.experimentInfo?.moocletPolicyParameters) {
       this.defaultPolicyParametersForAlgorithm = new MOOCLET_POLICY_SCHEMA_MAP[this.currentAssignmentAlgorithm]();
       this.defaultPolicyParametersForAlgorithm.outcome_variable_name = `${this.experimentName
+        .trim()
         .toUpperCase()
         .replace(/ /g, '_')}_REWARD_VARIABLE`;
     } else {
@@ -68,6 +69,7 @@ export class MoocletPolicyEditorComponent implements OnInit {
   resetPolicyParameters() {
     this.defaultPolicyParametersForAlgorithm = new MOOCLET_POLICY_SCHEMA_MAP[this.currentAssignmentAlgorithm]();
     this.defaultPolicyParametersForAlgorithm.outcome_variable_name = `${this.experimentName
+      .trim()
       .toUpperCase()
       .replace(/ /g, '_')}_REWARD_VARIABLE`;
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/mooclet-policy-editor/mooclet-policy-editor.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/mooclet-policy-editor/mooclet-policy-editor.component.ts
@@ -38,14 +38,15 @@ export class MoocletPolicyEditorComponent implements OnInit {
         .toUpperCase()
         .replace(/ /g, '_')}_REWARD_VARIABLE`;
     } else {
-      // Use existing parameters from backend (When editing)
+      // Use existing parameters from backend when editing
       this.defaultPolicyParametersForAlgorithm = this.experimentInfo.moocletPolicyParameters;
     }
 
     this.options.mode = 'code';
     this.options.statusBar = false;
 
-    // set up value change listener for the editor value
+    // Set up value change listener for the editor value
+    // This feels hacky but it ensures that editor value is always getting updated validation
     this.options.onChange = () => {
       try {
         const value = this.policyEditor.get();
@@ -56,6 +57,7 @@ export class MoocletPolicyEditorComponent implements OnInit {
     };
 
     // Set up validation pipeline for feedback while typing
+    // TODO: Enforce stricter validation (disallow missing props) and improve errors
     this.editorValue$
       .pipe(
         debounceTime(300),

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.html
@@ -126,7 +126,7 @@
           class="stratification-factor"
           appearance="outline"
           subscriptSizing="dynamic"
-          *ngIf="assignmentAlgorithmValue === 'stratified random sampling'"
+          *ngIf="assignmentAlgorithmValue === ASSIGNMENT_ALGORITHM.STRATIFIED_RANDOM_SAMPLING"
         >
           <mat-label class="ft-14-400">
             {{ 'home-global.stratification-factor.text' | translate }}

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.ts
@@ -52,7 +52,8 @@ export class ExperimentOverviewComponent implements OnInit, OnDestroy {
   @ViewChild('contextInput') contextInput: ElementRef<HTMLInputElement>;
   overviewForm: UntypedFormGroup;
   unitOfAssignments = [{ value: ASSIGNMENT_UNIT.INDIVIDUAL }, { value: ASSIGNMENT_UNIT.GROUP }];
-  public ASSIGNMENT_UNIT = ASSIGNMENT_UNIT;
+  ASSIGNMENT_UNIT = ASSIGNMENT_UNIT;
+  ASSIGNMENT_ALGORITHM = ASSIGNMENT_ALGORITHM;
 
   groupTypes = [];
   allContexts = [];
@@ -103,10 +104,10 @@ export class ExperimentOverviewComponent implements OnInit, OnDestroy {
       this.unitOfAssignments.push({ value: ASSIGNMENT_UNIT.WITHIN_SUBJECTS });
     }
     if (this.environment.moocletToggle) {
-      const supportedMoocletAlgorithms = Object.keys(MOOCLET_POLICY_SCHEMA_MAP) as ASSIGNMENT_ALGORITHM[]
+      const supportedMoocletAlgorithms = Object.keys(MOOCLET_POLICY_SCHEMA_MAP) as ASSIGNMENT_ALGORITHM[];
       supportedMoocletAlgorithms.forEach((algorithmName) => {
-        this.assignmentAlgorithms.push({ value: algorithmName })
-      })
+        this.assignmentAlgorithms.push({ value: algorithmName });
+      });
     }
   }
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.ts
@@ -146,6 +146,10 @@ export class ExperimentOverviewComponent implements OnInit, OnDestroy {
         tags: [[]],
       });
 
+      this.overviewForm.get('experimentName').valueChanges.subscribe((name) => {
+        this.experimentDesignStepperService.changeExperimentName(name);
+      });
+
       this.overviewForm.get('unitOfAssignment').valueChanges.subscribe((assignmentUnit) => {
         this.experimentDesignStepperService.changeAssignmentUnit(assignmentUnit);
         this.overviewForm.get('consistencyRule').reset();

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/factorial-experiment-design/conditions-table/conditions-table.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/factorial-experiment-design/conditions-table/conditions-table.component.scss
@@ -1,6 +1,4 @@
 .conditions-table-component {
-  height: 515px;
-
   .row-is-locked {
     opacity: 0.4;
   }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/factorial-experiment-design/factorial-experiment-design.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/factorial-experiment-design/factorial-experiment-design.component.html
@@ -769,6 +769,20 @@
                 [experimentInfo]="experimentInfo"
                 [isExperimentEditable]="isExperimentEditable"
               ></app-conditions-table>
+
+              <div *ngIf="isMoocletExperimentDesign$ | async" class="json-editor-container">
+                <span class="title">{{ 'home.new-experiment.design.mooclet-policy-parameters.header.text' | translate }}</span>
+                <json-editor
+                  #policyEditor
+                  [options]="options"
+                  [data]="defaultPolicyParametersForAlgorithm"
+                ></json-editor>
+                <span
+                  class="ft-14-600 validation-message"
+                  *ngIf="moocletPolicyParametersErrors$ | async as errors"
+                  [innerHTML]="errors"
+                ></span>
+              </div>
             </div>
           </div>
         </section>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/factorial-experiment-design/factorial-experiment-design.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/factorial-experiment-design/factorial-experiment-design.component.html
@@ -769,20 +769,13 @@
                 [experimentInfo]="experimentInfo"
                 [isExperimentEditable]="isExperimentEditable"
               ></app-conditions-table>
-
-              <div *ngIf="isMoocletExperimentDesign$ | async" class="json-editor-container">
-                <span class="title">{{ 'home.new-experiment.design.mooclet-policy-parameters.header.text' | translate }}</span>
-                <json-editor
-                  #policyEditor
-                  [options]="options"
-                  [data]="defaultPolicyParametersForAlgorithm"
-                ></json-editor>
-                <span
-                  class="ft-14-600 validation-message"
-                  *ngIf="moocletPolicyParametersErrors$ | async as errors"
-                  [innerHTML]="errors"
-                ></span>
-              </div>
+              <app-mooclet-policy-editor
+                *ngIf="isMoocletExperimentDesign$ | async"
+                [experimentInfo]="experimentInfo"
+                [experimentName]="experimentName"
+                [currentAssignmentAlgorithm]="currentAssignmentAlgorithm$.value"
+                #policyEditor
+              ></app-mooclet-policy-editor>
             </div>
           </div>
         </section>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/factorial-experiment-design/factorial-experiment-design.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/factorial-experiment-design/factorial-experiment-design.component.scss
@@ -284,13 +284,6 @@
         color: var(--light-blue);
       }
     }
-
-    .json-editor-container {
-      display: flex;
-      flex-direction: column;
-      row-gap: 8px;
-      margin-bottom: 32px;
-    }
   }
 
   .level-container {

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/factorial-experiment-design/factorial-experiment-design.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/factorial-experiment-design/factorial-experiment-design.component.scss
@@ -284,6 +284,13 @@
         color: var(--light-blue);
       }
     }
+
+    .json-editor-container {
+      display: flex;
+      flex-direction: column;
+      row-gap: 8px;
+      margin-bottom: 32px;
+    }
   }
 
   .level-container {

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/factorial-experiment-design/factorial-experiment-design.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/factorial-experiment-design/factorial-experiment-design.component.ts
@@ -170,7 +170,6 @@ export class FactorialExperimentDesignComponent implements OnInit, OnChanges, On
         this.experimentInfo.conditionPayloads = [];
 
         if (this.experimentInfo.moocletPolicyParameters) {
-          this.experimentInfo.moocletPolicyParameters = null;
           if (this.policyEditor) {
             this.policyEditor.resetPolicyParameters();
           }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/home.module.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/home.module.ts
@@ -39,6 +39,7 @@ import { FactorialExperimentDesignComponent } from './components/factorial-exper
 import { ConditionsTableComponent } from './components/factorial-experiment-design/conditions-table/conditions-table.component';
 import { NgJsonEditorModule } from 'ang-jsoneditor';
 import { assignmentAlgorithmPipe } from '../../../shared/pipes/assignment-algorithm.pipe';
+import { MoocletPolicyEditorComponent } from './components/experiment-design/mooclet-policy-editor/mooclet-policy-editor.component';
 
 @NgModule({
   declarations: [
@@ -69,6 +70,7 @@ import { assignmentAlgorithmPipe } from '../../../shared/pipes/assignment-algori
     PayloadsTableComponent,
     FactorialExperimentDesignComponent,
     ConditionsTableComponent,
+    MoocletPolicyEditorComponent,
     assignmentAlgorithmPipe,
   ],
   imports: [

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
@@ -250,7 +250,7 @@
                 <span class="ft-16-600 section-data-title">
                   {{ 'home-global.assignment-algorithm.text' | translate | uppercase }}
                 </span>
-                <span class="ft-18-700 section-data-value">{{ experiment.assignmentAlgorithm | titlecase }} </span>
+                <span class="ft-18-700 section-data-value">{{ experiment.assignmentAlgorithm | assignmentAlgorithmFormat }} </span>
               </div>
             </div>
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
@@ -756,6 +756,12 @@
               </mat-table>
             </ng-container>
           </div>
+
+          <!-- Mooclet Policy Parameters JSON Viewer -->
+          <div class="json-viewer-container" *ngIf="experiment.moocletPolicyParameters">
+            <span class="ft-24-700">{{ 'home.view-experiment.experiment-mooclet-policy-parameters-title.text' | translate }}</span>
+            <pre class="ft-12-600">{{ displayMoocletParameters | json }}</pre>
+          </div>
         </div>
       </mat-tab>
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
@@ -401,7 +401,7 @@
               </div>
 
               <!-- Stratification Factor-->
-              <div class="section-data" *ngIf="experiment.assignmentAlgorithm === 'stratified random sampling'">
+              <div class="section-data" *ngIf="experiment.assignmentAlgorithm === ASSIGNMENT_ALGORITHM.STRATIFIED_RANDOM_SAMPLING">
                 <span class="ft-16-600 section-data-title">
                   {{ 'home-global.stratification-factor.text' | translate | uppercase }}
                 </span>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.scss
@@ -254,7 +254,7 @@ $font-size-small: 15px;
     padding: 0px !important;
   }
 
-  .table-container {
+  .table-container, .json-viewer-container {
     padding: 24px 34px;
 
     &-partition {
@@ -367,6 +367,13 @@ $font-size-small: 15px;
       mat-header-cell {
         color: var(--grey-2);
       }
+    }
+
+    pre {
+      padding: 16px 8px 0;
+      white-space: pre-wrap;
+      word-wrap: break-word;
+      -webkit-font-smoothing: antialiased;
     }
   }
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.ts
@@ -131,6 +131,16 @@ export class ViewExperimentComponent implements OnInit, OnDestroy {
     return this.environment.metricAnalyticsExperimentDisplayToggle;
   }
 
+  get displayMoocletParameters() {
+    if (!this.experiment?.moocletPolicyParameters) {
+      return null;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { assignmentAlgorithm, ...rest } = this.experiment.moocletPolicyParameters;
+    return rest;
+  }
+
   ngOnInit() {
     this.isLoadingExperimentDetailStats$ = this.experimentService.isLoadingExperimentDetailStats$;
     this.isPollingExperimentDetailStats$ = this.experimentService.isPollingExperimentDetailStats$;

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.ts
@@ -24,7 +24,7 @@ import { ExperimentEndCriteriaComponent } from '../../components/modal/experimen
 import { StateTimeLogsComponent } from '../../components/modal/state-time-logs/state-time-logs.component';
 import { ExportModalComponent } from '../../components/modal/export-experiment/export-experiment.component';
 import { EnrollmentOverTimeComponent } from '../../components/enrollment-over-time/enrollment-over-time.component';
-import { EXPERIMENT_TYPE, IMetricMetaData, OPERATION_TYPES, PAYLOAD_TYPE } from 'upgrade_types';
+import { EXPERIMENT_TYPE, IMetricMetaData, OPERATION_TYPES, PAYLOAD_TYPE, ASSIGNMENT_ALGORITHM } from 'upgrade_types';
 import { MemberTypes } from '../../../../../core/segments/store/segments.model';
 import { METRICS_JOIN_TEXT } from '../../../../../core/analysis/store/analysis.models';
 import { ExperimentDesignStepperService } from '../../../../../core/experiment-design-stepper/experiment-design-stepper.service';
@@ -63,6 +63,7 @@ export class ViewExperimentComponent implements OnInit, OnDestroy {
   factorsDataSource: Factors[];
   conditionDatasource: FactorialConditionTableDataFromConditionPayload[];
   expandedId: number = null;
+  ASSIGNMENT_ALGORITHM = ASSIGNMENT_ALGORITHM;
 
   displayedConditionColumns: string[] = ['conditionCode', 'assignmentWeight', 'description'];
   displayedConditionColumnsFactorial: string[] = ['conditionCode', 'payload', 'assignmentWeight'];

--- a/frontend/projects/upgrade/src/app/shared/pipes/assignment-algorithm.pipe.spec.ts
+++ b/frontend/projects/upgrade/src/app/shared/pipes/assignment-algorithm.pipe.spec.ts
@@ -11,12 +11,8 @@ describe('assignmentAlgorithmPipe', () => {
     expect(pipe.transform('hello world')).toBe('Hello World');
   });
 
-  it('should preserve TS in ts configurable', () => {
-    expect(pipe.transform('ts configurable')).toBe('TS Configurable');
-  });
-
-  it('should preserve UCB', () => {
-    expect(pipe.transform('ucb')).toBe('UCB');
+  it('should preserve TS in ts_configurable', () => {
+    expect(pipe.transform('ts_configurable')).toBe('TS Configurable');
   });
 
   it('should handle empty string', () => {

--- a/frontend/projects/upgrade/src/app/shared/pipes/assignment-algorithm.pipe.ts
+++ b/frontend/projects/upgrade/src/app/shared/pipes/assignment-algorithm.pipe.ts
@@ -5,16 +5,13 @@ import { Pipe, PipeTransform } from '@angular/core';
 })
 export class assignmentAlgorithmPipe implements PipeTransform {
   // Special cases that should remain as-is
-  private readonly specialCases = new Map([
-    ['ts', 'TS'],
-    ['ucb', 'UCB'],
-  ]);
+  private readonly specialCases = new Map([['ts', 'TS']]);
 
   transform(value: string): string {
     if (!value) return value;
 
     // Split the string into words
-    const words = value.toLowerCase().split(' ');
+    const words = value.toLowerCase().split('_');
 
     // Transform each word
     const transformedWords = words.map((word, index) => {

--- a/frontend/projects/upgrade/src/assets/i18n/en.json
+++ b/frontend/projects/upgrade/src/assets/i18n/en.json
@@ -250,6 +250,7 @@
   "home.view-experiment.experiment-payloads.column-label.target": "TARGET",
   "home.view-experiment.experiment-payloads.column-label.condition": "CONDITION",
   "home.view-experiment.experiment-payloads.column-label.payload": "PAYLOAD",
+  "home.view-experiment.experiment-mooclet-policy-parameters-title.text": "Mooclet Policy Parameters",
   "home.view-experiment.metrics-analysis-unavailable.text": "Experiment metrics analysis has been temporarily disabled in this view. This information is still available when exporting the experiment data.",
   "home.view-experiment.graph-type.text": "Type",
   "home.view-experiment.graph-conditions.text": "Conditions",

--- a/types/src/Experiment/enums.ts
+++ b/types/src/Experiment/enums.ts
@@ -18,9 +18,7 @@ export enum CONDITION_ORDER {
 
 export enum ASSIGNMENT_ALGORITHM {
   RANDOM = 'random',
-  STRATIFIED_RANDOM_SAMPLING = 'stratified random sampling',
-  EPSILON_GREEDY = 'epsilon greedy',
-  UCB = 'ucb',
+  STRATIFIED_RANDOM_SAMPLING = 'stratified_random_sampling',
   MOOCLET_TS_CONFIGURABLE = 'ts_configurable',
 }
 

--- a/types/src/Experiment/interfaces.ts
+++ b/types/src/Experiment/interfaces.ts
@@ -246,18 +246,6 @@ export interface TsConfigurableParameters {
   outcome_variable_name: string;
 }
 
-export interface EpsilonGreedyParameters {
-  epsilon: number;
-  decay_rate?: number;
-  min_epsilon?: number;
-}
-
-export interface UcbParameters {
-  alpha: number;
-  window_size: number;
-}
-
-
 export interface ScoreObject {
   id: string;
   type: string;

--- a/types/src/Mooclet/MoocletTSConfigurablePolicyParametersDTO.ts
+++ b/types/src/Mooclet/MoocletTSConfigurablePolicyParametersDTO.ts
@@ -53,5 +53,5 @@ export class MoocletTSConfigurablePolicyParametersDTO extends MoocletPolicyParam
 
   @IsNotEmpty()
   @IsString()
-  outcome_variable_name= "";
+  outcome_variable_name = 'example_reward_var';
 }

--- a/types/src/Mooclet/MoocletTSConfigurablePolicyParametersDTO.ts
+++ b/types/src/Mooclet/MoocletTSConfigurablePolicyParametersDTO.ts
@@ -53,5 +53,5 @@ export class MoocletTSConfigurablePolicyParametersDTO extends MoocletPolicyParam
 
   @IsNotEmpty()
   @IsString()
-  outcome_variable_name = 'example_reward_var';
+  outcome_variable_name = 'my_var';
 }

--- a/types/src/Mooclet/MoocletTSConfigurablePolicyParametersDTO.ts
+++ b/types/src/Mooclet/MoocletTSConfigurablePolicyParametersDTO.ts
@@ -53,5 +53,5 @@ export class MoocletTSConfigurablePolicyParametersDTO extends MoocletPolicyParam
 
   @IsNotEmpty()
   @IsString()
-  outcome_variable_name = 'my_var';
+  outcome_variable_name = '';
 }


### PR DESCRIPTION
This PR branches from and merges into the [wip/json-editor-validation](https://github.com/CarnegieLearningWeb/UpGrade/tree/wip/json-editor-validation) branch created by @danoswaltCL.

Changes Include:

- Applied ESLint rules for consistent styles
- Removed redundant code (e.g., unused imports, variables, policy types)
- Set the default `outcome_variable_name` with the experiment name set from Overview step
- Updated the `experiments/single/:id` endpoint to include `moocletPolicyParameters` in the response
- Displayed Mooclet policy parameters JSON on the details page, and the stepper when editing an experiment
- Displayed the JSON editor when "Factorial" experiment type is selected
- Extracted shared Mooclet policy editor into separate component (`MoocletPolicyEditorComponent`) 

Notes:

- The validation of the JSON editor could be stricter (e.g., disallow missing props) and the error messages could be improved. I tried a few different things but wasn't able to really make it work. I think it's OK to move on for now as long as the backend does the strict validation.
- Changes to the `experiments/single/:id` endpoint (with other backend changes) should be reviewed thoroughly and could potentially be refined.