### PR TITLE
Disable overview and design steps during Mooclet experiment editing

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.html
@@ -445,6 +445,7 @@
               [experimentInfo]="experimentInfo"
               [experimentName]="currentExperimentName$ | async"
               [currentAssignmentAlgorithm]="currentAssignmentAlgorithm$.value"
+              [isEditable]="isExperimentEditable"
               #policyEditor
             ></app-mooclet-policy-editor>
           </div>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
@@ -11,6 +11,7 @@ import {
   SimpleChanges,
   OnDestroy,
 } from '@angular/core';
+import { EXPERIMENT_STATE, MOOCLET_POLICY_SCHEMA_MAP } from 'upgrade_types';
 import { UntypedFormBuilder, UntypedFormGroup, Validators, UntypedFormArray, AbstractControl } from '@angular/forms';
 import { BehaviorSubject, Observable, Subscription } from 'rxjs';
 import {
@@ -21,7 +22,6 @@ import {
   ExperimentCondition,
   ExperimentDecisionPoint,
   IContextMetaData,
-  EXPERIMENT_STATE,
 } from '../../../../../core/experiments/store/experiments.model';
 import { ExperimentFormValidators } from '../../validators/experiment-form.validators';
 import { ExperimentService } from '../../../../../core/experiments/experiments.service';
@@ -252,7 +252,8 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
 
       this.isExperimentEditable =
         this.experimentInfo.state !== this.ExperimentState.ENROLLING &&
-        this.experimentInfo.state !== this.ExperimentState.ENROLLMENT_COMPLETE;
+        this.experimentInfo.state !== this.ExperimentState.ENROLLMENT_COMPLETE &&
+        !(this.experimentInfo.assignmentAlgorithm in MOOCLET_POLICY_SCHEMA_MAP);
 
       // disable control on edit:
       if (!this.isExperimentEditable) {

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/mooclet-policy-editor/mooclet-policy-editor.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/mooclet-policy-editor/mooclet-policy-editor.component.ts
@@ -17,6 +17,7 @@ export class MoocletPolicyEditorComponent implements OnInit {
   @Input() experimentInfo: ExperimentVM;
   @Input() experimentName: string;
   @Input() currentAssignmentAlgorithm: string;
+  @Input() isEditable = true;
 
   @ViewChild('policyEditor', { static: false }) policyEditor: JsonEditorComponent;
 
@@ -42,7 +43,7 @@ export class MoocletPolicyEditorComponent implements OnInit {
       this.defaultPolicyParametersForAlgorithm = this.experimentInfo.moocletPolicyParameters;
     }
 
-    this.options.mode = 'code';
+    this.options.mode = this.isEditable ? 'code' : 'view';
     this.options.statusBar = false;
 
     // Set up value change listener for the editor value

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.ts
@@ -216,7 +216,8 @@ export class ExperimentOverviewComponent implements OnInit, OnDestroy {
       if (this.experimentInfo) {
         if (
           this.experimentInfo.state == this.ExperimentState.ENROLLING ||
-          this.experimentInfo.state == this.ExperimentState.ENROLLMENT_COMPLETE
+          this.experimentInfo.state == this.ExperimentState.ENROLLMENT_COMPLETE ||
+          this.experimentInfo.assignmentAlgorithm in MOOCLET_POLICY_SCHEMA_MAP
         ) {
           this.overviewForm.disable();
           this.isExperimentEditable = false;
@@ -335,7 +336,8 @@ export class ExperimentOverviewComponent implements OnInit, OnDestroy {
     if (
       this.experimentInfo &&
       (this.experimentInfo.state == this.ExperimentState.ENROLLING ||
-        this.experimentInfo.state == this.ExperimentState.ENROLLMENT_COMPLETE)
+        this.experimentInfo.state == this.ExperimentState.ENROLLMENT_COMPLETE ||
+        this.experimentInfo.assignmentAlgorithm in MOOCLET_POLICY_SCHEMA_MAP)
     ) {
       this.emitExperimentDialogEvent.emit({
         type: eventType,

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
@@ -29,8 +29,7 @@
             *ngIf="
               permissions?.experiments.update &&
               experiment.state !== ExperimentState.CANCELLED &&
-              experiment.state !== ExperimentState.ARCHIVED &&
-              !experiment.moocletPolicyParameters
+              experiment.state !== ExperimentState.ARCHIVED
             "
           >
             {{ 'home.view-experiment.edit-button.text' | translate }}


### PR DESCRIPTION
Resolves #2184

This PR disables the Overview and Design steps (except the Payloads table) when a Mooclet experiment is being edited (Just like when the experiment is in the "Enrolling" status).

I've also disallowed editing the Mooclet Policy Parameters by updating the JSON editor mode to "view" (I couldn't find a better way to disable the JSON editor).

@danoswaltCL Please let me know if this looks good and works as you expected.