### PR TITLE
feature flag caching on any change to flags or lists, no wait on exposures save

### DIFF
--- a/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
+++ b/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
@@ -33,6 +33,7 @@ import {
   FEATURE_FLAG_LIST_FILTER_MODE,
   FEATURE_FLAG_LIST_OPERATION,
   ListOperationsData,
+  CACHE_PREFIX,
 } from 'upgrade_types';
 import { UpgradeLogger } from '../../lib/logger/UpgradeLogger';
 import { FeatureFlagValidation } from '../controllers/validators/FeatureFlagValidator';
@@ -49,6 +50,7 @@ import { User } from '../models/User';
 import { diffString } from 'json-diff';
 import { SegmentRepository } from '../repositories/SegmentRepository';
 import { ExperimentAuditLog } from '../models/ExperimentAuditLog';
+import { CacheService } from './CacheService';
 
 @Service()
 export class FeatureFlagService {
@@ -60,7 +62,8 @@ export class FeatureFlagService {
     @InjectRepository() private experimentAuditLogRepository: ExperimentAuditLogRepository,
     @InjectDataSource() private dataSource: DataSource,
     public experimentAssignmentService: ExperimentAssignmentService,
-    public segmentService: SegmentService
+    public segmentService: SegmentService,
+    public cacheService: CacheService
   ) {}
 
   public find(logger: UpgradeLogger): Promise<FeatureFlag[]> {
@@ -89,7 +92,7 @@ export class FeatureFlagService {
       throw error;
     }
 
-    const filteredFeatureFlags = await this.featureFlagRepository.getFlagsFromContext(context);
+    const filteredFeatureFlags = await this.getCachedFlagsFromContext(context);
 
     const [userExcluded, groupExcluded] = await this.experimentAssignmentService.checkUserOrGroupIsGloballyExcluded(
       experimentUserDoc
@@ -110,7 +113,8 @@ export class FeatureFlagService {
           experimentUser: experimentUserDoc,
         }));
         if (exposuresToSave.length > 0) {
-          await exposureRepo.save(exposuresToSave);
+          // fire and forget, we don't need to wait on this, return flag asap to user
+          exposureRepo.save(exposuresToSave);
         }
       });
     } catch (err) {
@@ -120,6 +124,22 @@ export class FeatureFlagService {
     }
 
     return includedFeatureFlags.map((flags) => flags.key);
+  }
+
+  public async getCachedFlagsFromContext(context: string): Promise<FeatureFlag[]> {
+    const cacheKey = CACHE_PREFIX.FEATURE_FLAG_KEY_PREFIX + context;
+
+    const flags = await this.cacheService.wrap(
+      cacheKey,
+      this.featureFlagRepository.getFlagsFromContext.bind(this.featureFlagRepository, context)
+    );
+
+    return JSON.parse(JSON.stringify(flags));
+  }
+
+  public async clearCachedFlagsForContext(context: string): Promise<void> {
+    const cacheKey = CACHE_PREFIX.FEATURE_FLAG_KEY_PREFIX + context;
+    this.cacheService.delCache(cacheKey);
   }
 
   public async findOne(id: string, logger?: UpgradeLogger): Promise<FeatureFlag | undefined> {
@@ -231,6 +251,7 @@ export class FeatureFlagService {
       const featureFlag = await this.findOne(featureFlagId, logger);
 
       if (featureFlag) {
+        this.clearCachedFlagsForContext(featureFlag.context[0]);
         const deletedFlag = await this.featureFlagRepository.deleteById(featureFlagId, transactionalEntityManager);
 
         featureFlag.featureFlagSegmentInclusion.forEach(async (segmentInclusion) => {
@@ -272,6 +293,7 @@ export class FeatureFlagService {
 
   public async updateState(flagId: string, status: FEATURE_FLAG_STATUS, currentUser: User): Promise<FeatureFlag> {
     const oldFeatureFlag = await this.findOne(flagId);
+    this.clearCachedFlagsForContext(oldFeatureFlag.context[0]);
     let updatedState: FeatureFlag;
     try {
       updatedState = await this.featureFlagRepository.updateState(flagId, status);
@@ -295,8 +317,10 @@ export class FeatureFlagService {
 
   public async updateFilterMode(flagId: string, filterMode: FILTER_MODE, currentUser: User): Promise<FeatureFlag> {
     let updatedFilterMode: FeatureFlag;
+
     try {
       updatedFilterMode = await this.featureFlagRepository.updateFilterMode(flagId, filterMode);
+      this.clearCachedFlagsForContext(updatedFilterMode?.context[0]);
     } catch (err) {
       const error = new Error(`Error in updating feature flag filter mode ${err}`);
       (error as any).type = SERVER_ERROR.QUERY_FAILED;
@@ -354,6 +378,7 @@ export class FeatureFlagService {
     flag.id = uuid();
     // saving feature flag doc
 
+    this.clearCachedFlagsForContext(flag.context[0]);
     const executeTransaction = async (manager: EntityManager): Promise<FeatureFlag> => {
       let featureFlagDoc;
       try {
@@ -385,6 +410,7 @@ export class FeatureFlagService {
   }
 
   private async updateFeatureFlagInDB(flag: FeatureFlag, user: User, logger: UpgradeLogger): Promise<FeatureFlag> {
+    this.clearCachedFlagsForContext(flag.context[0]);
     const {
       featureFlagSegmentExclusion,
       featureFlagSegmentInclusion,
@@ -485,6 +511,7 @@ export class FeatureFlagService {
     logger: UpgradeLogger
   ): Promise<Segment> {
     await this.createDeleteListAuditLogs([segmentId], filterType, currentUser);
+    this.cacheService.resetPrefixCache(CACHE_PREFIX.FEATURE_FLAG_KEY_PREFIX);
     return this.segmentService.deleteSegment(segmentId, logger);
   }
 
@@ -550,6 +577,8 @@ export class FeatureFlagService {
     transactionalEntityManager?: EntityManager
   ): Promise<(FeatureFlagSegmentInclusion | FeatureFlagSegmentExclusion)[]> {
     logger.info({ message: `Add ${filterType} list to feature flag` });
+
+    this.cacheService.resetPrefixCache(CACHE_PREFIX.FEATURE_FLAG_KEY_PREFIX);
 
     const executeTransaction = async (manager: EntityManager) => {
       // Create a new private segment
@@ -647,6 +676,7 @@ export class FeatureFlagService {
     logger: UpgradeLogger
   ): Promise<FeatureFlagSegmentInclusion | FeatureFlagSegmentExclusion> {
     logger.info({ message: `Update ${filterType} list for feature flag` });
+    this.cacheService.resetPrefixCache(CACHE_PREFIX.FEATURE_FLAG_KEY_PREFIX);
     return await this.dataSource.transaction(async (transactionalEntityManager) => {
       // Find the existing record
       let existingRecord: FeatureFlagSegmentInclusion | FeatureFlagSegmentExclusion;

--- a/backend/packages/Upgrade/test/unit/services/FeatureFlagService.test.ts
+++ b/backend/packages/Upgrade/test/unit/services/FeatureFlagService.test.ts
@@ -161,7 +161,7 @@ describe('Feature Flag Service Testing', () => {
             delCache: jest.fn().mockResolvedValue(undefined),
             resetPrefixCache: jest.fn().mockResolvedValue(undefined),
             wrap: jest.fn().mockImplementation((key, cb) => cb()),
-          }
+          },
         },
         {
           provide: getDataSourceToken('default'),

--- a/types/src/Experiment/enums.ts
+++ b/types/src/Experiment/enums.ts
@@ -269,6 +269,7 @@ export enum CACHE_PREFIX {
   EXPERIMENT_KEY_PREFIX = 'validExperiments-',
   SEGMENT_KEY_PREFIX = 'segments-',
   MARK_KEY_PREFIX = 'markExperiments-',
+  FEATURE_FLAG_KEY_PREFIX = 'featureFlags-',
 }
 
 export enum STATUS_INDICATOR_CHIP_TYPE {


### PR DESCRIPTION
This will cache the feature flags when fetched by context.

- The flag cache is cleared by context when any flag is added, deleted, or updated in any way including enabling/disabling.
- On list add, delete, or modify, including enabling/disabling, the flag cache will clear all contexts.
- Also, I removed the `await` when calling exposures.

I tested as well as I could in local with JMeter load tests, it certainly does make a difference but it's not really a good representation of a real test on staging.