### PR TITLE
add reward metric and query on mooclet create

### DIFF
--- a/backend/packages/Upgrade/src/api/models/MoocletExperimentRef.ts
+++ b/backend/packages/Upgrade/src/api/models/MoocletExperimentRef.ts
@@ -28,4 +28,10 @@ export class MoocletExperimentRef {
 
   @Column({ nullable: true })
   variableId?: number;
+
+  @Column({ nullable: true })
+  rewardMetricKey?: string;
+
+  @Column({ nullable: true })
+  outcomeVariableName?: string;
 }

--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -87,6 +87,7 @@ import { plainToClass } from 'class-transformer';
 import { StratificationFactorRepository } from '../repositories/StratificationFactorRepository';
 import { ExperimentDetailsForCSVData } from '../repositories/AnalyticsRepository';
 import { compare } from 'compare-versions';
+import { MetricService } from './MetricService';
 
 const errorRemovePart = 'instance of ExperimentDTO has failed the validation:\n - ';
 const stratificationErrorMessage =
@@ -126,7 +127,8 @@ export class ExperimentService {
     protected scheduledJobService: ScheduledJobService,
     protected errorService: ErrorService,
     protected cacheService: CacheService,
-    protected queryService: QueryService
+    protected queryService: QueryService,
+    protected metricService: MetricService
   ) {}
 
   public async find(logger?: UpgradeLogger): Promise<ExperimentDTO[]> {

--- a/backend/packages/Upgrade/src/api/services/MoocletDataService.ts
+++ b/backend/packages/Upgrade/src/api/services/MoocletDataService.ts
@@ -14,6 +14,8 @@ import {
   MoocletPolicyParametersResponseDetails,
   MoocletVariableRequestBody,
   MoocletVariableResponseDetails,
+  MoocletValueRequestBody,
+  MoocletValueResponseDetails,
 } from '../../types/Mooclet';
 import { UpgradeLogger } from '../../../src/lib/logger/UpgradeLogger';
 
@@ -141,35 +143,20 @@ export class MoocletDataService {
     return response;
   }
 
-  /* not yet implemented */
+  public async postNewReward(requestBody: MoocletValueRequestBody): Promise<MoocletValueResponseDetails> {
+    const endpoint = '/value';
 
-  // public async postNewValue(requestBody: any): Promise<any> {
-  //   const endpoint = '/value';
+    const requestParams: MoocletProxyRequestParams = {
+      method: 'POST',
+      url: this.apiUrl + endpoint,
+      apiToken: this.apiToken,
+      body: requestBody,
+    };
 
-  //   const requestParams: MoocletProxyRequestParams = {
-  //     method: 'POST',
-  //     url: this.apiUrl + endpoint,
-  //     apiToken: this.apiToken,
-  //     body: requestBody,
-  //   };
+    const response = await this.fetchExternalMoocletsData(requestParams);
 
-  //   const response = await this.fetchExternalMoocletsData(requestParams);
-
-  //   return response;
-  // }
-
-  // public async deleteValue(valueId: number): Promise<any> {
-  //   const endpoint = `/value/${valueId}`;
-  //   const requestParams: MoocletProxyRequestParams = {
-  //     method: 'DELETE',
-  //     url: this.apiUrl + endpoint,
-  //     apiToken: this.apiToken,
-  //   };
-
-  //   const response = await this.fetchExternalMoocletsData(requestParams);
-
-  //   return response;
-  // }
+    return response;
+  }
 
   public async postNewVariable(requestBody: MoocletVariableRequestBody): Promise<MoocletVariableResponseDetails> {
     const endpoint = '/variable';

--- a/backend/packages/Upgrade/src/api/services/MoocletExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/MoocletExperimentService.ts
@@ -47,8 +47,17 @@ import { ConditionValidator, ExperimentDTO } from '../DTO/ExperimentDTO';
 import { UserDTO } from '../DTO/UserDTO';
 import { Experiment } from '../models/Experiment';
 import { UpgradeLogger } from '../../lib/logger/UpgradeLogger';
-import { ASSIGNMENT_ALGORITHM, MOOCLET_POLICY_SCHEMA_MAP, MoocletPolicyParametersDTO } from 'upgrade_types';
+import {
+  ASSIGNMENT_ALGORITHM,
+  IMetricMetaData,
+  MOOCLET_POLICY_SCHEMA_MAP,
+  MoocletPolicyParametersDTO,
+  MoocletTSConfigurablePolicyParametersDTO,
+  REPEATED_MEASURE,
+} from 'upgrade_types';
 import { ExperimentCondition } from '../models/ExperimentCondition';
+import { MetricService } from './MetricService';
+import { Metric } from '../models/Metric';
 
 export interface SyncCreateParams {
   experimentDTO: ExperimentDTO;
@@ -96,7 +105,8 @@ export class MoocletExperimentService extends ExperimentService {
     scheduledJobService: ScheduledJobService,
     errorService: ErrorService,
     cacheService: CacheService,
-    queryService: QueryService
+    queryService: QueryService,
+    metricService: MetricService
   ) {
     super(
       experimentRepository,
@@ -124,7 +134,8 @@ export class MoocletExperimentService extends ExperimentService {
       scheduledJobService,
       errorService,
       cacheService,
-      queryService
+      queryService,
+      metricService
     );
   }
 
@@ -141,6 +152,15 @@ export class MoocletExperimentService extends ExperimentService {
     params: SyncCreateParams
   ): Promise<ExperimentDTO> {
     const moocletPolicyParameters = params.experimentDTO.moocletPolicyParameters;
+    const queries = params.experimentDTO.queries;
+
+    const { rewardMetricKey, rewardMetricQuery } = await this.createMoocletRewardMetricAndQuery(
+      params.experimentDTO.name,
+      params.experimentDTO.context[0],
+      logger
+    );
+
+    queries.push(rewardMetricQuery);
 
     // create Upgrade Experiment. If this fails, then mooclet resources will not be created, and the UpGrade experiment transaction will abort
     const experimentResponse = await this.createExperiment(manager, params);
@@ -150,6 +170,8 @@ export class MoocletExperimentService extends ExperimentService {
       experimentResponse,
       moocletPolicyParameters
     );
+
+    moocletExperimentRefResponse.rewardMetricKey = rewardMetricKey;
 
     logger.info({
       message: 'Mooclet experiment created successfully:',
@@ -215,6 +237,12 @@ export class MoocletExperimentService extends ExperimentService {
       deleteResponse = await super.delete(params.experimentId, currentUser, {
         existingEntityManager: manager,
       });
+
+      // delete the associated reward metric key isn't working in transaction?
+      // if (moocletExperimentRef.rewardMetricKey) {
+      //   this.metricService.deleteMetric(moocletExperimentRef.rewardMetricKey, logger);
+      // }
+
       // delete the mooclet resources. If this fails, the transaction will abort and the upgrade experiment will not be deleted,
       // but the Mooclet resources may not be deleted either
       await this.orchestrateDeleteMoocletResources(moocletExperimentRef);
@@ -299,9 +327,8 @@ export class MoocletExperimentService extends ExperimentService {
       });
 
       const moocletVariableResponse = await this.createVariableIfNeeded(
-        moocletPolicyParametersResponse,
-        upgradeExperiment.assignmentAlgorithm,
-        moocletResponse
+        moocletPolicyParameters,
+        upgradeExperiment.assignmentAlgorithm
       );
       logger.debug({
         message: `[Mooclet Creation] 5. Variable created (if needed):`,
@@ -309,6 +336,7 @@ export class MoocletExperimentService extends ExperimentService {
       });
 
       moocletExperimentRef.variableId = moocletVariableResponse?.id;
+      moocletExperimentRef.outcomeVariableName = moocletVariableResponse?.name;
     } catch (err) {
       await this.orchestrateDeleteMoocletResources(moocletExperimentRef);
       throw err;
@@ -317,6 +345,45 @@ export class MoocletExperimentService extends ExperimentService {
     moocletExperimentRef.id = uuid();
 
     return moocletExperimentRef;
+  }
+
+  private async createMoocletRewardMetricAndQuery(
+    experimentName: string,
+    context: string,
+    logger: UpgradeLogger
+  ): Promise<{ rewardMetricKey: string; rewardMetricQuery: any }> {
+    const rewardMetricKey = experimentName.toLocaleUpperCase() + '_REWARD';
+    await this.createMoocletRewardMetric(rewardMetricKey, context, logger);
+    const rewardMetricQuery = {
+      id: uuid(),
+      name: 'Success Rate',
+      query: {
+        operationType: 'percentage',
+        compareFn: '=',
+        compareValue: 'SUCCESS',
+      },
+      metric: {
+        key: rewardMetricKey,
+      },
+      repeatedMeasure: REPEATED_MEASURE.mostRecent,
+    };
+
+    return { rewardMetricKey, rewardMetricQuery };
+  }
+
+  public async createMoocletRewardMetric(
+    rewardMetricName: string,
+    context: string,
+    logger: UpgradeLogger
+  ): Promise<Metric[]> {
+    const metric = {
+      id: uuid(),
+      metric: rewardMetricName,
+      datatype: IMetricMetaData.CATEGORICAL,
+      allowedValues: ['SUCCESS', 'FAILURE'],
+    };
+
+    return this.metricService.saveAllMetrics([metric], [context], logger);
   }
 
   private createMoocletVersionConditionMaps(
@@ -473,16 +540,15 @@ export class MoocletExperimentService extends ExperimentService {
   }
 
   private async createVariableIfNeeded(
-    moocletPolicyParametersResponse: MoocletPolicyParametersResponseDetails,
-    assignmentAlgorithm: string,
-    moocletResponse: MoocletResponseDetails
+    moocletPolicyParameters: MoocletPolicyParametersDTO,
+    assignmentAlgorithm: string
   ): Promise<MoocletVariableResponseDetails> {
-    if (!moocletPolicyParametersResponse || assignmentAlgorithm !== ASSIGNMENT_ALGORITHM.MOOCLET_TS_CONFIGURABLE) {
+    if (!moocletPolicyParameters || assignmentAlgorithm !== ASSIGNMENT_ALGORITHM.MOOCLET_TS_CONFIGURABLE) {
       return null;
     }
 
     const variableRequest: MoocletVariableRequestBody = {
-      name: this.createOutcomeVariableName(moocletResponse.name),
+      name: (moocletPolicyParameters as MoocletTSConfigurablePolicyParametersDTO)?.outcome_variable_name,
     };
 
     try {
@@ -491,10 +557,6 @@ export class MoocletExperimentService extends ExperimentService {
       logger.error({ message: 'Failed to create Mooclet variable' });
       throw new Error(`Failed to create variable: ${err}`);
     }
-  }
-
-  private createOutcomeVariableName(moocletName: string): string {
-    return 'TS_CONFIG_' + moocletName;
   }
 
   public async getMoocletExperimentRefByUpgradeExperimentId(

--- a/backend/packages/Upgrade/src/database/migrations/1738968460239-rewardMetricKeyOutcomeVariableName.ts
+++ b/backend/packages/Upgrade/src/database/migrations/1738968460239-rewardMetricKeyOutcomeVariableName.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RewardMetricKeyOutcomeVariableName1738968460239 implements MigrationInterface {
+  name = 'RewardMetricKeyOutcomeVariableName1738968460239';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "mooclet_experiment_ref" ADD "rewardMetricKey" character varying`);
+    await queryRunner.query(`ALTER TABLE "mooclet_experiment_ref" ADD "outcomeVariableName" character varying`);
+    await queryRunner.query(
+      `ALTER TYPE "public"."experiment_assignmentalgorithm_enum" RENAME TO "experiment_assignmentalgorithm_enum_old"`
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."experiment_assignmentalgorithm_enum" AS ENUM('random', 'stratified random sampling', 'ts_configurable')`
+    );
+    await queryRunner.query(`ALTER TABLE "experiment" ALTER COLUMN "assignmentAlgorithm" DROP DEFAULT`);
+    await queryRunner.query(
+      `ALTER TABLE "experiment" ALTER COLUMN "assignmentAlgorithm" TYPE "public"."experiment_assignmentalgorithm_enum" USING "assignmentAlgorithm"::"text"::"public"."experiment_assignmentalgorithm_enum"`
+    );
+    await queryRunner.query(`ALTER TABLE "experiment" ALTER COLUMN "assignmentAlgorithm" SET DEFAULT 'random'`);
+    await queryRunner.query(`DROP TYPE "public"."experiment_assignmentalgorithm_enum_old"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."experiment_assignmentalgorithm_enum_old" AS ENUM('random', 'stratified random sampling', 'ts_configurable', 'uniform_random')`
+    );
+    await queryRunner.query(`ALTER TABLE "experiment" ALTER COLUMN "assignmentAlgorithm" DROP DEFAULT`);
+    await queryRunner.query(
+      `ALTER TABLE "experiment" ALTER COLUMN "assignmentAlgorithm" TYPE "public"."experiment_assignmentalgorithm_enum_old" USING "assignmentAlgorithm"::"text"::"public"."experiment_assignmentalgorithm_enum_old"`
+    );
+    await queryRunner.query(`ALTER TABLE "experiment" ALTER COLUMN "assignmentAlgorithm" SET DEFAULT 'random'`);
+    await queryRunner.query(`DROP TYPE "public"."experiment_assignmentalgorithm_enum"`);
+    await queryRunner.query(
+      `ALTER TYPE "public"."experiment_assignmentalgorithm_enum_old" RENAME TO "experiment_assignmentalgorithm_enum"`
+    );
+    await queryRunner.query(`ALTER TABLE "mooclet_experiment_ref" DROP COLUMN "outcomeVariableName"`);
+    await queryRunner.query(`ALTER TABLE "mooclet_experiment_ref" DROP COLUMN "rewardMetricKey"`);
+  }
+}

--- a/backend/packages/Upgrade/src/types/Mooclet.ts
+++ b/backend/packages/Upgrade/src/types/Mooclet.ts
@@ -66,11 +66,11 @@ export interface MoocletVariableResponseDetails {
 
 export interface MoocletValueRequestBody {
   variable: string;
-  learner?: number;
   value: number;
   mooclet: number;
   version: number;
-  policy: number;
+  learner?: number;
+  policy?: number;
 }
 
 export interface MoocletValueResponseDetails {

--- a/backend/packages/Upgrade/test/unit/services/MoocletExperimentService.test.ts
+++ b/backend/packages/Upgrade/test/unit/services/MoocletExperimentService.test.ts
@@ -31,7 +31,18 @@ import { QueryService } from '../../../src/api/services/QueryService';
 import { ScheduledJobService } from '../../../src/api/services/ScheduledJobService';
 import { SegmentService } from '../../../src/api/services/SegmentService';
 import { DataSource, EntityManager } from 'typeorm';
-import { ASSIGNMENT_ALGORITHM, ASSIGNMENT_UNIT, CONSISTENCY_RULE, EXPERIMENT_STATE, EXPERIMENT_TYPE, FILTER_MODE, PAYLOAD_TYPE, POST_EXPERIMENT_RULE, SEGMENT_TYPE } from 'upgrade_types';
+import {
+  ASSIGNMENT_ALGORITHM,
+  ASSIGNMENT_UNIT,
+  CONSISTENCY_RULE,
+  EXPERIMENT_STATE,
+  EXPERIMENT_TYPE,
+  FILTER_MODE,
+  PAYLOAD_TYPE,
+  POST_EXPERIMENT_RULE,
+  SEGMENT_TYPE,
+} from 'upgrade_types';
+import { MetricService } from '../../../src/api/services/MetricService';
 
 const mockDataSource = {
   initialize: jest.fn(),
@@ -81,112 +92,112 @@ jest.mock('../../../src/api/services/ScheduledJobService');
 jest.mock('../../../src/api/services/ErrorService');
 jest.mock('../../../src/api/services/CacheService');
 jest.mock('../../../src/api/services/QueryService');
+jest.mock('../../../src/api/services/MetricService');
 
 const mockTSConfigMoocletPolicyParameters = {
   assignmentAlgorithm: ASSIGNMENT_ALGORITHM.MOOCLET_TS_CONFIGURABLE,
   prior: {
     success: 1,
-    failure: 1
+    failure: 1,
   },
   batch_size: 1,
   max_rating: 1,
   min_rating: 0,
   uniform_threshold: 0,
   tspostdiff_thresh: 0,
-  outcome_variable_name: "TS_CONFIG_TEST"
+  outcome_variable_name: 'TS_CONFIG_TEST',
 };
 
 const moocletExperimentDataTSConfigurable = {
-    id: 'test-exp-123',
-    name: "test",
-    description: "",
-    consistencyRule: CONSISTENCY_RULE.INDIVIDUAL,
-    assignmentUnit: ASSIGNMENT_UNIT.INDIVIDUAL,
-    type: EXPERIMENT_TYPE.SIMPLE,
-    context: ["mathstream"],
-    assignmentAlgorithm: ASSIGNMENT_ALGORITHM.MOOCLET_TS_CONFIGURABLE,
-    stratificationFactor: null,
-    tags: [],
-    conditions: [
-      {
-        id: "A",
-        conditionCode: "question-hint-default",
-        assignmentWeight: 50,
-        description: null,
-        order: 1,
-        name: ""
-      },
-      {
-        id: "B",
-        conditionCode: "question-hint-tutorbot",
-        assignmentWeight: 50,
-        description: null,
-        order: 2,
-        name: ""
-      }
-    ],
-    conditionPayloads: [
-      {
-        id: "E",
-        payload: {
-          type: PAYLOAD_TYPE.STRING,
-          value: "question-hint-default"
-        },
-        parentCondition: "A",
-        decisionPoint: "C"
-      },
-      {
-        id: "F",
-        payload: {
-          type: PAYLOAD_TYPE.STRING,
-          value: "question-hint-tutorbot"
-        },
-        parentCondition: "B",
-        decisionPoint: "C"
-      }
-    ],
-    partitions: [
-      {
-        id: "C",
-        site: "lesson-stream",
-        target: "question-hint",
-        description: "",
-        order: 1,
-        excludeIfReached: false
-      }
-    ],
-    experimentSegmentInclusion: {
-      segment: {
-        individualForSegment: [],
-        groupForSegment: [
-          {
-            type: "All",
-            groupId: "All"
-          }
-        ],
-        subSegments: [],
-        type: SEGMENT_TYPE.PRIVATE
-      }
+  id: 'test-exp-123',
+  name: 'test',
+  description: '',
+  consistencyRule: CONSISTENCY_RULE.INDIVIDUAL,
+  assignmentUnit: ASSIGNMENT_UNIT.INDIVIDUAL,
+  type: EXPERIMENT_TYPE.SIMPLE,
+  context: ['mathstream'],
+  assignmentAlgorithm: ASSIGNMENT_ALGORITHM.MOOCLET_TS_CONFIGURABLE,
+  stratificationFactor: null,
+  tags: [],
+  conditions: [
+    {
+      id: 'A',
+      conditionCode: 'question-hint-default',
+      assignmentWeight: 50,
+      description: null,
+      order: 1,
+      name: '',
     },
-    experimentSegmentExclusion: {
-      segment: {
-        individualForSegment: [],
-        groupForSegment: [],
-        subSegments: [],
-        type: SEGMENT_TYPE.PRIVATE
-      }
+    {
+      id: 'B',
+      conditionCode: 'question-hint-tutorbot',
+      assignmentWeight: 50,
+      description: null,
+      order: 2,
+      name: '',
     },
-    filterMode: FILTER_MODE.EXCLUDE_ALL,
-    queries: [],
-    endOn: null,
-    enrollmentCompleteCondition: null,
-    startOn: null,
-    state: EXPERIMENT_STATE.ENROLLING,
-    postExperimentRule: POST_EXPERIMENT_RULE.CONTINUE,
-    revertTo: null,
-    moocletPolicyParameters: mockTSConfigMoocletPolicyParameters
-  };
-
+  ],
+  conditionPayloads: [
+    {
+      id: 'E',
+      payload: {
+        type: PAYLOAD_TYPE.STRING,
+        value: 'question-hint-default',
+      },
+      parentCondition: 'A',
+      decisionPoint: 'C',
+    },
+    {
+      id: 'F',
+      payload: {
+        type: PAYLOAD_TYPE.STRING,
+        value: 'question-hint-tutorbot',
+      },
+      parentCondition: 'B',
+      decisionPoint: 'C',
+    },
+  ],
+  partitions: [
+    {
+      id: 'C',
+      site: 'lesson-stream',
+      target: 'question-hint',
+      description: '',
+      order: 1,
+      excludeIfReached: false,
+    },
+  ],
+  experimentSegmentInclusion: {
+    segment: {
+      individualForSegment: [],
+      groupForSegment: [
+        {
+          type: 'All',
+          groupId: 'All',
+        },
+      ],
+      subSegments: [],
+      type: SEGMENT_TYPE.PRIVATE,
+    },
+  },
+  experimentSegmentExclusion: {
+    segment: {
+      individualForSegment: [],
+      groupForSegment: [],
+      subSegments: [],
+      type: SEGMENT_TYPE.PRIVATE,
+    },
+  },
+  filterMode: FILTER_MODE.EXCLUDE_ALL,
+  queries: [],
+  endOn: null,
+  enrollmentCompleteCondition: null,
+  startOn: null,
+  state: EXPERIMENT_STATE.ENROLLING,
+  postExperimentRule: POST_EXPERIMENT_RULE.CONTINUE,
+  revertTo: null,
+  moocletPolicyParameters: mockTSConfigMoocletPolicyParameters,
+};
 
 describe('#MoocletExperimentService', () => {
   let moocletExperimentService: MoocletExperimentService;
@@ -217,6 +228,7 @@ describe('#MoocletExperimentService', () => {
   let errorService: ErrorService;
   let cacheService: CacheService;
   let queryService: QueryService;
+  let metricService: MetricService;
 
   beforeEach(() => {
     moocletDataService = {
@@ -253,7 +265,8 @@ describe('#MoocletExperimentService', () => {
       scheduledJobService,
       errorService,
       cacheService,
-      queryService
+      queryService,
+      metricService
     );
   });
 
@@ -262,12 +275,12 @@ describe('#MoocletExperimentService', () => {
     let params: SyncCreateParams;
     let mockExperimentResponse: ExperimentDTO;
     let mockMoocletExperimentRefResponse: MoocletExperimentRef;
-  
+
     beforeEach(() => {
       mockExperimentResponse = {
         id: 'exp-123',
       } as ExperimentDTO;
-  
+
       mockMoocletExperimentRefResponse = {
         id: 'moocletRef-123',
       } as MoocletExperimentRef;
@@ -275,107 +288,95 @@ describe('#MoocletExperimentService', () => {
       manager = mockDataSource.manager as EntityManager;
       params = {
         experimentDTO: moocletExperimentDataTSConfigurable,
-        currentUser: {} as UserDTO
+        currentUser: {} as UserDTO,
       };
-  
+
       // Spy on class methods
       jest.spyOn(moocletExperimentService as any, 'createExperiment').mockResolvedValue(mockExperimentResponse);
-      jest.spyOn(moocletExperimentService as any, 'orchestrateMoocletCreation').mockResolvedValue(mockMoocletExperimentRefResponse);
+      jest
+        .spyOn(moocletExperimentService as any, 'orchestrateMoocletCreation')
+        .mockResolvedValue(mockMoocletExperimentRefResponse);
       jest.spyOn(moocletExperimentService as any, 'saveMoocletExperimentRef').mockResolvedValue(undefined);
       jest.spyOn(moocletExperimentService as any, 'createAndSaveVersionConditionMaps').mockResolvedValue(undefined);
       jest.spyOn(moocletExperimentService as any, 'orchestrateDeleteMoocletResources').mockResolvedValue(undefined);
     });
-  
+
     afterEach(() => {
       jest.clearAllMocks();
     });
-  
+
     it('should successfully create a mooclet experiment with all required resources', async () => {
-      const result = await moocletExperimentService['handleCreateMoocletTransaction'](
-        manager,
-        params
-      );
-  
+      const result = await moocletExperimentService['handleCreateMoocletTransaction'](manager, params);
+
       // Verify all methods were called with correct parameters
-      expect(moocletExperimentService['createExperiment']).toHaveBeenCalledWith(
-        manager,
-        params
-      );
-  
+      expect(moocletExperimentService['createExperiment']).toHaveBeenCalledWith(manager, params);
+
       expect(moocletExperimentService['orchestrateMoocletCreation']).toHaveBeenCalledWith(
         mockExperimentResponse,
         params.experimentDTO.moocletPolicyParameters
       );
-  
+
       expect(moocletExperimentService['saveMoocletExperimentRef']).toHaveBeenCalledWith(
         manager,
         mockMoocletExperimentRefResponse
       );
-  
+
       expect(moocletExperimentService['createAndSaveVersionConditionMaps']).toHaveBeenCalledWith(
         manager,
         mockMoocletExperimentRefResponse
       );
-  
+
       // Verify the result
       expect(result).toEqual({
         ...mockExperimentResponse,
-        moocletPolicyParameters: params.experimentDTO.moocletPolicyParameters
+        moocletPolicyParameters: params.experimentDTO.moocletPolicyParameters,
       });
-  
+
       // Verify orchestrateDeleteMoocletResources was not called
       expect(moocletExperimentService['orchestrateDeleteMoocletResources']).not.toHaveBeenCalled();
     });
-  
+
     it('should handle failure during createExperiment and throw error', async () => {
       const error = new Error('Failed to create experiment');
       jest.spyOn(moocletExperimentService as any, 'createExperiment').mockRejectedValue(error);
-  
-      await expect(
-        moocletExperimentService['handleCreateMoocletTransaction'](manager, params)
-      ).rejects.toThrow(error);
-  
+
+      await expect(moocletExperimentService['handleCreateMoocletTransaction'](manager, params)).rejects.toThrow(error);
+
       // Verify subsequent methods were not called
       expect(moocletExperimentService['orchestrateMoocletCreation']).not.toHaveBeenCalled();
       expect(moocletExperimentService['saveMoocletExperimentRef']).not.toHaveBeenCalled();
       expect(moocletExperimentService['createAndSaveVersionConditionMaps']).not.toHaveBeenCalled();
     });
-  
+
     it('should handle failure during orchestrateMoocletCreation and throw error', async () => {
       const error = new Error('Failed to create mooclet resources');
       jest.spyOn(moocletExperimentService as any, 'orchestrateMoocletCreation').mockRejectedValue(error);
-  
-      await expect(
-        moocletExperimentService['handleCreateMoocletTransaction'](manager, params)
-      ).rejects.toThrow(error);
-  
+
+      await expect(moocletExperimentService['handleCreateMoocletTransaction'](manager, params)).rejects.toThrow(error);
+
       // Verify subsequent methods were not called
       expect(moocletExperimentService['saveMoocletExperimentRef']).not.toHaveBeenCalled();
       expect(moocletExperimentService['createAndSaveVersionConditionMaps']).not.toHaveBeenCalled();
     });
-  
+
     it('should handle failure during saveMoocletExperimentRef and cleanup resources', async () => {
       const error = new Error('Failed to save mooclet ref');
       jest.spyOn(moocletExperimentService as any, 'saveMoocletExperimentRef').mockRejectedValue(error);
-  
-      await expect(
-        moocletExperimentService['handleCreateMoocletTransaction'](manager, params)
-      ).rejects.toThrow(error);
-  
+
+      await expect(moocletExperimentService['handleCreateMoocletTransaction'](manager, params)).rejects.toThrow(error);
+
       // Verify cleanup was called
       expect(moocletExperimentService['orchestrateDeleteMoocletResources']).toHaveBeenCalledWith(
         mockMoocletExperimentRefResponse
       );
     });
-  
+
     it('should handle failure during createAndSaveVersionConditionMaps and cleanup resources', async () => {
       const error = new Error('Failed to save version condition maps');
       jest.spyOn(moocletExperimentService as any, 'createAndSaveVersionConditionMaps').mockRejectedValue(error);
-  
-      await expect(
-        moocletExperimentService['handleCreateMoocletTransaction'](manager, params)
-      ).rejects.toThrow(error);
-  
+
+      await expect(moocletExperimentService['handleCreateMoocletTransaction'](manager, params)).rejects.toThrow(error);
+
       // Verify cleanup was called
       expect(moocletExperimentService['orchestrateDeleteMoocletResources']).toHaveBeenCalledWith(
         mockMoocletExperimentRefResponse
@@ -383,8 +384,7 @@ describe('#MoocletExperimentService', () => {
     });
   });
 
-  describe("#orchestrateMoocletCreation", ()=> {
-
+  describe('#orchestrateMoocletCreation', () => {
     afterEach(() => {
       jest.clearAllMocks();
     });
@@ -398,13 +398,22 @@ describe('#MoocletExperimentService', () => {
 
       jest.spyOn(moocletExperimentService as any, 'getMoocletPolicy').mockResolvedValue(mockMoocletPolicy);
       jest.spyOn(moocletExperimentService as any, 'createMooclet').mockResolvedValue(mockMoocletResponse);
-      jest.spyOn(moocletExperimentService as any, 'createMoocletVersions').mockResolvedValue(mockMoocletVersionsResponse);
+      jest
+        .spyOn(moocletExperimentService as any, 'createMoocletVersions')
+        .mockResolvedValue(mockMoocletVersionsResponse);
       jest.spyOn(moocletExperimentService as any, 'createMoocletVersionConditionMaps').mockReturnValue([]);
-      jest.spyOn(moocletExperimentService as any, 'createPolicyParameters').mockResolvedValue(mockMoocletPolicyParametersResponse);
-      jest.spyOn(moocletExperimentService as any, 'createVariableIfNeeded').mockResolvedValue(mockMoocletVariableResponse);
+      jest
+        .spyOn(moocletExperimentService as any, 'createPolicyParameters')
+        .mockResolvedValue(mockMoocletPolicyParametersResponse);
+      jest
+        .spyOn(moocletExperimentService as any, 'createVariableIfNeeded')
+        .mockResolvedValue(mockMoocletVariableResponse);
       jest.spyOn(moocletExperimentService as any, 'orchestrateDeleteMoocletResources').mockResolvedValue(undefined);
 
-      const result = await moocletExperimentService.orchestrateMoocletCreation(moocletExperimentDataTSConfigurable, mockTSConfigMoocletPolicyParameters);
+      const result = await moocletExperimentService.orchestrateMoocletCreation(
+        moocletExperimentDataTSConfigurable,
+        mockTSConfigMoocletPolicyParameters
+      );
 
       expect(result).toBeDefined();
       expect(result?.experimentId).toBe(moocletExperimentDataTSConfigurable.id);
@@ -420,19 +429,24 @@ describe('#MoocletExperimentService', () => {
       jest.spyOn(moocletExperimentService as any, 'getMoocletPolicy').mockRejectedValue(mockError);
       jest.spyOn(moocletExperimentService as any, 'orchestrateDeleteMoocletResources').mockRejectedValue(mockError);
 
-      await expect(moocletExperimentService.orchestrateMoocletCreation(moocletExperimentDataTSConfigurable, mockTSConfigMoocletPolicyParameters)).rejects.toThrow(mockError);
+      await expect(
+        moocletExperimentService.orchestrateMoocletCreation(
+          moocletExperimentDataTSConfigurable,
+          mockTSConfigMoocletPolicyParameters
+        )
+      ).rejects.toThrow(mockError);
       expect(moocletExperimentService.orchestrateDeleteMoocletResources).toHaveBeenCalled();
     });
   });
 
-  describe("#orchestrateDeleteMoocletResources", ()=> {
+  describe('#orchestrateDeleteMoocletResources', () => {
     const mockMoocletExperimentRef = new MoocletExperimentRef();
     mockMoocletExperimentRef.moocletId = 1;
     mockMoocletExperimentRef.policyParametersId = 2;
     mockMoocletExperimentRef.variableId = 3;
     mockMoocletExperimentRef.id = 'mockMoocletExperimentRef123';
     mockMoocletExperimentRef.versionConditionMaps = [];
-      
+
     afterEach(() => {
       jest.clearAllMocks();
     });
@@ -441,11 +455,13 @@ describe('#MoocletExperimentService', () => {
       jest.spyOn(moocletDataService, 'deleteMooclet').mockResolvedValue(undefined);
       jest.spyOn(moocletDataService, 'deletePolicyParameters').mockResolvedValue(undefined);
       jest.spyOn(moocletDataService, 'deleteVariable').mockResolvedValue(undefined);
-  
+
       await moocletExperimentService.orchestrateDeleteMoocletResources(mockMoocletExperimentRef);
-  
+
       expect(moocletDataService.deleteMooclet).toHaveBeenCalledWith(mockMoocletExperimentRef.moocletId);
-      expect(moocletDataService.deletePolicyParameters).toHaveBeenCalledWith(mockMoocletExperimentRef.policyParametersId);
+      expect(moocletDataService.deletePolicyParameters).toHaveBeenCalledWith(
+        mockMoocletExperimentRef.policyParametersId
+      );
       expect(moocletDataService.deleteVariable).toHaveBeenCalledWith(mockMoocletExperimentRef.variableId);
     });
     it('should handle errors and log them', async () => {
@@ -454,9 +470,11 @@ describe('#MoocletExperimentService', () => {
       jest.spyOn(moocletExperimentService as any, 'deleteMoocletVersions').mockResolvedValue(undefined);
       jest.spyOn(moocletDataService, 'deletePolicyParameters').mockResolvedValue(undefined);
       jest.spyOn(moocletDataService, 'deleteVariable').mockResolvedValue(undefined);
-  
-      await expect(moocletExperimentService.orchestrateDeleteMoocletResources(mockMoocletExperimentRef)).rejects.toThrow(mockError);
-  
+
+      await expect(
+        moocletExperimentService.orchestrateDeleteMoocletResources(mockMoocletExperimentRef)
+      ).rejects.toThrow(mockError);
+
       expect(moocletDataService.deleteMooclet).toHaveBeenCalledWith(mockMoocletExperimentRef.moocletId);
       expect(moocletDataService.deletePolicyParameters).not.toHaveBeenCalled();
       expect(moocletDataService.deleteVariable).not.toHaveBeenCalled();


### PR DESCRIPTION
#1934 

This is working except for on experiment delete, I'd like to [delete the reward metric](https://github.com/CarnegieLearningWeb/UpGrade/compare/feature/reward-metric-and-query-on-creation?expand=1#diff-e29da6f404aa3e3fd4a253786e23cf2fda0d8e8e09d4d0ca3ecfcd5aab43c1b4R242)... it appears I can't just delete the metric in the transaction? If I remove await, it works, but that seems wrong, if I put await on there, it deletes it the metric but it hangs and never moves on, which makes me think using `metricService.deleteMetric` inside this transaction doesn't work?

