### PR TITLE
Disallow Empty Metrics Rows For Experiment Creation/Update

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.ts
@@ -635,23 +635,22 @@ export class MonitoredMetricsComponent implements OnInit, OnChanges, OnDestroy {
     this.queryComparisonStatisticError = [];
     this.queryMetricDropDownError = [];
     this.queryNameError = [];
+    this.queryForm.markAllAsTouched();
     const monitoredMetricsFormData = this.queryForm.getRawValue();
     monitoredMetricsFormData.queries = monitoredMetricsFormData.queries.map((query, index) => {
       let { keys } = query;
       const { operationType, queryName, compareFn, compareValue, repeatedMeasure } = query;
 
       if (keys) {
-        // check for metric key required except default row:
-        if (keys[0].metricKey || operationType || queryName || compareFn || compareValue) {
-          this.checkMetricKeyRequiredError(keys);
-        }
+        this.checkMetricKeyRequiredError(keys);
+        this.checkQueryNameRequiredError(queryName);
+        this.checkStatisticRequiredError(operationType);
+
         const metrics = [...keys];
         keys = keys
           .filter((key) => key.metricKey !== null)
           .map((key) => (key.metricKey.key ? key.metricKey.key : key.metricKey));
         if (keys.length) {
-          this.checkQueryNameRequiredError(queryName);
-          this.checkStatisticRequiredError(operationType);
           this.checkMetricFromDropDownError(metrics[keys.length - 1].metricKey['metadata']);
 
           if (metrics[keys.length - 1].metricKey['metadata']) {


### PR DESCRIPTION
Resolves #2224 


When "Next" is clicked while empty rows exist:
<img width="750" alt="Screenshot 2025-02-14 at 10 38 25 PM" src="https://github.com/user-attachments/assets/9950e463-5233-419d-8ed6-89f4ffb66939" />
