### PR TITLE
fix await in assign service, fix missing get

### DIFF
--- a/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
@@ -1375,7 +1375,7 @@ export class ExperimentAssignmentService {
           if (experiment.assignmentAlgorithm === ASSIGNMENT_ALGORITHM.STRATIFIED_RANDOM_SAMPLING) {
             conditionAssigned = experiment.conditions.find((expCondition) => expCondition.conditionCode === condition);
           } else {
-            conditionAssigned = this.assignExperiment(
+            conditionAssigned = await this.assignExperiment(
               user,
               experiment,
               individualEnrollment,
@@ -1556,7 +1556,8 @@ export class ExperimentAssignmentService {
         return (
           (experiment.assignmentUnit === ASSIGNMENT_UNIT.INDIVIDUAL
             ? individualEnrollmentCondition
-            : groupEnrollmentCondition) || this.assignRandom(experiment, user, enrollmentCount)
+            : groupEnrollmentCondition) ||
+          this.getNewExperimentConditionAssignment(experiment, user, logger, enrollmentCount)
         );
       }
     }

--- a/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario3.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentAssignment/Scenario3.ts
@@ -2,14 +2,19 @@ import { Container } from 'typedi';
 import { groupAssignmentWithGroupConsistencyExperiment } from '../mockData/experiment';
 import { ExperimentService } from '../../../src/api/services/ExperimentService';
 import { EXPERIMENT_STATE } from 'upgrade_types';
-import { getAllExperimentCondition, markExperimentPoint, checkDeletedExperiment, updateExcludeIfReachedFlag } from '../utils';
+import {
+  getAllExperimentCondition,
+  markExperimentPoint,
+  checkDeletedExperiment,
+  updateExcludeIfReachedFlag,
+} from '../utils';
 import { UserService } from '../../../src/api/services/UserService';
 import { systemUser } from '../mockData/user/index';
 import { experimentUsers } from '../mockData/experimentUsers/index';
 import {
   checkMarkExperimentPointForUser,
   checkExperimentAssignedIsNull,
-  checkExperimentAssignedIsNotDefault
+  checkExperimentAssignedIsNotDefault,
 } from '../utils/index';
 import { UpgradeLogger } from '../../../src/lib/logger/UpgradeLogger';
 

--- a/backend/packages/Upgrade/test/integration/utils/index.ts
+++ b/backend/packages/Upgrade/test/integration/utils/index.ts
@@ -13,7 +13,11 @@ import { UpgradeLogger } from '../../../src/lib/logger/UpgradeLogger';
 import { ExperimentUserService } from '../../../src/api/services/ExperimentUserService';
 import { DecisionPoint } from 'src/api/models/DecisionPoint';
 
-export function updateExcludeIfReachedFlag(partitions: Array<Partial<Omit<DecisionPoint, 'createdAt' | 'updatedAt' | 'versionNumber' | 'experiment' | 'conditionPayloads'>>>): DecisionPoint[] {
+export function updateExcludeIfReachedFlag(
+  partitions: Array<
+    Partial<Omit<DecisionPoint, 'createdAt' | 'updatedAt' | 'versionNumber' | 'experiment' | 'conditionPayloads'>>
+  >
+): DecisionPoint[] {
   partitions.forEach((partition) => {
     partition.excludeIfReached = true;
   });


### PR DESCRIPTION
this fixes failing tests related to assign not awaiting a promise in group enrollment complete scenarios, and addresses a missing replacement of `assignRandom` with `getNewExperimentConditionAssignment` that I somehow missed when creating the PR for mooclet assign changes.