### PR TITLE
refetch metrics on exp upsert

### DIFF
--- a/frontend/projects/upgrade/src/app/core/experiments/store/experiments.effects.spec.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/store/experiments.effects.spec.ts
@@ -60,7 +60,7 @@ import {
 } from './experiments.model';
 import * as Selectors from './experiments.selectors';
 import { environment } from '../../../../environments/environment';
-import { actionExecuteQuery } from '../../analysis/store/analysis.actions';
+import { actionExecuteQuery, actionFetchMetrics } from '../../analysis/store/analysis.actions';
 import { selectCurrentUser } from '../../auth/store/auth.selectors';
 import { UserRole } from '../../users/store/users.model';
 import { Environment } from '../../../../environments/environment-types';
@@ -377,13 +377,14 @@ describe('ExperimentEffects', () => {
         actionUpsertExperimentSuccess({ experiment }),
         actionFetchAllDecisionPoints(),
         actionExecuteQuery({ queryIds: ['queryid1'] }),
+        actionFetchMetrics(),
       ];
 
       Selectors.selectExperimentStats.setResult({ test1: stats });
       experimentDataService.getAllExperimentsStats = jest.fn().mockReturnValue(of(experimentStats));
 
       service.UpsertExperiment$.pipe(
-        take(4),
+        take(5),
         scan((acc, val) => {
           acc.unshift(val);
           acc.splice(4);
@@ -410,13 +411,14 @@ describe('ExperimentEffects', () => {
         actionUpsertExperimentSuccess({ experiment }),
         actionFetchAllDecisionPoints(),
         actionExecuteQuery({ queryIds: ['queryid1'] }),
+        actionFetchMetrics(),
       ];
 
       Selectors.selectExperimentStats.setResult({ test1: stats });
       experimentDataService.getAllExperimentsStats = jest.fn().mockReturnValue(of(experimentStats));
 
       service.UpsertExperiment$.pipe(
-        take(4),
+        take(5),
         scan((acc, val) => {
           acc.unshift(val);
           acc.splice(4);
@@ -443,13 +445,14 @@ describe('ExperimentEffects', () => {
         actionUpsertExperimentSuccess({ experiment }),
         actionFetchAllDecisionPoints(),
         actionExecuteQuery({ queryIds: ['queryid1'] }),
+        actionFetchMetrics(),
       ];
 
       Selectors.selectExperimentStats.setResult({ test1: stats });
       experimentDataService.getAllExperimentsStats = jest.fn().mockReturnValue(of(experimentStats));
 
       service.UpsertExperiment$.pipe(
-        take(4),
+        take(5),
         scan((acc, val) => {
           acc.unshift(val);
           acc.splice(4);

--- a/frontend/projects/upgrade/src/app/core/experiments/store/experiments.effects.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/store/experiments.effects.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import * as experimentAction from './experiments.actions';
+import * as analysisActions from '../../analysis/store/analysis.actions';
 import { ExperimentDataService } from '../experiments.data.service';
 import {
   map,
@@ -162,6 +163,7 @@ export class ExperimentEffects {
                   experimentAction.actionFetchExperimentStatsSuccess({ stats }),
                   experimentAction.actionUpsertExperimentSuccess({ experiment: data }),
                   experimentAction.actionFetchAllDecisionPoints(),
+                  analysisActions.actionFetchMetrics(),
                 ];
               })
             )


### PR DESCRIPTION
related to #2207, metrics need refetched on experiment upsert so the UI will know about the new reward metric. This will work for create, edit, and import.