### PR TITLE
Hotfix/trim segment ids before insert

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ab_testing_backend",
-  "version": "6.0.13",
+  "version": "6.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ab_testing_backend",
-      "version": "6.0.13",
+      "version": "6.0.14",
       "license": "ISC",
       "dependencies": {
         "dayjs": "^1.11.10",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ab_testing_backend",
-  "version": "6.0.13",
+  "version": "6.0.14",
   "description": "Backend for A/B Testing Project",
   "scripts": {
     "install:all": "npm ci && cd packages/Scheduler && npm ci && cd ../Upgrade && npm ci",

--- a/backend/packages/Scheduler/package-lock.json
+++ b/backend/packages/Scheduler/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppl-upgrade-serverless",
-  "version": "6.0.13",
+  "version": "6.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppl-upgrade-serverless",
-      "version": "6.0.13",
+      "version": "6.0.14",
       "license": "MIT",
       "dependencies": {
         "jsonwebtoken": "^9.0.0",

--- a/backend/packages/Scheduler/package.json
+++ b/backend/packages/Scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppl-upgrade-serverless",
-  "version": "6.0.13",
+  "version": "6.0.14",
   "description": "Serverless webpack example using Typescript",
   "main": "handler.js",
   "scripts": {

--- a/backend/packages/Upgrade/package-lock.json
+++ b/backend/packages/Upgrade/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ab_testing_backend",
-  "version": "6.0.13",
+  "version": "6.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ab_testing_backend",
-      "version": "6.0.13",
+      "version": "6.0.14",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.633.0",

--- a/backend/packages/Upgrade/package.json
+++ b/backend/packages/Upgrade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ab_testing_backend",
-  "version": "6.0.13",
+  "version": "6.0.14",
   "description": "Backend for A/B Testing Project",
   "main": "index.js",
   "scripts": {

--- a/backend/packages/Upgrade/src/api/services/SegmentService.ts
+++ b/backend/packages/Upgrade/src/api/services/SegmentService.ts
@@ -626,6 +626,6 @@ export class SegmentService {
   }
 
   private trimAndRemoveHiddenChars(value: string): string {
-    return value.trim().replace(/[\r\n]/g, '');
+    return value.replace(/[\r\n\t]/g, '').trim();
   }
 }

--- a/backend/packages/Upgrade/src/api/services/SegmentService.ts
+++ b/backend/packages/Upgrade/src/api/services/SegmentService.ts
@@ -580,13 +580,21 @@ export class SegmentService {
       throw error;
     }
 
-    const individualForSegmentDocsToSave = segment.userIds.map((userId) => ({
-      userId,
-      segment: segmentDoc,
-    }));
+    const individualForSegmentDocsToSave = segment.userIds.map((userId) => {
+      const trimmedId = this.trimAndRemoveHiddenChars(userId);
+      return {
+        userId: trimmedId,
+        segment: segmentDoc,
+      };
+    });
 
     const groupForSegmentDocsToSave = segment.groups.map((group) => {
-      return { ...group, segment: segmentDoc };
+      group.groupId = this.trimAndRemoveHiddenChars(group.groupId);
+
+      return {
+        ...group,
+        segment: segmentDoc,
+      };
     });
 
     try {
@@ -615,5 +623,9 @@ export class SegmentService {
     return transactionalEntityManager
       .getRepository(Segment)
       .findOne({ where: { id: segmentDoc.id }, relations: ['individualForSegment', 'groupForSegment', 'subSegments'] });
+  }
+
+  private trimAndRemoveHiddenChars(value: string): string {
+    return value.trim().replace(/[\r\n]/g, '');
   }
 }

--- a/backend/packages/Upgrade/test/unit/services/SegmentService.test.ts
+++ b/backend/packages/Upgrade/test/unit/services/SegmentService.test.ts
@@ -409,14 +409,15 @@ describe('Segment Service Testing', () => {
 
     segmentWithIdsToCleanUp.groups = [
       { groupId: 'group1\n', type: 'skool' },
-      { groupId: 'group2\r ', type: 'skool' },
+      { groupId: '\rgroup2 ', type: 'skool' },
       { groupId: ' group3 ', type: 'skool' },
       { groupId: 'group4', type: 'skool' },
+      { groupId: ' group5 \t', type: 'skool' },
     ];
-    segmentWithIdsToCleanUp.userIds = ['user1\n', 'user2\r', ' user3 ', 'user4'];
+    segmentWithIdsToCleanUp.userIds = ['user1\n', 'user2\r', ' user3 ', 'user4 \r', '\tuser5'];
 
-    const expectedCleanedUpUserIds = ['user1', 'user2', 'user3', 'user4'];
-    const expectedCleanedUpGroupIds = ['group1', 'group2', 'group3', 'group4'];
+    const expectedCleanedUpUserIds = ['user1', 'user2', 'user3', 'user4', 'user5'];
+    const expectedCleanedUpGroupIds = ['group1', 'group2', 'group3', 'group4', 'group5'];
 
     const indivRepo = module.get<IndividualForSegmentRepository>(getRepositoryToken(IndividualForSegmentRepository));
     indivRepo.insertIndividualForSegment = jest.fn();
@@ -432,6 +433,7 @@ describe('Segment Service Testing', () => {
         { userId: expectedCleanedUpUserIds[1], segment: expect.any(Object) },
         { userId: expectedCleanedUpUserIds[2], segment: expect.any(Object) },
         { userId: expectedCleanedUpUserIds[3], segment: expect.any(Object) },
+        { userId: expectedCleanedUpUserIds[4], segment: expect.any(Object) },
       ],
       expect.any(Object),
       expect.any(Object)
@@ -443,6 +445,7 @@ describe('Segment Service Testing', () => {
         { groupId: expectedCleanedUpGroupIds[1], segment: expect.any(Object), type: 'skool' },
         { groupId: expectedCleanedUpGroupIds[2], segment: expect.any(Object), type: 'skool' },
         { groupId: expectedCleanedUpGroupIds[3], segment: expect.any(Object), type: 'skool' },
+        { groupId: expectedCleanedUpGroupIds[4], segment: expect.any(Object), type: 'skool' },
       ],
       expect.any(Object),
       expect.any(Object)

--- a/backend/packages/Upgrade/test/unit/services/SegmentService.test.ts
+++ b/backend/packages/Upgrade/test/unit/services/SegmentService.test.ts
@@ -403,6 +403,52 @@ describe('Segment Service Testing', () => {
     expect(segments).toEqual(seg1);
   });
 
+  it('should upsert a segment with trimmed whitespace and removed newline or carriage return', async () => {
+    const segmentWithIdsToCleanUp = new SegmentInputValidator();
+    segmentWithIdsToCleanUp.subSegmentIds = [];
+
+    segmentWithIdsToCleanUp.groups = [
+      { groupId: 'group1\n', type: 'skool' },
+      { groupId: 'group2\r ', type: 'skool' },
+      { groupId: ' group3 ', type: 'skool' },
+      { groupId: 'group4', type: 'skool' },
+    ];
+    segmentWithIdsToCleanUp.userIds = ['user1\n', 'user2\r', ' user3 ', 'user4'];
+
+    const expectedCleanedUpUserIds = ['user1', 'user2', 'user3', 'user4'];
+    const expectedCleanedUpGroupIds = ['group1', 'group2', 'group3', 'group4'];
+
+    const indivRepo = module.get<IndividualForSegmentRepository>(getRepositoryToken(IndividualForSegmentRepository));
+    indivRepo.insertIndividualForSegment = jest.fn();
+
+    const groupRepo = module.get<GroupForSegmentRepository>(getRepositoryToken(GroupForSegmentRepository));
+    groupRepo.insertGroupForSegment = jest.fn();
+
+    await service.upsertSegment(segmentWithIdsToCleanUp, logger);
+
+    expect(indivRepo.insertIndividualForSegment).toHaveBeenCalledWith(
+      [
+        { userId: expectedCleanedUpUserIds[0], segment: expect.any(Object) },
+        { userId: expectedCleanedUpUserIds[1], segment: expect.any(Object) },
+        { userId: expectedCleanedUpUserIds[2], segment: expect.any(Object) },
+        { userId: expectedCleanedUpUserIds[3], segment: expect.any(Object) },
+      ],
+      expect.any(Object),
+      expect.any(Object)
+    );
+
+    expect(groupRepo.insertGroupForSegment).toHaveBeenCalledWith(
+      [
+        { groupId: expectedCleanedUpGroupIds[0], segment: expect.any(Object), type: 'skool' },
+        { groupId: expectedCleanedUpGroupIds[1], segment: expect.any(Object), type: 'skool' },
+        { groupId: expectedCleanedUpGroupIds[2], segment: expect.any(Object), type: 'skool' },
+        { groupId: expectedCleanedUpGroupIds[3], segment: expect.any(Object), type: 'skool' },
+      ],
+      expect.any(Object),
+      expect.any(Object)
+    );
+  });
+
   it('should upsert a segment with no id', async () => {
     const err = new Error('error');
     const segment = new SegmentInputValidator();

--- a/clientlibs/js/package-lock.json
+++ b/clientlibs/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "upgrade_client_lib",
-  "version": "6.0.13",
+  "version": "6.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "upgrade_client_lib",
-      "version": "6.0.13",
+      "version": "6.0.14",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.4.0",

--- a/clientlibs/js/package.json
+++ b/clientlibs/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upgrade_client_lib",
-  "version": "6.0.13",
+  "version": "6.0.14",
   "description": "Client library to communicate with the Upgrade server",
   "files": [
     "dist/*"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ab-testing",
-  "version": "6.0.13",
+  "version": "6.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ab-testing",
-      "version": "6.0.13",
+      "version": "6.0.14",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ab-testing",
-  "version": "6.0.13",
+  "version": "6.0.14",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "UpGrade",
-  "version": "6.0.13",
+  "version": "6.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "UpGrade",
-      "version": "6.0.13",
+      "version": "6.0.14",
       "license": "ISC",
       "devDependencies": {
         "@angular-eslint/eslint-plugin": "^14.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "UpGrade",
-  "version": "6.0.13",
+  "version": "6.0.14",
   "description": "This is a combined repository for UpGrade, an open-source platform to support large-scale A/B testing in educational applications.  Learn more at www.upgradeplatform.org",
   "main": "index.js",
   "devDependencies": {

--- a/types/package-lock.json
+++ b/types/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "upgrade_types",
-  "version": "6.0.13",
+  "version": "6.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "upgrade_types",
-      "version": "6.0.13",
+      "version": "6.0.14",
       "license": "ISC",
       "devDependencies": {
         "eslint": "^8.27.0",

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upgrade_types",
-  "version": "6.0.13",
+  "version": "6.0.14",
   "description": "",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
#2235

To recap the issue, `\r` hidden carriage returns were sneaking into some of the segment ids in the json, which renders them useless. The requirement here should be that this fix addresses sanitizing those ids to remove any whitespace or hidden carriage returns or newline characters.

This is a hotfix because several pre-existing segment lists in prod had this issue, and it may have led to wrong assignments even though it looks like the ids are perfectly fine.

This adds a utility in Segment Service to trim the userids and/or groupids before being saved. This is the first time I've really looked at this code, so if there's a better approach let me know.
