### PR TITLE
Display N/A for weights on the stepper/details page for Mooclet experiments

### DIFF
--- a/frontend/projects/upgrade/src/app/core/experiment-design-stepper/experiment-design-stepper.service.ts
+++ b/frontend/projects/upgrade/src/app/core/experiment-design-stepper/experiment-design-stepper.service.ts
@@ -670,6 +670,10 @@ export class ExperimentDesignStepperService {
     );
   }
 
+  clearAssignmentAlgorithm(): void {
+    this.currentAssignmentAlgorithm$.next(ASSIGNMENT_ALGORITHM.RANDOM);
+  }
+
   clearDecisionPointTableEditModeDetails(): void {
     this.store$.dispatch(experimentDesignStepperAction.actionClearDecisionPointTableEditDetails());
   }

--- a/frontend/projects/upgrade/src/app/core/experiment-design-stepper/experiment-design-stepper.service.ts
+++ b/frontend/projects/upgrade/src/app/core/experiment-design-stepper/experiment-design-stepper.service.ts
@@ -670,10 +670,6 @@ export class ExperimentDesignStepperService {
     );
   }
 
-  clearAssignmentAlgorithm(): void {
-    this.currentAssignmentAlgorithm$.next(ASSIGNMENT_ALGORITHM.RANDOM);
-  }
-
   clearDecisionPointTableEditModeDetails(): void {
     this.store$.dispatch(experimentDesignStepperAction.actionClearDecisionPointTableEditDetails());
   }
@@ -696,11 +692,9 @@ export class ExperimentDesignStepperService {
 
   clearFactorialDesignStepperData(): void {
     this.store$.dispatch(experimentDesignStepperAction.clearFactorialDesignStepperData());
-    this.clearAssignmentAlgorithm();
   }
 
   clearSimpleExperimentDesignStepperData(): void {
     this.store$.dispatch(experimentDesignStepperAction.clearSimpleExperimentDesignStepperData());
-    this.clearAssignmentAlgorithm();
   }
 }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.html
@@ -217,10 +217,12 @@
           <!-- Condition table -->
           <span class="title">{{ 'home.new-experiment.design.condition.text' | translate }}</span>
           <!-- apply equal condition weights -->
-          <div class="conditions-header-container">
+          <div
+            *ngIf="isExperimentEditable && !(isMoocletExperimentDesign$ | async)"
+            class="conditions-header-container"
+          >
             <mat-checkbox
               color="primary"
-              [disabled]="!isExperimentEditable"
               [checked]="equalWeightFlag"
               (change)="changeEqualWeightFlag($event)"
             >
@@ -296,25 +298,33 @@
                   [formGroupName]="groupIndex"
                   style="justify-content: center"
                 >
-                  <ng-container *ngIf="(conditionsTableEditIndex$ | async) !== groupIndex">
-                    <div class="assignment-weight-readonly align-right">
-                      {{
-                        conditions.at(groupIndex).get(SIMPLE_EXP_CONSTANTS.FORM_CONTROL_NAMES.ASSIGNMENT_WEIGHT).value
-                          | truncate : 35
-                      }}
-                    </div>
+                  <!-- When isMoocletExperimentDesign$ is false, show the existing logic -->
+                  <ng-container *ngIf="!(isMoocletExperimentDesign$ | async)">
+                    <ng-container *ngIf="(conditionsTableEditIndex$ | async) !== groupIndex">
+                      <div class="assignment-weight-readonly align-right">
+                        {{
+                          conditions.at(groupIndex).get(SIMPLE_EXP_CONSTANTS.FORM_CONTROL_NAMES.ASSIGNMENT_WEIGHT).value
+                            | truncate : 35
+                        }}
+                      </div>
+                    </ng-container>
+                    <ng-container *ngIf="(conditionsTableEditIndex$ | async) === groupIndex">
+                      <mat-form-field class="dense-2" appearance="outline" subscriptSizing="dynamic">
+                        <input
+                          class="ft-14-400 align-right"
+                          type="number"
+                          matInput
+                          [placeholder]="'home.new-experiment.design.assignment-weight.placeholder.text' | translate"
+                          [formControlName]="SIMPLE_EXP_CONSTANTS.FORM_CONTROL_NAMES.ASSIGNMENT_WEIGHT"
+                          autocomplete="off"
+                        />
+                      </mat-form-field>
+                    </ng-container>
                   </ng-container>
-                  <ng-container *ngIf="(conditionsTableEditIndex$ | async) === groupIndex">
-                    <mat-form-field class="dense-2" appearance="outline" subscriptSizing="dynamic">
-                      <input
-                        class="ft-14-400 align-right"
-                        type="number"
-                        matInput
-                        [placeholder]="'home.new-experiment.design.assignment-weight.placeholder.text' | translate"
-                        [formControlName]="SIMPLE_EXP_CONSTANTS.FORM_CONTROL_NAMES.ASSIGNMENT_WEIGHT"
-                        autocomplete="off"
-                      />
-                    </mat-form-field>
+
+                  <!-- When isMoocletExperimentDesign$ is true, show N/A regardless of edit mode -->
+                  <ng-container *ngIf="isMoocletExperimentDesign$ | async">
+                    <div class="assignment-weight-readonly align-right">N/A</div>
                   </ng-container>
                 </mat-cell>
               </ng-container>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
@@ -118,7 +118,7 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
   isConditionsTableEditMode$ = this.experimentDesignStepperService.isConditionsTableEditMode$;
   conditionsTableEditIndex$ = this.experimentDesignStepperService.conditionsTableEditIndex$;
 
-  // Used for displaying the Mooclet Policy Parameters JSON editor
+  // Used for displaying the Mooclet Policy Parameters JSON editor and for hiding the Weight Equally checkbox
   currentAssignmentAlgorithm$ = this.experimentDesignStepperService.currentAssignmentAlgorithm$;
   isMoocletExperimentDesign$ = this.experimentDesignStepperService.isMoocletExperimentDesign$;
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.ts
@@ -786,9 +786,8 @@ export class ExperimentDesignComponent implements OnInit, OnChanges, OnDestroy {
         });
       } else {
         this.conditions.controls.forEach((control, index) => {
-          const assignmentWeightFormControl = control.get(SIMPLE_EXP_CONSTANTS.FORM_CONTROL_NAMES.ASSIGNMENT_WEIGHT);
-          assignmentWeightFormControl.setValue(control.value.assignmentWeight ? control.value.assignmentWeight : 0);
           if (this.isExperimentEditable) {
+            const assignmentWeightFormControl = control.get(SIMPLE_EXP_CONSTANTS.FORM_CONTROL_NAMES.ASSIGNMENT_WEIGHT);
             assignmentWeightFormControl.enable();
           }
         });

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.ts
@@ -202,7 +202,7 @@ export class ExperimentOverviewComponent implements OnInit, OnDestroy {
       });
 
       this.overviewForm.get('designType').valueChanges.subscribe((type) => {
-        if (this.initialDesignType !== type) {
+        if (this.isOverviewFormCompleted && this.initialDesignType !== type) {
           this.warningStatus = OverviewFormWarningStatus.DESIGN_TYPE_CHANGED;
         }
         this.initialDesignType = type;
@@ -240,6 +240,7 @@ export class ExperimentOverviewComponent implements OnInit, OnDestroy {
           context: this.currentContext,
           tags: this.experimentInfo.tags,
         });
+        this.warningStatus = OverviewFormWarningStatus.NO_WARNING;
         this.checkExperiment();
         this.isOverviewFormCompleted = true;
       }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/factorial-experiment-design/conditions-table/conditions-table.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/factorial-experiment-design/conditions-table/conditions-table.component.html
@@ -3,12 +3,14 @@
     <span class="title">{{ 'home.new-experiment.design.condition.text' | translate }}</span>
   </div>
 
-  <div class="conditions-weight-checkbox">
+  <div
+    *ngIf="isExperimentEditable && !(isMoocletExperimentDesign$ | async)"
+    class="conditions-weight-checkbox"
+  >
     <mat-checkbox
       color="primary"
       [checked]="equalWeightFlag"
       (change)="handleEqualWeightToggle()"
-      [disabled]="!isExperimentEditable"
     >
       <span class="ft-13-700 checkbox-label">
         {{ 'home.new-experiment.design.equal-assignment-weights.text' | translate }}
@@ -62,15 +64,24 @@
           {{ 'WEIGHT' | translate }}
         </mat-header-cell>
         <mat-cell *matCellDef="let rowData; let rowIndex = index" [formGroupName]="rowIndex">
-          <ng-container *ngIf="equalWeightFlag || (tableEditIndex$ | async) !== rowIndex || !isExperimentEditable">
-            <span [matTooltip]="rowData.weight" matTooltipPosition="above">
-              {{ rowData.weight }}
-            </span>
+
+          <!-- When isMoocletExperimentDesign$ is false, show the existing logic -->
+          <ng-container *ngIf="!(isMoocletExperimentDesign$ | async)">
+            <ng-container *ngIf="equalWeightFlag || (tableEditIndex$ | async) !== rowIndex || !isExperimentEditable">
+              <span [matTooltip]="rowData.weight" matTooltipPosition="above">
+                {{ rowData.weight }}
+              </span>
+            </ng-container>
+            <ng-container *ngIf="!equalWeightFlag && (tableEditIndex$ | async) === rowIndex && isExperimentEditable">
+              <mat-form-field class="dense-2 input-weight" appearance="outline" subscriptSizing="dynamic">
+                <input class="ft-14-400" autocomplete="off" type="text" matInput formControlName="weight" />
+              </mat-form-field>
+            </ng-container>
           </ng-container>
-          <ng-container *ngIf="!equalWeightFlag && (tableEditIndex$ | async) === rowIndex && isExperimentEditable">
-            <mat-form-field class="dense-2 input-weight" appearance="outline" subscriptSizing="dynamic">
-              <input class="ft-14-400" autocomplete="off" type="text" matInput formControlName="weight" />
-            </mat-form-field>
+
+          <!-- When isMoocletExperimentDesign$ is true, show N/A regardless of edit mode -->
+          <ng-container *ngIf="isMoocletExperimentDesign$ | async">
+            <span>N/A</span>
           </ng-container>
         </mat-cell>
       </ng-container>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/factorial-experiment-design/conditions-table/conditions-table.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/factorial-experiment-design/conditions-table/conditions-table.component.ts
@@ -38,6 +38,9 @@ export class ConditionsTableComponent implements OnInit, OnDestroy {
   conditionWeightSumError: string = null;
   conditionNegativeWeightError: string = null;
 
+  // Used for hiding the Weight Equally checkbox
+  isMoocletExperimentDesign$ = this.experimentDesignStepperService.isMoocletExperimentDesign$;
+
   constructor(
     private experimentDesignStepperService: ExperimentDesignStepperService,
     private _formBuilder: UntypedFormBuilder,

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/factorial-experiment-design/factorial-experiment-design.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/factorial-experiment-design/factorial-experiment-design.component.html
@@ -774,6 +774,7 @@
                 [experimentInfo]="experimentInfo"
                 [experimentName]="currentExperimentName$ | async"
                 [currentAssignmentAlgorithm]="currentAssignmentAlgorithm$.value"
+                [isEditable]="isExperimentEditable"
                 #policyEditor
               ></app-mooclet-policy-editor>
             </div>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/factorial-experiment-design/factorial-experiment-design.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/factorial-experiment-design/factorial-experiment-design.component.ts
@@ -10,6 +10,7 @@ import {
   OnChanges,
   OnDestroy,
 } from '@angular/core';
+import { EXPERIMENT_STATE, MOOCLET_POLICY_SCHEMA_MAP } from 'upgrade_types';
 import { UntypedFormBuilder, UntypedFormGroup, Validators, UntypedFormArray, AbstractControl } from '@angular/forms';
 import { BehaviorSubject, Observable, Subscription } from 'rxjs';
 import {
@@ -20,7 +21,6 @@ import {
   ExperimentCondition,
   ExperimentDecisionPoint,
   IContextMetaData,
-  EXPERIMENT_STATE,
 } from '../../../../../core/experiments/store/experiments.model';
 import { ExperimentService } from '../../../../../core/experiments/experiments.service';
 import { TranslateService } from '@ngx-translate/core';
@@ -249,7 +249,8 @@ export class FactorialExperimentDesignComponent implements OnInit, OnChanges, On
 
       this.isExperimentEditable =
         this.experimentInfo.state !== this.ExperimentState.ENROLLING &&
-        this.experimentInfo.state !== this.ExperimentState.ENROLLMENT_COMPLETE;
+        this.experimentInfo.state !== this.ExperimentState.ENROLLMENT_COMPLETE &&
+        !(this.experimentInfo.assignmentAlgorithm in MOOCLET_POLICY_SCHEMA_MAP);
 
       // disable control on edit:
       if (!this.isExperimentEditable) {

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/new-experiment/new-experiment.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/new-experiment/new-experiment.component.ts
@@ -44,6 +44,7 @@ export class NewExperimentComponent implements OnInit {
   }
 
   ngOnDestroy() {
+    this.experimentDesignStepperService.clearAssignmentAlgorithm();
     this.experimentDesignStepperService.clearFactorialDesignStepperData();
     this.experimentDesignStepperService.clearSimpleExperimentDesignStepperData();
   }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/table-row/table-row.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/table-row/table-row.component.html
@@ -2,20 +2,36 @@
   <mat-table [dataSource]="dataSource" multiTemplateDataRows>
     <!-- COLUMNS AND ROWS-->
     <ng-container *ngFor="let key of displayedColumns" [matColumnDef]="key">
-      <mat-header-cell style="justify-content: left; padding-left: 15px" class="ft-12-700" *matHeaderCellDef>{{
-        key.includes('Icon') ? '' : columnHeaders[key]
-      }}</mat-header-cell>
+      <mat-header-cell
+        [ngClass]="{'weight-column': key === 'weight'}"
+        style="justify-content: left; padding-left: 15px"
+        class="ft-12-700"
+        *matHeaderCellDef
+      >
+        {{ key.includes('Icon') ? '' : columnHeaders[key] }}
+      </mat-header-cell>
 
-      <mat-cell style="justify-content: left" class="ft-12-600" *matCellDef="let element; let i = dataIndex">
-        <span *ngIf="!key.includes('Icon'); else icon" style="padding-left: -5px">{{ element.data[key] }}</span>
-        <ng-template #icon>
-          <mat-icon
-            style="margin-left: -17.5px"
-            *ngIf="element.partitions && key === 'expandIcon'"
-            [class.active]="element.data[referenceId] === expandedId"
-            (click)="toggleExpandableSymbol(element.data[referenceId])"
-            >play_arrow</mat-icon
-          >
+      <mat-cell
+        [ngClass]="{'weight-column': key === 'weight'}"
+        style="justify-content: left"
+        class="ft-12-600"
+        *matCellDef="let element; let i = dataIndex"
+      >
+        <!-- Special handling for weight column when experiment has moocletPolicyParameters -->
+        <span *ngIf="key === 'weight' && experiment?.moocletPolicyParameters; else regularCell">N/A</span>
+
+        <ng-template #regularCell>
+          <span *ngIf="!key.includes('Icon'); else icon" style="padding-left: -5px">{{ element.data[key] }}</span>
+          <ng-template #icon>
+            <mat-icon
+              style="margin-left: -17.5px"
+              *ngIf="element.partitions && key === 'expandIcon'"
+              [class.active]="element.data[referenceId] === expandedId"
+              (click)="toggleExpandableSymbol(element.data[referenceId])"
+            >
+              play_arrow
+            </mat-icon>
+          </ng-template>
         </ng-template>
       </mat-cell>
     </ng-container>

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/table-row/table-row.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/table-row/table-row.component.scss
@@ -21,6 +21,12 @@ div {
       color: var(--grey-2);
     }
 
+    .weight-column {
+      justify-content: flex-end !important;
+      max-width: 96px;
+      margin-right: 64px;
+    }
+
     .mat-column-expandIcon {
       flex: 0 0 60px;
       width: 30px;

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
@@ -596,7 +596,7 @@
           </div>
 
           <!-- Experiment Conditions Table -->
-          <div class="table-container table-container-partition">
+          <div class="table-container table-container-condition">
             <span class="ft-24-700">{{ 'home.view-experiment.experiment-conditions-title.text' | translate }}</span>
             <div *ngIf="experiment.type === 'Simple'">
               <mat-table [dataSource]="experiment.conditions" class="table">
@@ -622,7 +622,14 @@
                   <mat-header-cell class="ft-12-700" *matHeaderCellDef>
                     {{ 'home-global.assignment-weight.text' | translate }}
                   </mat-header-cell>
-                  <mat-cell class="ft-12-600" *matCellDef="let data"> {{ data.assignmentWeight }} </mat-cell>
+                  <mat-cell class="ft-12-600" *matCellDef="let data">
+                    <ng-container *ngIf="experiment?.moocletPolicyParameters; else showWeight">
+                      <span>N/A</span>
+                    </ng-container>
+                    <ng-template #showWeight>
+                      {{ data.assignmentWeight }}
+                    </ng-template>
+                  </mat-cell>
                 </ng-container>
 
                 <!-- Description Column -->
@@ -690,11 +697,16 @@
 
                 <!-- Weight Column -->
                 <ng-container matColumnDef="assignmentWeight">
-                  <mat-header-cell style="justify-content: left" class="ft-12-700" *matHeaderCellDef>
+                  <mat-header-cell class="ft-12-700" *matHeaderCellDef>
                     {{ 'home-global.assignment-weight.text' | translate }}
                   </mat-header-cell>
-                  <mat-cell style="justify-content: left; padding-left: 10px" class="ft-12-600" *matCellDef="let data">
-                    {{ data.assignmentWeight }}
+                  <mat-cell class="ft-12-600" *matCellDef="let data">
+                    <ng-container *ngIf="experiment?.moocletPolicyParameters; else showFactorialWeight">
+                      <span>N/A</span>
+                    </ng-container>
+                    <ng-template #showFactorialWeight>
+                      {{ data.assignmentWeight }}
+                    </ng-template>
                   </mat-cell>
                 </ng-container>
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
@@ -455,7 +455,7 @@
         </ng-template>
         <div class="tab-body-container tab-table-body-container">
           <!-- Experiment Decision Points Table -->
-          <div class="table-container table-container-partition">
+          <div class="table-container table-container-partitions">
             <span class="ft-24-700">{{ 'home.view-experiment.experiment-decision-point-title.text' | translate }}</span>
             <mat-table [dataSource]="experiment.partitions" class="table">
               <!-- Site Column -->
@@ -596,7 +596,7 @@
           </div>
 
           <!-- Experiment Conditions Table -->
-          <div class="table-container table-container-condition">
+          <div class="table-container table-container-conditions">
             <span class="ft-24-700">{{ 'home.view-experiment.experiment-conditions-title.text' | translate }}</span>
             <div *ngIf="experiment.type === 'Simple'">
               <mat-table [dataSource]="experiment.conditions" class="table">

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.scss
@@ -258,7 +258,8 @@ $font-size-small: 15px;
   .json-viewer-container {
     padding: 24px 34px;
 
-    &-partition, &-condition {
+    &-partitions,
+    &-conditions {
       margin-bottom: 24px;
 
       .table {

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.scss
@@ -258,12 +258,36 @@ $font-size-small: 15px;
   .json-viewer-container {
     padding: 24px 34px;
 
-    &-partition {
+    &-partition, &-condition {
       margin-bottom: 24px;
 
       .table {
         mat-row {
           max-height: 50px;
+        }
+
+        .cdk-column-partitionPoint {
+          max-width: 35%;
+        }
+
+        .cdk-column-excludeIfReached {
+          justify-content: center;
+          max-width: 150px;
+          margin-right: 32px;
+        }
+
+        .cdk-column-conditionCode {
+          max-width: 35%;
+        }
+
+        .cdk-column-assignmentWeight {
+          justify-content: flex-end;
+          max-width: 96px;
+          margin-right: 64px;
+        }
+
+        .cdk-column-description {
+          margin-right: 32px;
         }
       }
 
@@ -322,14 +346,6 @@ $font-size-small: 15px;
     &-participants,
     &-metrics {
       margin-bottom: 24px;
-
-      .table {
-        mat-cell,
-        mat-header-cell {
-          justify-content: flex-start !important;
-          padding-left: 10.5% !important;
-        }
-      }
     }
 
     &-payloads .payload-table-overview {
@@ -348,7 +364,7 @@ $font-size-small: 15px;
       mat-cell,
       mat-header-cell {
         display: flex;
-        justify-content: center;
+        justify-content: flex-start;
         padding: 10px;
         margin-left: 25px;
         word-break: break-word;


### PR DESCRIPTION
Resolves #2211

Changes made:
- Feature: Hide Weight Equally checkbox on the stepper for Mooclet experiments
- Feature: Display `N/A` for weights on the stepper and details page for Mooclet experiments
- Enhancement: Refined styles for tables on the details page
- Enhancement: Disable factorialExperimentDesignForm in the stepper when editing a Mooclet experiment
- Bugfix: Suppress the initial `DESIGN_TYPE_CHANGED` warning message on the stepper when editing a factorial experiment
- Enhancement: Prevent weights being reset to 0 when the Weight Equally checkbox is unchecked (for consistency with factorial conditions table)
- Bugfix: Reset the assignment algorithm to `RANDOM` when the stepper is closed instead of when the design step is cleared by the updated experiment type

FYI, I didn't address the bugs I mentioned in this PR regarding the Include checkboxes in the factorial conditions table, as it wasn't as simple as I thought. I will create a separate ticket for that.