### PR TITLE
Add fetchSegmentsPaginated function to SegmentsDataService

### DIFF
--- a/frontend/projects/upgrade/src/app/core/segments/segments.data.service.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/segments.data.service.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable } from '@angular/core';
-import { SegmentFile, SegmentInput } from './store/segments.model';
+import { SegmentFile, SegmentInput, SegmentsPaginationInfo, SegmentsPaginationParams } from './store/segments.model';
+import { Observable } from 'rxjs';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { ENV, Environment } from '../../../environments/environment-types';
 
@@ -10,6 +11,11 @@ export class SegmentsDataService {
   fetchSegments() {
     const url = this.environment.api.segments;
     return this.http.get(url);
+  }
+
+  fetchSegmentsPaginated(params: SegmentsPaginationParams): Observable<SegmentsPaginationInfo> {
+    const url = this.environment.api.getPaginatedSegments;
+    return this.http.post<SegmentsPaginationInfo>(url, params);
   }
 
   createNewSegment(segment: SegmentInput) {

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.model.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.model.ts
@@ -124,6 +124,33 @@ export interface SegmentInput {
   type: SEGMENT_TYPE;
 }
 
+export interface SegmentsPaginationInfo {
+  nodes: Segment[];
+  total: number;
+  skip: number;
+  take: number;
+}
+
+// TODO: This should be probably be a part of env config
+export const NUMBER_OF_SEGMENTS = 20;
+
+interface ISegmentsSearchParams {
+  key: SEGMENT_SEARCH_KEY;
+  string: string;
+}
+
+interface ISegmentsSortParams {
+  key: SEGMENT_SORT_KEY;
+  sortAs: SORT_AS_DIRECTION;
+}
+
+export interface SegmentsPaginationParams {
+  skip: number;
+  take: number;
+  searchParams?: ISegmentsSearchParams;
+  sortParams?: ISegmentsSortParams;
+}
+
 export interface SegmentState extends EntityState<Segment> {
   isLoadingSegments: boolean;
   // TODO: remove any

--- a/frontend/projects/upgrade/src/environments/environment-types.ts
+++ b/frontend/projects/upgrade/src/environments/environment-types.ts
@@ -49,6 +49,7 @@ export interface APIEndpoints {
   getVersion: string;
   contextMetaData: string;
   segments: string;
+  getPaginatedSegments: string;
   validateSegments: string;
   importSegments: string;
   exportSegments: string;

--- a/frontend/projects/upgrade/src/environments/environment.beanstalk.prod.ts
+++ b/frontend/projects/upgrade/src/environments/environment.beanstalk.prod.ts
@@ -66,6 +66,7 @@ export const environment = {
     getVersion: '/version',
     contextMetaData: '/experiments/contextMetaData',
     segments: '/segments',
+    getPaginatedSegments: '/segments/paginated',
     validateSegments: '/segments/validation',
     importSegments: '/segments/import',
     exportSegments: '/segments/export/json',

--- a/frontend/projects/upgrade/src/environments/environment.bsnl.ts
+++ b/frontend/projects/upgrade/src/environments/environment.bsnl.ts
@@ -66,6 +66,7 @@ export const environment = {
     getVersion: '/version',
     contextMetaData: '/experiments/contextMetaData',
     segments: '/segments',
+    getPaginatedSegments: '/segments/paginated',
     validateSegments: '/segments/validation',
     importSegments: '/segments/import',
     exportSegments: '/segments/export/json',

--- a/frontend/projects/upgrade/src/environments/environment.demo.prod.ts
+++ b/frontend/projects/upgrade/src/environments/environment.demo.prod.ts
@@ -66,6 +66,7 @@ export const environment = {
     getVersion: '/version',
     contextMetaData: '/experiments/contextMetaData',
     segments: '/segments',
+    getPaginatedSegments: '/segments/paginated',
     validateSegments: '/segments/validation',
     importSegments: '/segments/import',
     exportSegments: '/segments/export/json',

--- a/frontend/projects/upgrade/src/environments/environment.prod.ts
+++ b/frontend/projects/upgrade/src/environments/environment.prod.ts
@@ -66,6 +66,7 @@ export const environment = {
     getVersion: '/version',
     contextMetaData: '/experiments/contextMetaData',
     segments: '/segments',
+    getPaginatedSegments: '/segments/paginated',
     validateSegments: '/segments/validation',
     importSegments: '/segments/import',
     exportSegments: '/segments/export/json',

--- a/frontend/projects/upgrade/src/environments/environment.qa.ts
+++ b/frontend/projects/upgrade/src/environments/environment.qa.ts
@@ -66,6 +66,7 @@ export const environment = {
     getVersion: '/version',
     contextMetaData: '/experiments/contextMetaData',
     segments: '/segments',
+    getPaginatedSegments: '/segments/paginated',
     validateSegments: '/segments/validation',
     importSegments: '/segments/import',
     exportSegments: '/segments/export/json',

--- a/frontend/projects/upgrade/src/environments/environment.staging.ts
+++ b/frontend/projects/upgrade/src/environments/environment.staging.ts
@@ -66,6 +66,7 @@ export const environment = {
     getVersion: '/version',
     contextMetaData: '/experiments/contextMetaData',
     segments: '/segments',
+    getPaginatedSegments: '/segments/paginated',
     validateSegments: '/segments/validation',
     importSegments: '/segments/import',
     exportSegments: '/segments/export/json',

--- a/frontend/projects/upgrade/src/environments/environment.ts
+++ b/frontend/projects/upgrade/src/environments/environment.ts
@@ -71,6 +71,7 @@ export const environment = {
     getVersion: '/version',
     contextMetaData: '/experiments/contextMetaData',
     segments: '/segments',
+    getPaginatedSegments: '/segments/paginated',
     validateSegments: '/segments/validation',
     importSegments: '/segments/import',
     exportSegments: '/segments/export/json',


### PR DESCRIPTION
Related Issue: #2255

This PR involves frontend changes only and doesn't affect the current behavior of the app. Once the `/segments/paginated` endpoint is implemented in the backend, the `segments.effects.ts` file should be updated to call `fetchSegmentsPaginated` instead of `fetchSegments`. Changes include:

- Added the `fetchSegmentsPaginated` function to `SegmentsDataService` so that it can be used to make requests to `/segments/paginated` endpoint (just like `FeatureFlagsDataService`)
- Updated `segments.model.ts` to include some interfaces (just like `feature-flags.model.ts`)
- Added `getPaginatedSegments` to the environment files
