### PR TITLE
Implement Segments Details Page

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-content/segment-details-page-content.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-content/segment-details-page-content.component.html
@@ -1,1 +1,37 @@
-<p>segment-details-page-content works!</p>
+<div class="content-container">
+  <ng-container *ngIf="segment$ | async as segment; else loading">
+    <app-common-section-card-list class="common-section-card-list">
+      <app-segment-overview-details-section-card
+        [data]="segment"
+        [isSectionCardExpanded]="isSectionCardExpanded"
+        (sectionCardExpandChange)="onSectionCardExpandChange($event)"
+        (tabChange)="onTabChange($event)"
+        section-card
+      ></app-segment-overview-details-section-card>
+
+      <!-- Show Lists section when the Lists tab is active (activeTabIndex === 0) -->
+      <app-segment-lists-section-card
+        *ngIf="activeTabIndex === 0"
+        [data]="segment"
+        [isSectionCardExpanded]="isSectionCardExpanded"
+        section-card
+      >
+      </app-segment-lists-section-card>
+
+      <!-- Show Used By section when the Used By tab is active (activeTabIndex === 1) -->
+      <app-segment-used-by-section-card
+        *ngIf="activeTabIndex === 1"
+        [data]="segment"
+        [isSectionCardExpanded]="isSectionCardExpanded"
+        section-card
+      >
+      </app-segment-used-by-section-card>
+    </app-common-section-card-list>
+  </ng-container>
+
+  <ng-template #loading>
+    <div class="mat-spinner-container">
+      <mat-spinner diameter="100"></mat-spinner>
+    </div>
+  </ng-template>
+</div>

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-content/segment-details-page-content.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-content/segment-details-page-content.component.scss
@@ -1,0 +1,7 @@
+.mat-spinner-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  padding: 100px;
+}

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-content/segment-details-page-content.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-content/segment-details-page-content.component.ts
@@ -1,10 +1,56 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
+import { CommonSectionCardListComponent } from '../../../../../../shared-standalone-component-lib/components';
+import { CommonModule } from '@angular/common';
+import { SegmentOverviewDetailsSectionCardComponent } from './segment-overview-details-section-card/segment-overview-details-section-card.component';
+import { SegmentListsSectionCardComponent } from './segment-lists-section-card/segment-lists-section-card.component';
+import { SegmentUsedBySectionCardComponent } from './segment-used-by-section-card/segment-used-by-section-card.component';
+import { SegmentsService } from '../../../../../../core/segments/segments.service';
+import { Observable, Subscription } from 'rxjs';
+import { Segment } from '../../../../../../core/segments/store/segments.model';
+import { ActivatedRoute } from '@angular/router';
+import { SharedModule } from '../../../../../../shared/shared.module';
 
 @Component({
   selector: 'app-segment-details-page-content',
-  imports: [],
+  imports: [
+    CommonModule,
+    CommonSectionCardListComponent,
+    SegmentOverviewDetailsSectionCardComponent,
+    SegmentListsSectionCardComponent,
+    SegmentUsedBySectionCardComponent,
+    SharedModule,
+  ],
   templateUrl: './segment-details-page-content.component.html',
   styleUrl: './segment-details-page-content.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SegmentDetailsPageContentComponent {}
+export class SegmentDetailsPageContentComponent implements OnInit, OnDestroy {
+  isSectionCardExpanded = true;
+  segment$: Observable<Segment>;
+  activeTabIndex = 0; // 0 for Lists, 1 for Used By
+
+  segmentIdSub: Subscription;
+
+  constructor(private segmentsService: SegmentsService, private _Activatedroute: ActivatedRoute) {}
+
+  ngOnInit() {
+    this.segmentIdSub = this._Activatedroute.paramMap.subscribe((params) => {
+      const segmentIdFromParams = params.get('segmentId');
+      this.segmentsService.fetchSegmentById(segmentIdFromParams);
+    });
+
+    this.segment$ = this.segmentsService.selectedSegment$;
+  }
+
+  onSectionCardExpandChange(expanded: boolean) {
+    this.isSectionCardExpanded = expanded;
+  }
+
+  onTabChange(tabIndex: number) {
+    this.activeTabIndex = tabIndex;
+  }
+
+  ngOnDestroy() {
+    this.segmentIdSub.unsubscribe();
+  }
+}

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-header/segment-details-page-header.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-header/segment-details-page-header.component.html
@@ -1,1 +1,6 @@
-<p>segment-details-page-header works!</p>
+<app-common-details-page-header
+  rootName="app-header.title.segments"
+  [detailsName]="(selectedSegment$ | async)?.name ?? ''"
+  rootLink="segments"
+>
+</app-common-details-page-header>

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-header/segment-details-page-header.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-header/segment-details-page-header.component.ts
@@ -1,10 +1,17 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { CommonDetailsPageHeaderComponent } from '../../../../../../shared-standalone-component-lib/components';
+import { SegmentsService } from '../../../../../../core/segments/segments.service';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-segment-details-page-header',
-  imports: [],
+  imports: [CommonDetailsPageHeaderComponent, CommonModule],
   templateUrl: './segment-details-page-header.component.html',
   styleUrl: './segment-details-page-header.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SegmentDetailsPageHeaderComponent {}
+export class SegmentDetailsPageHeaderComponent {
+  selectedSegment$ = this.segmentsService.selectedSegment$;
+
+  constructor(private segmentsService: SegmentsService) {}
+}

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page.component.html
@@ -1,1 +1,4 @@
-<p>segment-details-page works!</p>
+<app-common-page>
+  <app-segment-details-page-header header></app-segment-details-page-header>
+  <app-segment-details-page-content content></app-segment-details-page-content>
+</app-common-page>

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page.component.ts
@@ -1,10 +1,12 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
+import { CommonPageComponent } from '../../../../../shared-standalone-component-lib/components';
+import { SegmentDetailsPageHeaderComponent } from './segment-details-page-header/segment-details-page-header.component';
+import { SegmentDetailsPageContentComponent } from './segment-details-page-content/segment-details-page-content.component';
 
 @Component({
   selector: 'app-segment-details-page',
-  imports: [],
   templateUrl: './segment-details-page.component.html',
   styleUrl: './segment-details-page.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonPageComponent, SegmentDetailsPageHeaderComponent, SegmentDetailsPageContentComponent],
 })
 export class SegmentDetailsPageComponent {}

--- a/frontend/projects/upgrade/src/environments/environment.ts
+++ b/frontend/projects/upgrade/src/environments/environment.ts
@@ -17,7 +17,7 @@ export const environment = {
   pollingInterval: 10 * 1000,
   pollingLimit: 600,
   featureFlagNavToggle: true,
-  segmentsRefreshToggle: false,
+  segmentsRefreshToggle: true,
   withinSubjectExperimentSupportToggle: false,
   errorLogsToggle: false,
   metricAnalyticsExperimentDisplayToggle: true,

--- a/frontend/projects/upgrade/src/environments/environment.ts
+++ b/frontend/projects/upgrade/src/environments/environment.ts
@@ -17,7 +17,7 @@ export const environment = {
   pollingInterval: 10 * 1000,
   pollingLimit: 600,
   featureFlagNavToggle: true,
-  segmentsRefreshToggle: true,
+  segmentsRefreshToggle: false,
   withinSubjectExperimentSupportToggle: false,
   errorLogsToggle: false,
   metricAnalyticsExperimentDisplayToggle: true,


### PR DESCRIPTION
Resolves #2248

The PR currently looks like this (Implemented `SegmentDetailsPageComponent`, `SegmentDetailsPageHeaderComponent`, and `SegmentDetailsPageContentComponent`):
<img width="1000" alt="Screenshot 2025-03-13 at 9 08 04 PM" src="https://github.com/user-attachments/assets/f4815a5c-ce0e-4269-9885-6ccbb4d817f0" />

Maybe I can create a separate PR that implements the section cards to avoid this PR becoming too large.