### PR TITLE
Bugfix: Created and Updated dates for fresh and imported experiments-ff-segments

### DIFF
--- a/backend/packages/Upgrade/src/api/DTO/ExperimentDTO.ts
+++ b/backend/packages/Upgrade/src/api/DTO/ExperimentDTO.ts
@@ -465,7 +465,7 @@ abstract class BaseExperimentWithoutPayload {
   public type: EXPERIMENT_TYPE;
 }
 
-const isMoocletAssigmentAlgorithm = (experiment: ExperimentDTO) =>
+const isMoocletAssignmentAlgorithm = (experiment: ExperimentDTO) =>
   experiment.assignmentAlgorithm && SUPPORTED_MOOCLET_ALGORITHMS.includes(experiment.assignmentAlgorithm);
 
 export class ExperimentDTO extends BaseExperimentWithoutPayload {
@@ -476,7 +476,7 @@ export class ExperimentDTO extends BaseExperimentWithoutPayload {
   public conditionPayloads?: ConditionPayloadValidator[];
 
   // This should be validated when assignmentAlgorithm is not RANDOM or STRATIFIED_RANDOM_SAMPLING
-  @ValidateIf(isMoocletAssigmentAlgorithm)
+  @ValidateIf(isMoocletAssignmentAlgorithm)
   @IsDefined()
   @ValidateNested()
   @Type(() => MoocletPolicyParametersDTO, {
@@ -491,7 +491,7 @@ export class ExperimentDTO extends BaseExperimentWithoutPayload {
   })
   public moocletPolicyParameters?: MoocletPolicyParametersDTO;
 
-  @ValidateIf(isMoocletAssigmentAlgorithm)
+  @ValidateIf(isMoocletAssignmentAlgorithm)
   @IsDefined()
   public rewardMetricKey?: string;
 }

--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -1623,7 +1623,7 @@ export class ExperimentService {
     experiment.id = uuid();
     // delete createdAt date to let typeorm handle it and initialize versionNumber as fresh experiment version to detect updates
     delete experiment.createdAt;
-    experiment.versionNumber = 1;
+    delete experiment.versionNumber;
     this.deduceFactors(experiment);
     this.deduceConditions(experiment);
     this.deducePartition(experiment);

--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -1619,8 +1619,11 @@ export class ExperimentService {
     return errorString;
   }
 
-  private deduceExperimentDetails(experiment: ExperimentDTO): ExperimentDTO {
+  private deduceExperimentDetails(experiment: Experiment): Experiment {
     experiment.id = uuid();
+    // set current createdAt date and initialize versionNumber as fresh experiment version to detect updates
+    experiment.createdAt = new Date();
+    experiment.versionNumber = 1;
     this.deduceFactors(experiment);
     this.deduceConditions(experiment);
     this.deducePartition(experiment);

--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -1621,8 +1621,8 @@ export class ExperimentService {
 
   private deduceExperimentDetails(experiment: Experiment): Experiment {
     experiment.id = uuid();
-    // set current createdAt date and initialize versionNumber as fresh experiment version to detect updates
-    experiment.createdAt = new Date();
+    // delete createdAt date to let typeorm handle it and initialize versionNumber as fresh experiment version to detect updates
+    delete experiment.createdAt;
     experiment.versionNumber = 1;
     this.deduceFactors(experiment);
     this.deduceConditions(experiment);

--- a/frontend/projects/upgrade/src/app/features/auth/login/login.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/auth/login/login.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { LoginComponent } from './login.component';
 import { TestingModule } from '../../../../testing/testing.module';
@@ -9,7 +9,7 @@ xdescribe('LoginComponent', () => {
   let component: LoginComponent;
   let fixture: ComponentFixture<LoginComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [LoginComponent],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/dashboard-root/dashboard-root.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/dashboard-root/dashboard-root.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { DashboardRootComponent } from './dashboard-root.component';
 import { TestingModule } from '../../../../testing/testing.module';
@@ -9,7 +9,7 @@ xdescribe('DashboardRootComponent', () => {
   let component: DashboardRootComponent;
   let fixture: ComponentFixture<DashboardRootComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [DashboardRootComponent],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiment-users/components/experiment-users/experiment-users.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiment-users/components/experiment-users/experiment-users.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ExperimentUsersComponent } from './experiment-users.component';
 import { TestingModule } from '../../../../../../testing/testing.module';
@@ -10,7 +10,7 @@ xdescribe('ExperimentUsersComponent', () => {
   let component: ExperimentUsersComponent;
   let fixture: ComponentFixture<ExperimentUsersComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ExperimentUsersComponent],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiment-users/components/preview-user/preview-user.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiment-users/components/preview-user/preview-user.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PreviewUserComponent } from './preview-user.component';
 import { TestingModule } from '../../../../../../testing/testing.module';
@@ -10,7 +10,7 @@ xdescribe('PreviewUserComponent', () => {
   let component: PreviewUserComponent;
   let fixture: ComponentFixture<PreviewUserComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [PreviewUserComponent],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiment-users/experiment-users-root/experiment-users-root.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiment-users/experiment-users-root/experiment-users-root.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ExperimentUsersRootComponent } from './experiment-users-root.component';
 import { TestingModule } from '../../../../../testing/testing.module';
@@ -13,7 +13,7 @@ xdescribe('UserRootComponent', () => {
   let component: ExperimentUsersRootComponent;
   let fixture: ComponentFixture<ExperimentUsersRootComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ExperimentUsersRootComponent, ExperimentUsersComponent, PreviewUserComponent],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-overview-details-section-card/feature-flag-overview-details-section-card.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-overview-details-section-card/feature-flag-overview-details-section-card.component.html
@@ -5,6 +5,7 @@
     [title]="flag.name"
     [createdAt]="flag.createdAt"
     [updatedAt]="flag.updatedAt"
+    [versionNumber]="flag.versionNumber"
     [chipClass]="flag.status"
     [showWarning]="shouldShowWarning$ | async"
   ></app-common-section-card-title-header>

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.html
@@ -54,7 +54,12 @@
         {{ FLAG_TRANSLATION_KEYS.UPDATED_AT | translate }}
       </th>
       <td mat-cell *matCellDef="let flag" class="updated-at-column ft-14-400">
-        {{ flag.updatedAt | date : 'MMM d, y h:mm a' }}
+        <ng-container *ngIf="flag.versionNumber === 1; else displayUpdatedAt">
+          {{ '-' }}
+        </ng-container>
+        <ng-template #displayUpdatedAt>
+          {{ flag.updatedAt | date : 'MMM d, y h:mm a' }}
+        </ng-template>
       </td>
     </ng-container>
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/create-query/create-query.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/create-query/create-query.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CreateQueryComponent } from './create-query.component';
 import { TestingModule } from '../../../../../../testing/testing.module';
@@ -9,7 +9,7 @@ xdescribe('CreateQueryComponent', () => {
   let component: CreateQueryComponent;
   let fixture: ComponentFixture<CreateQueryComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [CreateQueryComponent],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/enrollment-condition-table/enrollment-condition-table.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/enrollment-condition-table/enrollment-condition-table.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { EnrollmentConditionTableComponent } from './enrollment-condition-table.component';
 import { TestingModule } from '../../../../../../testing/testing.module';
@@ -9,7 +9,7 @@ xdescribe('EnrollmentConditionTableComponent', () => {
   let component: EnrollmentConditionTableComponent;
   let fixture: ComponentFixture<EnrollmentConditionTableComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [EnrollmentConditionTableComponent, TableRowComponent, EnrollmentPointPartitionTableComponent],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/enrollment-over-time/enrollment-over-time.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/enrollment-over-time/enrollment-over-time.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { EnrollmentOverTimeComponent } from './enrollment-over-time.component';
 import { TestingModule } from '../../../../../../testing/testing.module';
@@ -9,7 +9,7 @@ xdescribe('EnrollmentOverTimeComponent', () => {
   let component: EnrollmentOverTimeComponent;
   let fixture: ComponentFixture<EnrollmentOverTimeComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [EnrollmentOverTimeComponent],
       imports: [TestingModule, NgxChartsModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/enrollment-point-partition-table/enrollment-point-partition-table.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/enrollment-point-partition-table/enrollment-point-partition-table.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { EnrollmentPointPartitionTableComponent } from './enrollment-point-partition-table.component';
 import { TestingModule } from '../../../../../../testing/testing.module';
@@ -8,7 +8,7 @@ xdescribe('EnrollmentPointPartitionTableComponent', () => {
   let component: EnrollmentPointPartitionTableComponent;
   let fixture: ComponentFixture<EnrollmentPointPartitionTableComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [EnrollmentPointPartitionTableComponent, TableRowComponent],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-design/experiment-design.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ExperimentDesignComponent } from './experiment-design.component';
 import { TestingModule } from '../../../../../../testing/testing.module';
@@ -8,7 +8,7 @@ xdescribe('ExperimentDesignComponent', () => {
   let component: ExperimentDesignComponent;
   let fixture: ComponentFixture<ExperimentDesignComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ExperimentDesignComponent],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-list/experiment-list.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-list/experiment-list.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ExperimentListComponent } from './experiment-list.component';
 import { TestingModule } from '../../../../../../testing/testing.module';
@@ -11,7 +11,7 @@ xdescribe('ExperimentListComponent', () => {
   let component: ExperimentListComponent;
   let fixture: ComponentFixture<ExperimentListComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ExperimentListComponent],
       imports: [TestingModule, NgxSkeletonLoaderModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ExperimentOverviewComponent } from './experiment-overview.component';
 import { TestingModule } from '../../../../../../testing/testing.module';
@@ -8,7 +8,7 @@ xdescribe('ExperimentOverviewComponent', () => {
   let component: ExperimentOverviewComponent;
   let fixture: ComponentFixture<ExperimentOverviewComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ExperimentOverviewComponent],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-participants/experiment-participants.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-participants/experiment-participants.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ExperimentParticipantsComponent } from './experiment-participants.component';
 
@@ -6,7 +6,7 @@ xdescribe('ExperimentParticipantsComponent', () => {
   let component: ExperimentParticipantsComponent;
   let fixture: ComponentFixture<ExperimentParticipantsComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ExperimentParticipantsComponent],
     }).compileComponents();

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-post-condition/experiment-post-condition.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-post-condition/experiment-post-condition.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ExperimentPostConditionComponent } from './experiment-post-condition.component';
 import { TestingModule } from '../../../../../../testing/testing.module';
@@ -7,7 +7,7 @@ xdescribe('ExperimentPostConditionComponent', () => {
   let component: ExperimentPostConditionComponent;
   let fixture: ComponentFixture<ExperimentPostConditionComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ExperimentPostConditionComponent],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-query-result/experiment-query-result.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-query-result/experiment-query-result.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ExperimentQueryResultComponent } from './experiment-query-result.component';
 import { TestingModule } from '../../../../../../testing/testing.module';
@@ -10,7 +10,7 @@ xdescribe('ExperimentQueryResultComponent', () => {
   let component: ExperimentQueryResultComponent;
   let fixture: ComponentFixture<ExperimentQueryResultComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ExperimentQueryResultComponent],
       imports: [TestingModule, NgxChartsModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-schedule/experiment-schedule.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-schedule/experiment-schedule.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ExperimentScheduleComponent } from './experiment-schedule.component';
 import { TestingModule } from '../../../../../../testing/testing.module';
@@ -8,7 +8,7 @@ xdescribe('ExperimentScheduleComponent', () => {
   let component: ExperimentScheduleComponent;
   let fixture: ComponentFixture<ExperimentScheduleComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ExperimentScheduleComponent],
       imports: [TestingModule, OwlDateTimeModule, OwlNativeDateTimeModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MonitoredMetricsComponent } from './metrics.component';
 import { TestingModule } from '../../../../../../testing/testing.module';
@@ -8,7 +8,7 @@ xdescribe('ExperimentDesignComponent', () => {
   let component: MonitoredMetricsComponent;
   let fixture: ComponentFixture<MonitoredMetricsComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [MonitoredMetricsComponent],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/experiment-end-criteria/experiment-end-criteria.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/experiment-end-criteria/experiment-end-criteria.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ExperimentEndCriteriaComponent } from './experiment-end-criteria.component';
 import { TestingModule } from '../../../../../../../testing/testing.module';
@@ -14,7 +14,7 @@ xdescribe('ExperimentEndCriteriaComponent', () => {
   const modalData = {
     experiment: TestMockData.getExperiment()[0],
   };
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ExperimentEndCriteriaComponent],
       imports: [TestingModule, OwlDateTimeModule, OwlNativeDateTimeModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/experiment-status/experiment-status.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/experiment-status/experiment-status.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ExperimentStatusComponent } from './experiment-status.component';
 import { TestingModule } from '../../../../../../../testing/testing.module';
@@ -14,7 +14,7 @@ xdescribe('ExperimentStatusComponent', () => {
   const modalData = {
     experiment: TestMockData.getExperiment()[0],
   };
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ExperimentStatusComponent],
       imports: [TestingModule, OwlDateTimeModule, OwlNativeDateTimeModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/export-experiment/export-experiment.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/export-experiment/export-experiment.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogRef } from '@angular/material/dialog';
 import { TestingModule } from '../../../../../../../testing/testing.module';
 import { ExportModalComponent } from './export-experiment.component';
@@ -7,7 +7,7 @@ xdescribe('ExportModalComponent', () => {
   let component: ExportModalComponent;
   let fixture: ComponentFixture<ExportModalComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/import-experiment/import-experiment.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/import-experiment/import-experiment.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ImportExperimentComponent } from './import-experiment.component';
 import { TestingModule } from '../../../../../../../testing/testing.module';
@@ -9,7 +9,7 @@ xdescribe('ImportExperimentComponent', () => {
   let component: ImportExperimentComponent;
   let fixture: ComponentFixture<ImportExperimentComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ImportExperimentComponent],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/new-experiment/new-experiment.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/new-experiment/new-experiment.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { NewExperimentComponent } from './new-experiment.component';
 import { TestingModule } from '../../../../../../../testing/testing.module';
@@ -14,7 +14,7 @@ xdescribe('NewExperimentComponent', () => {
   let component: NewExperimentComponent;
   let fixture: ComponentFixture<NewExperimentComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [
         NewExperimentComponent,

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/post-experiment-rule/post-experiment-rule.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/post-experiment-rule/post-experiment-rule.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PostExperimentRuleComponent } from './post-experiment-rule.component';
 import { TestingModule } from '../../../../../../../testing/testing.module';
@@ -13,7 +13,7 @@ xdescribe('PostExperimentRuleComponent', () => {
   const modalData = {
     experiment: TestMockData.getExperiment()[0],
   };
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [PostExperimentRuleComponent],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/queries-modal/queries-modal.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/queries-modal/queries-modal.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { QueriesModalComponent } from './queries-modal.component';
 import { TestingModule } from '../../../../../../../testing/testing.module';
@@ -10,7 +10,7 @@ xdescribe('QueriesModalComponent', () => {
   let component: QueriesModalComponent;
   let fixture: ComponentFixture<QueriesModalComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [QueriesModalComponent, CreateQueryComponent],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/state-time-logs/state-time-logs.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/state-time-logs/state-time-logs.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { TestingModule } from '../../../../../../../testing/testing.module';
 
@@ -8,7 +8,7 @@ xdescribe('StateTimeLogsComponent', () => {
   let component: StateTimeLogsComponent;
   let fixture: ComponentFixture<StateTimeLogsComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [StateTimeLogsComponent],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/table-row/table-row.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/table-row/table-row.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TableRowComponent } from './table-row.component';
 import { TestingModule } from '../../../../../../testing/testing.module';
@@ -8,7 +8,7 @@ xdescribe('TableRowComponent', () => {
   let component: TableRowComponent;
   let fixture: ComponentFixture<TableRowComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [TableRowComponent, EnrollmentPointPartitionTableComponent],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
@@ -59,16 +59,22 @@
         <span class="ft-32-700 experiment-overview-dates">
           <span class="ft-14-700 experiment-overview-create-date">
             {{
-              ('home.view-experiment.created-on.text' | translate) + (experiment.createdAt | formatDate : 'medium date')
+              ('home.view-experiment.created-on.text' | translate) + (experiment.createdAt | formatDate : 'short date')
             }}
           </span>
-
-          <span class="ft-14-700 experiment-overview-last-update-date">
+          <span class="ft-14-700 experiment-overview-last-update-date" *ngIf="experiment.versionNumber === 1; else displayUpdatedAt">
             {{
-              ('home.view-experiment.last-updated-on.text' | translate) +
-                (experiment.updatedAt | formatDate : 'medium date')
+              ('home.view-experiment.last-updated-on.text' | translate) + ' -'
             }}
           </span>
+          <ng-template #displayUpdatedAt>
+            <span class="ft-14-700 experiment-overview-last-update-date">
+              {{
+                ('home.view-experiment.last-updated-on.text' | translate) +
+                  (experiment.updatedAt | formatDate : 'short date')
+              }}
+            </span>
+          </ng-template>
         </span>
 
         <!-- <div class="action-buttons">

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ViewExperimentComponent } from './view-experiment.component';
 import { TestingModule } from '../../../../../../testing/testing.module';
@@ -15,7 +15,7 @@ xdescribe('ViewExperimentComponent', () => {
   let component: ViewExperimentComponent;
   let fixture: ComponentFixture<ViewExperimentComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [
         ViewExperimentComponent,

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/root/home.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/root/home.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HomeComponent } from './home.component';
 import { TestingModule } from '../../../../../testing/testing.module';
@@ -11,7 +11,7 @@ xdescribe('HomeComponent', () => {
   let component: HomeComponent;
   let fixture: ComponentFixture<HomeComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [HomeComponent, ExperimentListComponent],
       imports: [TestingModule, NgxSkeletonLoaderModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/logs/components/audit-logs/audit-logs.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/logs/components/audit-logs/audit-logs.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AuditLogsComponent } from './audit-logs.component';
 import { TestingModule } from '../../../../../../testing/testing.module';
@@ -13,7 +13,7 @@ xdescribe('AuditLogsComponent', () => {
   let component: AuditLogsComponent;
   let fixture: ComponentFixture<AuditLogsComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [AuditLogsComponent, TimelineComponent, LogDateFormatPipe, ErrorLogPipe, ExperimentActionMessage],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/logs/components/error-logs/error-logs.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/logs/components/error-logs/error-logs.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ErrorLogsComponent } from './error-logs.component';
 import { TestingModule } from '../../../../../../testing/testing.module';
@@ -13,7 +13,7 @@ xdescribe('ErrorLogsComponent', () => {
   let component: ErrorLogsComponent;
   let fixture: ComponentFixture<ErrorLogsComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ErrorLogsComponent, TimelineComponent, LogDateFormatPipe, ErrorLogPipe, ExperimentActionMessage],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/logs/components/timeline/timeline.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/logs/components/timeline/timeline.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TimelineComponent } from './timeline.component';
 import { TestingModule } from '../../../../../../testing/testing.module';
@@ -9,7 +9,7 @@ xdescribe('TimelineComponent', () => {
   let component: TimelineComponent;
   let fixture: ComponentFixture<TimelineComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [TimelineComponent, ErrorLogPipe, ExperimentActionMessage],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/logs/root/logs.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/logs/root/logs.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { LogsComponent } from './logs.component';
 import { TestingModule } from '../../../../../testing/testing.module';
@@ -15,7 +15,7 @@ xdescribe('LogsComponent', () => {
   let component: LogsComponent;
   let fixture: ComponentFixture<LogsComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [
         LogsComponent,

--- a/frontend/projects/upgrade/src/app/features/dashboard/profile/components/metrics/metrics.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/profile/components/metrics/metrics.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MetricsComponent } from './metrics.component';
 import { TestingModule } from '../../../../../../testing/testing.module';
@@ -9,7 +9,7 @@ xdescribe('MetricsComponent', () => {
   let component: MetricsComponent;
   let fixture: ComponentFixture<MetricsComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [MetricsComponent],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/profile/components/modals/add-metrics/add-metrics.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/profile/components/modals/add-metrics/add-metrics.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AddMetricsComponent } from './add-metrics.component';
 import { TestingModule } from '../../../../../../../testing/testing.module';
@@ -10,7 +10,7 @@ xdescribe('AddMetricsComponent', () => {
   let component: AddMetricsComponent;
   let fixture: ComponentFixture<AddMetricsComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [AddMetricsComponent],
       imports: [TestingModule, NgJsonEditorModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/profile/components/modals/new-user/new-user.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/profile/components/modals/new-user/new-user.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { NewUserComponent } from './new-user.component';
 import { TestingModule } from '../../../../../../../testing/testing.module';
@@ -9,7 +9,7 @@ xdescribe('NewUserComponent', () => {
   let component: NewUserComponent;
   let fixture: ComponentFixture<NewUserComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [NewUserComponent],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/profile/components/profile-info/profile-info.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/profile/components/profile-info/profile-info.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ProfileInfoComponent } from './profile-info.component';
 import { TestingModule } from '../../../../../../testing/testing.module';
@@ -10,7 +10,7 @@ xdescribe('ProfileInfoComponent', () => {
   let component: ProfileInfoComponent;
   let fixture: ComponentFixture<ProfileInfoComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ProfileInfoComponent],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/profile/profile-root/profile-root.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/profile/profile-root/profile-root.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ProfileRootComponent } from './profile-root.component';
 import { TestingModule } from '../../../../../testing/testing.module';
@@ -13,7 +13,7 @@ xdescribe('ProfileRootComponent', () => {
   let component: ProfileRootComponent;
   let fixture: ComponentFixture<ProfileRootComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ProfileRootComponent, ProfileInfoComponent, MetricsComponent],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/components/modal/duplicate-segment/duplicate-segment.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/components/modal/duplicate-segment/duplicate-segment.component.spec.ts
@@ -1,11 +1,11 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { DuplicateSegmentComponent } from './duplicate-segment.component';
 
 xdescribe('DuplicateSegmentComponent', () => {
   let component: DuplicateSegmentComponent;
   let fixture: ComponentFixture<DuplicateSegmentComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [DuplicateSegmentComponent],
     }).compileComponents();

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/components/modal/import-segment/import-segment.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/components/modal/import-segment/import-segment.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ImportSegmentComponent } from './import-segment.component';
 import { TestingModule } from '../../../../../../../testing/testing.module';
 import { SegmentsService } from '../../../../../../core/segments/segments.service';
@@ -8,7 +8,7 @@ xdescribe('ImportSegmentComponent', () => {
   let component: ImportSegmentComponent;
   let fixture: ComponentFixture<ImportSegmentComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ImportSegmentComponent],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/components/modal/new-segment/new-segment.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/components/modal/new-segment/new-segment.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NewSegmentComponent } from './new-segment.component';
 import { TestingModule } from '../../../../../../../testing/testing.module';
 import { SegmentsService } from '../../../../../../core/segments/segments.service';
@@ -10,7 +10,7 @@ xdescribe('NewSegmentComponent', () => {
   let component: NewSegmentComponent;
   let fixture: ComponentFixture<NewSegmentComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [NewSegmentComponent, SegmentOverviewComponent, SegmentMembersComponent],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/components/modal/segment-experiment-list/segment-experiment-list.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/components/modal/segment-experiment-list/segment-experiment-list.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SegmentExperimentListComponent } from './segment-experiment-list.component';
 
@@ -6,7 +6,7 @@ xdescribe('SegmentExperimentListComponent', () => {
   let component: SegmentExperimentListComponent;
   let fixture: ComponentFixture<SegmentExperimentListComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [SegmentExperimentListComponent],
     }).compileComponents();

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/components/segment-members/segment-members.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/components/segment-members/segment-members.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { SegmentMembersComponent } from './segment-members.component';
 import { TestingModule } from '../../../../../../testing/testing.module';
 import { SegmentsService } from '../../../../../core/segments/segments.service';
@@ -7,7 +7,7 @@ xdescribe('SegmentMembersComponent', () => {
   let component: SegmentMembersComponent;
   let fixture: ComponentFixture<SegmentMembersComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [SegmentMembersComponent],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/components/segment-overview/segment-overview.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/components/segment-overview/segment-overview.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SegmentOverviewComponent } from './segment-overview.component';
 import { TestingModule } from '../../../../../../testing/testing.module';
@@ -8,7 +8,7 @@ xdescribe('SegmentOverviewComponent', () => {
   let component: SegmentOverviewComponent;
   let fixture: ComponentFixture<SegmentOverviewComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [SegmentOverviewComponent],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/components/segments-list/segments-list.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/components/segments-list/segments-list.component.html
@@ -124,7 +124,12 @@
           </span>
         </th>
         <td class="ft-12-600" mat-cell *matCellDef="let segment">
-          <span> {{ segment.updatedAt | date : 'MMM d, y h:mm a' }} </span>
+          <ng-container *ngIf="segment.versionNumber === 1; else displayUpdatedAt">
+            {{ '-' }}
+          </ng-container>
+          <ng-template #displayUpdatedAt>
+            <span> {{ segment.updatedAt | date : 'MMM d, y h:mm a' }} </span>
+          </ng-template>
         </td>
       </ng-container>
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/components/segments-list/segments-list.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/components/segments-list/segments-list.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { SegmentsListComponent } from './segments-list.component';
 import { TestingModule } from '../../../../../../testing/testing.module';
 import { SegmentsService } from '../../../../../core/segments/segments.service';
@@ -8,7 +8,7 @@ xdescribe('SegmentsListComponent', () => {
   let component: SegmentsListComponent;
   let fixture: ComponentFixture<SegmentsListComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [SegmentsListComponent],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/pages/view-segment/view-segment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/pages/view-segment/view-segment.component.html
@@ -56,13 +56,20 @@
         </div>
       </div>
       <span class="ft-14-700 segment-create-date">
-        {{ ('home.view-experiment.created-on.text' | translate) + (segment.createdAt | formatDate : 'medium date') }}
+        {{ ('home.view-experiment.created-on.text' | translate) + (segment.createdAt | formatDate : 'short date') }}
       </span>
-      <span class="ft-14-700 segment-update-date">
+      <span class="ft-14-700 segment-update-date" *ngIf="segment.versionNumber === 1; else displayUpdatedAt">
         {{
-          ('home.view-experiment.last-updated-on.text' | translate) + (segment.updatedAt | formatDate : 'medium date')
+          ('home.view-experiment.last-updated-on.text' | translate) + ' -'
         }}
       </span>
+      <ng-template #displayUpdatedAt>
+        <span class="ft-14-700 segment-update-date">
+          {{
+            ('home.view-experiment.last-updated-on.text' | translate) + (segment.updatedAt | formatDate : 'short date')
+          }}
+        </span>
+      </ng-template>
     </div>
 
     <div class="segment-secondary-info">

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/pages/view-segment/view-segment.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/pages/view-segment/view-segment.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ViewSegmentComponent } from './view-segment.component';
 import { TestingModule } from '../../../../../../testing/testing.module';
 import { SegmentsService } from '../../../../../core/segments/segments.service';
@@ -8,7 +8,7 @@ xdescribe('ViewSegmentComponent', () => {
   let component: ViewSegmentComponent;
   let fixture: ComponentFixture<ViewSegmentComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ViewSegmentComponent],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/segments-root/segments-root.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/segments-root/segments-root.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { SegmentsRootComponent } from './segments-root.component';
 import { TestingModule } from '../../../../../testing/testing.module';
 import { SegmentsListComponent } from '../components/segments-list/segments-list.component';
@@ -9,7 +9,7 @@ xdescribe('SegmentsRootComponent', () => {
   let component: SegmentsRootComponent;
   let fixture: ComponentFixture<SegmentsRootComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [SegmentsRootComponent, SegmentsListComponent],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-title-header/common-section-card-title-header.component.html
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-title-header/common-section-card-title-header.component.html
@@ -17,11 +17,16 @@
     </ng-container>
     <ng-container *ngIf="createdAt && updatedAt">
       <span class="ft-14-400">
-        {{ ('feature-flags.details-created-on.text' | translate) + (createdAt | formatDate : 'medium date') + ' | ' }}
+        {{ ('feature-flags.details-created-on.text' | translate) + (createdAt | formatDate : 'short date') + ' | ' }}
       </span>
-      <span class="ft-14-400">
-        {{ ('feature-flags.details-updated-at.text' | translate) + (updatedAt | formatDate : 'short date') + '.' }}
+      <span class="ft-14-400" *ngIf="versionNumber === 1; else displayUpdatedAt">
+        {{ ('feature-flags.details-updated-at.text' | translate) + ' -' }}
       </span>
+      <ng-template #displayUpdatedAt>
+        <span class="ft-14-400">
+          {{ ('feature-flags.details-updated-at.text' | translate) + (updatedAt | formatDate : 'short date') + '.' }}
+        </span>
+      </ng-template>
     </ng-container>
   </p>
 </div>

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-title-header/common-section-card-title-header.component.ts
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-title-header/common-section-card-title-header.component.ts
@@ -39,6 +39,7 @@ export class CommonSectionCardTitleHeaderComponent {
   @Input() subtitle?: string;
   @Input() createdAt?: string;
   @Input() updatedAt?: string;
+  @Input() versionNumber?: number;
   @Input() chipClass?: STATUS_INDICATOR_CHIP_TYPE;
   @Input() showWarning?: boolean;
 }

--- a/frontend/projects/upgrade/src/app/shared/components/delete/delete.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/shared/components/delete/delete.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogRef } from '@angular/material/dialog';
 import { TestingModule } from '../../../../testing/testing.module';
 import { DeleteComponent } from './delete.component';
@@ -7,7 +7,7 @@ xdescribe('DeleteComponent', () => {
   let component: DeleteComponent;
   let fixture: ComponentFixture<DeleteComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/shared/components/query-result/query-result.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/shared/components/query-result/query-result.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { QueryResultComponent } from './query-result.component';
 import { TestingModule } from '../../../../testing/testing.module';
@@ -13,7 +13,7 @@ xdescribe('QueryResultComponent', () => {
   const modalData = {
     query: TestMockData.getQuery()[0],
   };
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [],
       imports: [TestingModule],

--- a/frontend/projects/upgrade/src/app/shared/components/shared-icons/shared-icons.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/shared/components/shared-icons/shared-icons.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SharedIconsComponent } from './shared-icons.component';
 import { TestingModule } from '../../../../testing/testing.module';
@@ -7,7 +7,7 @@ xdescribe('SharedIconsComponent', () => {
   let component: SharedIconsComponent;
   let fixture: ComponentFixture<SharedIconsComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [],
       imports: [TestingModule],


### PR DESCRIPTION
This PR resolves #2213 

It will resolve the below things:

1. The created date for the imported experiment/feature-flag/segment will have the current created date instead of old date as per the design JSON.
2. The updated date for the imported and freshly created experiment/feature-flag/segment will have a blank (-) date as they are freshly created and not updated yet. Below are attached screenshot for the same.
3. Once we update the experiment/feature-flag/segment, we will store the updated date and update the `versionNumber` for these tables and based on the `versionNumber`, we will show the updated on date.
4. Added date-time for experiments and segments details page as in feature-flags pages' updated-date field for uniformity and it helps differentiate the created and updated times, else we just show dates which can be same for the same date. (Let me know in case this is not intended)
5. Replaced the `async` import from frontend tests as its deprecated from `@angular/core/testing` after angular update. We need to use `waitForAsync` instead. Please find attached screenshot.
6. Updated a spelling error for the `isMoocletAssignmentAlgorithm` in ExperimentDTO.

<img width="714" alt="Screenshot 2025-03-19 at 2 47 20 PM" src="https://github.com/user-attachments/assets/d23aa349-1ce5-4692-8569-780da152d6a9" />


Blank updated dates for freshly created or imported segments:

<img width="1023" alt="Screenshot 2025-03-19 at 5 24 50 PM" src="https://github.com/user-attachments/assets/529af46f-b99d-4c7d-9eed-de8407bed5b8" />

Complete date-time for created at as well, earlier we had date-time for only updated-at in Feature-Flag:

<img width="513" alt="Screenshot 2025-03-18 at 7 10 33 PM" src="https://github.com/user-attachments/assets/51d278f6-074c-4a08-95ab-f3e5f7c917a5" />

