### PR TITLE
Feature/java client apache connector

### DIFF
--- a/clientlibs/java/pom.xml
+++ b/clientlibs/java/pom.xml
@@ -9,7 +9,7 @@
 		at the same time that happen to rev to the same new version will be caught 
 		by a merge conflict. -->
 
-	<version>6.1.0</version>
+	<version>6.1.1</version>
 	<build>
 		<plugins>
 			<plugin>
@@ -20,10 +20,10 @@
 		</plugins>
 	</build>
 	<properties>
-		<jersey.version>2.16</jersey.version>
+		<jersey.version>2.30.1</jersey.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
 	</properties>
 	<dependencies>
 		<!-- https://mvnrepository.com/artifact/org.testng/testng -->

--- a/clientlibs/java/pom.xml
+++ b/clientlibs/java/pom.xml
@@ -53,6 +53,11 @@
 			<artifactId>jersey-hk2</artifactId>
 			<version>2.30.1</version>
 		</dependency>
+		<dependency>
+            <groupId>org.glassfish.jersey.connectors</groupId>
+            <artifactId>jersey-apache-connector</artifactId>
+            <version>2.30.1</version>
+        </dependency>
 
 		<!-- https://mvnrepository.com/artifact/io.vavr/vavr -->
 		<dependency>

--- a/clientlibs/java/pom.xml
+++ b/clientlibs/java/pom.xml
@@ -9,7 +9,7 @@
 		at the same time that happen to rev to the same new version will be caught 
 		by a merge conflict. -->
 
-	<version>6.1.1</version>
+	<version>6.1.1</version> <!-- 6.1.1: switch to jersey-apache-connector -->  
 	<build>
 		<plugins>
 			<plugin>
@@ -22,8 +22,7 @@
 	<properties>
 		<jersey.version>2.30.1</jersey.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.release>17</maven.compiler.release>
 	</properties>
 	<dependencies>
 		<!-- https://mvnrepository.com/artifact/org.testng/testng -->

--- a/clientlibs/java/src/main/java/org/upgradeplatform/utils/APIService.java
+++ b/clientlibs/java/src/main/java/org/upgradeplatform/utils/APIService.java
@@ -12,6 +12,8 @@ import javax.ws.rs.core.MediaType;
 
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.HttpUrlConnectorProvider;
+import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
+import org.glassfish.jersey.client.ClientConfig;
 
 
 public class APIService implements AutoCloseable{
@@ -39,7 +41,7 @@ public class APIService implements AutoCloseable{
 	}
 
 	public static Client createClient(Map<String,Object> properties) {
-		Client client = ClientBuilder.newClient();
+		Client client = ClientBuilder.newClient(new ClientConfig().connectorProvider(new ApacheConnectorProvider()));
 		client.property(ClientProperties.CONNECT_TIMEOUT, 3000);
 		client.property(ClientProperties.READ_TIMEOUT,    3000);
 		properties.entrySet().stream()


### PR DESCRIPTION
Smoke test of this worked for me testing with the `QuickTest.java` file (formerly Main.java). I installed JDK 17 on my local, and then when I target 17 here in properties for the jersey client instead of 8 I was able to replicate the PATCH error. After installing the updated dependency for apache connector as it was in the PR from years back, the error went away.

```
<properties>
		<jersey.version>2.30.1</jersey.version>
		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
		<maven.compiler.source>17</maven.compiler.source>
		<maven.compiler.target>17</maven.compiler.target>
	</properties>
```

Let me know what else we should consider to test, and if there are other deps we should go ahead and update alongside of this let's go ahead.