### PR TITLE
Add paginated and global endpoints for segments

### DIFF
--- a/backend/packages/Upgrade/src/api/controllers/validators/SegmentPaginatedParamsValidator.ts
+++ b/backend/packages/Upgrade/src/api/controllers/validators/SegmentPaginatedParamsValidator.ts
@@ -55,10 +55,10 @@ export class SegmentPaginatedParamsValidator {
   @IsOptional()
   @ValidateNested()
   @Type(() => ISegmentSearchParamsValidator)
-  public searchParams: ISegmentSearchParamsValidator;
+  public searchParams?: ISegmentSearchParamsValidator;
 
   @IsOptional()
   @ValidateNested()
   @Type(() => ISegmentSortParamsValidator)
-  public sortParams: ISegmentSortParamsValidator;
+  public sortParams?: ISegmentSortParamsValidator;
 }

--- a/backend/packages/Upgrade/src/api/controllers/validators/SegmentPaginatedParamsValidator.ts
+++ b/backend/packages/Upgrade/src/api/controllers/validators/SegmentPaginatedParamsValidator.ts
@@ -1,0 +1,64 @@
+import { Type } from 'class-transformer';
+import { IsNotEmpty, IsNumber, IsOptional, ValidateNested, IsEnum, IsString } from 'class-validator';
+import { SORT_AS_DIRECTION } from 'upgrade_types';
+
+// TODO: Move to upgrade types
+export interface ISegmentSearchParams {
+  key: SEGMENT_SEARCH_KEY;
+  string: string;
+}
+export interface ISegmentSortParams {
+  key: SEGMENT_SORT_KEY;
+  sortAs: SORT_AS_DIRECTION;
+}
+
+export enum SEGMENT_SORT_KEY {
+  NAME = 'name',
+  LAST_UPDATE = 'updatedAt',
+}
+
+export enum SEGMENT_SEARCH_KEY {
+  ALL = 'all',
+  NAME = 'name',
+  TAG = 'tag',
+  CONTEXT = 'context',
+}
+
+class ISegmentSortParamsValidator {
+  @IsNotEmpty()
+  @IsEnum(SEGMENT_SORT_KEY)
+  key: SEGMENT_SORT_KEY;
+
+  @IsNotEmpty()
+  @IsEnum(SORT_AS_DIRECTION)
+  sortAs: SORT_AS_DIRECTION;
+}
+
+class ISegmentSearchParamsValidator {
+  @IsNotEmpty()
+  @IsEnum(SEGMENT_SEARCH_KEY)
+  key: SEGMENT_SEARCH_KEY;
+
+  @IsNotEmpty()
+  @IsString()
+  string: string;
+}
+export class SegmentPaginatedParamsValidator {
+  @IsNotEmpty()
+  @IsNumber()
+  public skip: number;
+
+  @IsNotEmpty()
+  @IsNumber()
+  public take: number;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ISegmentSearchParamsValidator)
+  public searchParams: ISegmentSearchParamsValidator;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ISegmentSortParamsValidator)
+  public sortParams: ISegmentSortParamsValidator;
+}

--- a/backend/packages/Upgrade/src/api/models/Segment.ts
+++ b/backend/packages/Upgrade/src/api/models/Segment.ts
@@ -38,7 +38,7 @@ export class Segment extends BaseModel {
   public type: SEGMENT_TYPE;
 
   @Column('text', { array: true, nullable: true })
-  public tags: string[];
+  public tags?: string[];
 
   @OneToMany(() => IndividualForSegment, (individualForSegment) => individualForSegment.segment)
   @Type(() => IndividualForSegment)

--- a/backend/packages/Upgrade/src/api/models/Segment.ts
+++ b/backend/packages/Upgrade/src/api/models/Segment.ts
@@ -37,6 +37,9 @@ export class Segment extends BaseModel {
   })
   public type: SEGMENT_TYPE;
 
+  @Column('text', { array: true, nullable: true })
+  public tags: string[];
+
   @OneToMany(() => IndividualForSegment, (individualForSegment) => individualForSegment.segment)
   @Type(() => IndividualForSegment)
   public individualForSegment: IndividualForSegment[];

--- a/backend/packages/Upgrade/src/database/migrations/1742503415937-addTagsToSegment.ts
+++ b/backend/packages/Upgrade/src/database/migrations/1742503415937-addTagsToSegment.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddTagsToSegment1742503415937 implements MigrationInterface {
+  name = 'AddTagsToSegment1742503415937';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "segment" ADD "tags" text array`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "segment" DROP COLUMN "tags"`);
+  }
+}

--- a/backend/packages/Upgrade/test/unit/services/SegmentService.test.ts
+++ b/backend/packages/Upgrade/test/unit/services/SegmentService.test.ts
@@ -17,11 +17,15 @@ import {
   SegmentFile,
   SegmentInputValidator,
 } from '../../../src/api/controllers/validators/SegmentInputValidator';
+import {
+  SEGMENT_SEARCH_KEY,
+  SEGMENT_SORT_KEY,
+} from '../../../src/api/controllers/validators/SegmentPaginatedParamsValidator';
 import { IndividualForSegment } from '../../../src/api/models/IndividualForSegment';
 import { GroupForSegment } from '../../../src/api/models/GroupForSegment';
 import { Experiment } from '../../../src/api/models/Experiment';
 import { FeatureFlag } from '../../../src/api/models/FeatureFlag';
-import { SEGMENT_TYPE, SERVER_ERROR, EXPERIMENT_STATE, FEATURE_FLAG_STATUS } from 'upgrade_types';
+import { SEGMENT_TYPE, SERVER_ERROR, EXPERIMENT_STATE, FEATURE_FLAG_STATUS, SORT_AS_DIRECTION } from 'upgrade_types';
 import { configureLogger } from '../../utils/logger';
 import { ExperimentSegmentExclusion } from '../../../src/api/models/ExperimentSegmentExclusion';
 import { ExperimentSegmentInclusion } from '../../../src/api/models/ExperimentSegmentInclusion';
@@ -172,6 +176,7 @@ describe('Segment Service Testing', () => {
             save: jest.fn().mockResolvedValue(seg1),
             find: jest.fn().mockResolvedValue(segmentArr),
             delete: jest.fn(),
+            countBy: jest.fn().mockResolvedValue(segmentArr.length),
             getAllSegments: jest.fn().mockResolvedValue(segmentArr),
             deleteSegment: jest.fn().mockImplementation((seg) => {
               return seg;
@@ -184,6 +189,11 @@ describe('Segment Service Testing', () => {
               leftJoinAndSelect: jest.fn().mockReturnThis(),
               where: jest.fn().mockReturnThis(),
               andWhere: jest.fn().mockReturnThis(),
+              addSelect: jest.fn().mockReturnThis(),
+              addOrderBy: jest.fn().mockReturnThis(),
+              setParameter: jest.fn().mockReturnThis(),
+              offset: jest.fn().mockReturnThis(),
+              limit: jest.fn().mockReturnThis(),
               getMany: jest.fn().mockResolvedValue(segmentArr),
               getOne: jest.fn().mockResolvedValue(seg1),
             })),
@@ -484,5 +494,128 @@ describe('Segment Service Testing', () => {
     service.upsertSegmentInPipeline = jest.fn().mockResolvedValue(segValSegment);
     const segment = await service.addList(listVal, logger);
     expect(segment).toEqual(segValSegment);
+  });
+
+  it('should return a count of public segment', async () => {
+    const results = await service.getTotalPublicSegmentCount();
+    expect(results).toEqual(segmentArr.length);
+  });
+
+  it('should find all paginated segments with search string all', async () => {
+    const res = {
+      segmentsData: segmentArr.map((segment) => {
+        return { ...segment, status: 'Used' };
+      }),
+      experimentSegmentExclusionData: [{ experiment: exp, segment: seg1 }],
+      experimentSegmentInclusionData: [{ experiment: exp, segment: seg1 }],
+      featureFlagSegmentExclusionData: [{ featureFlag: ff, segment: seg1 }],
+      featureFlagSegmentInclusionData: [{ featureFlag: ff, segment: seg1 }],
+    };
+    const results = await service.findPaginated(
+      1,
+      2,
+      logger,
+      {
+        key: SEGMENT_SEARCH_KEY.ALL,
+        string: '',
+      },
+      {
+        key: SEGMENT_SORT_KEY.NAME,
+        sortAs: SORT_AS_DIRECTION.ASCENDING,
+      }
+    );
+    expect(results).toEqual(res);
+  });
+
+  it('should find all paginated segments with search string tag', async () => {
+    const res = {
+      segmentsData: segmentArr.map((segment) => {
+        return { ...segment, status: 'Used' };
+      }),
+      experimentSegmentExclusionData: [{ experiment: exp, segment: seg1 }],
+      experimentSegmentInclusionData: [{ experiment: exp, segment: seg1 }],
+      featureFlagSegmentExclusionData: [{ featureFlag: ff, segment: seg1 }],
+      featureFlagSegmentInclusionData: [{ featureFlag: ff, segment: seg1 }],
+    };
+    const results = await service.findPaginated(
+      1,
+      2,
+      logger,
+      {
+        key: SEGMENT_SEARCH_KEY.TAG,
+        string: '',
+      },
+      {
+        key: SEGMENT_SORT_KEY.NAME,
+        sortAs: SORT_AS_DIRECTION.ASCENDING,
+      }
+    );
+    expect(results).toEqual(res);
+  });
+
+  it('should find all paginated segmentss with search string name', async () => {
+    const res = {
+      segmentsData: segmentArr.map((segment) => {
+        return { ...segment, status: 'Used' };
+      }),
+      experimentSegmentExclusionData: [{ experiment: exp, segment: seg1 }],
+      experimentSegmentInclusionData: [{ experiment: exp, segment: seg1 }],
+      featureFlagSegmentExclusionData: [{ featureFlag: ff, segment: seg1 }],
+      featureFlagSegmentInclusionData: [{ featureFlag: ff, segment: seg1 }],
+    };
+    const results = await service.findPaginated(
+      1,
+      2,
+      logger,
+      {
+        key: SEGMENT_SEARCH_KEY.NAME,
+        string: '',
+      },
+      {
+        key: SEGMENT_SORT_KEY.NAME,
+        sortAs: SORT_AS_DIRECTION.ASCENDING,
+      }
+    );
+    expect(results).toEqual(res);
+  });
+
+  it('should find all paginated segments with search string context', async () => {
+    const res = {
+      segmentsData: segmentArr.map((segment) => {
+        return { ...segment, status: 'Used' };
+      }),
+      experimentSegmentExclusionData: [{ experiment: exp, segment: seg1 }],
+      experimentSegmentInclusionData: [{ experiment: exp, segment: seg1 }],
+      featureFlagSegmentExclusionData: [{ featureFlag: ff, segment: seg1 }],
+      featureFlagSegmentInclusionData: [{ featureFlag: ff, segment: seg1 }],
+    };
+    const results = await service.findPaginated(
+      1,
+      2,
+      logger,
+      {
+        key: SEGMENT_SEARCH_KEY.CONTEXT,
+        string: '',
+      },
+      {
+        key: SEGMENT_SORT_KEY.NAME,
+        sortAs: SORT_AS_DIRECTION.ASCENDING,
+      }
+    );
+    expect(results).toEqual(res);
+  });
+
+  it('should find all paginated segments without search params', async () => {
+    const res = {
+      segmentsData: segmentArr.map((segment) => {
+        return { ...segment, status: 'Used' };
+      }),
+      experimentSegmentExclusionData: [{ experiment: exp, segment: seg1 }],
+      experimentSegmentInclusionData: [{ experiment: exp, segment: seg1 }],
+      featureFlagSegmentExclusionData: [{ featureFlag: ff, segment: seg1 }],
+      featureFlagSegmentInclusionData: [{ featureFlag: ff, segment: seg1 }],
+    };
+    const results = await service.findPaginated(1, 2, logger);
+    expect(results).toEqual(res);
   });
 });

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/components/segments-list/segments-list.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/components/segments-list/segments-list.component.ts
@@ -45,12 +45,7 @@ export class SegmentsListComponent implements OnInit, OnDestroy, AfterViewInit {
   segmentSortKey$: Observable<string>;
   segmentSortAs$: Observable<string>;
   isLoadingSegments$ = this.segmentsService.isLoadingSegments$;
-  segmentFilterOptions = [
-    SEGMENT_SEARCH_KEY.ALL,
-    SEGMENT_SEARCH_KEY.NAME,
-    SEGMENT_SEARCH_KEY.STATUS,
-    SEGMENT_SEARCH_KEY.CONTEXT,
-  ];
+  segmentFilterOptions = [SEGMENT_SEARCH_KEY.ALL, SEGMENT_SEARCH_KEY.NAME, SEGMENT_SEARCH_KEY.CONTEXT];
   statusFilterOptions = Object.values(SEGMENT_STATUS);
   selectedSegmentFilterOption = SEGMENT_SEARCH_KEY.ALL;
   searchValue: string;
@@ -97,8 +92,6 @@ export class SegmentsListComponent implements OnInit, OnDestroy, AfterViewInit {
           );
         case SEGMENT_SEARCH_KEY.NAME:
           return data.name.toLocaleLowerCase().includes(filter);
-        case SEGMENT_SEARCH_KEY.STATUS:
-          return data.status.toLocaleLowerCase().includes(filter);
         case SEGMENT_SEARCH_KEY.CONTEXT:
           return data.context.toLocaleLowerCase().includes(filter);
       }

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-root-section-card/segment-root-section-card.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-root-section-card/segment-root-section-card.component.ts
@@ -56,7 +56,6 @@ export class SegmentRootSectionCardComponent {
   segmentFilterOptions = [
     SEGMENT_SEARCH_KEY.ALL,
     SEGMENT_SEARCH_KEY.NAME,
-    SEGMENT_SEARCH_KEY.STATUS,
     SEGMENT_SEARCH_KEY.CONTEXT,
     SEGMENT_SEARCH_KEY.TAG,
   ];
@@ -121,8 +120,6 @@ export class SegmentRootSectionCardComponent {
           );
         case SEGMENT_SEARCH_KEY.NAME:
           return data.name.toLowerCase().includes(filter);
-        case SEGMENT_SEARCH_KEY.STATUS:
-          return data.status.toLowerCase().includes(filter);
         case SEGMENT_SEARCH_KEY.CONTEXT:
           return data.context.toLowerCase().includes(filter);
         default:

--- a/types/src/Experiment/enums.ts
+++ b/types/src/Experiment/enums.ts
@@ -212,14 +212,12 @@ export enum SEGMENT_STATUS {
 export enum SEGMENT_SEARCH_KEY {
   ALL = 'all',
   NAME = 'name',
-  STATUS = 'status',
   TAG = 'tag',
   CONTEXT = 'context',
 }
 
 export enum SEGMENT_SORT_KEY {
   NAME = 'name',
-  STATUS = 'state',
   UPDATED_AT = 'updatedAt',
 }
 


### PR DESCRIPTION
- Adds POST /paginated endpoint to segments with a request body analogous to the other paginated endpoints
- Adds GET /global segments endpoint to get all global segments (for all contexts)
- Adds 'tags' to the segments model, creates db migration