### PR TITLE
Upsizing UpGrade ECS tasks CPU and RAM

### DIFF
--- a/cloudformation/backend/app-infrastructure.yml
+++ b/cloudformation/backend/app-infrastructure.yml
@@ -233,11 +233,11 @@ Resources:
           ReadonlyRootFilesystem: false
           PortMappings:
             - ContainerPort: !Ref servicePort
-      Cpu: 1024
+      Cpu: 2048
       ExecutionRoleArn:
         Fn::ImportValue: !Sub ${sharedEcsResourcesPrefix}-${environment}-ecsExecutionRoleArn
       Family: !Sub ${appName}-${environment}-${cluster}
-      Memory: 2048
+      Memory: 4096
       NetworkMode: awsvpc
       RequiresCompatibilities:
         - FARGATE
@@ -303,7 +303,7 @@ Resources:
     DependsOn: ecsService
     Properties:
       MaxCapacity: !If [IsStaging, 50, !If [IsProd, 75, 2]]
-      MinCapacity: !If [IsQA, 1, 2]
+      MinCapacity: !If [IsQA, 1, 4]
       ResourceId: !Join [ '/', [ 'service', Fn::ImportValue: !Sub '${sharedResourcesPrefix}-${environment}-ecsClusterName', !GetAtt 'ecsService.Name' ]]
       RoleARN: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService
       ScalableDimension: ecs:service:DesiredCount


### PR DESCRIPTION
Upsize to 2 vCPUs and 4GB of RAM to align with other major services