### PR TITLE
use environment type in frontend files and cleanup

### DIFF
--- a/frontend/projects/upgrade/src/environments/environment.beanstalk.prod.ts
+++ b/frontend/projects/upgrade/src/environments/environment.beanstalk.prod.ts
@@ -1,4 +1,6 @@
-export const environment = {
+import { Environment } from './environment-types';
+
+export const environment: Environment = {
   appName: 'UpGrade',
   envName: 'PROD',
   apiBaseUrl: '',
@@ -25,7 +27,6 @@ export const environment = {
     exportExperiment: '/experiments/export',
     exportAllExperiment: '/experiments/export/all',
     updateExperiments: '/experiments',
-    experimentContext: '/experiments/context',
     getExperimentById: '/experiments/single',
     getAllAuditLogs: '/audit',
     getAllErrorLogs: '/error',
@@ -36,7 +37,7 @@ export const environment = {
     deleteExperiment: '/experiments',
     updateExperimentState: '/experiments/state',
     users: '/users',
-    loginUser: '/login/user', // Used to create a new user after login if doesn't exist in DB
+    loginUser: '/login/user',
     getAllUsers: '/users/paginated',
     userDetails: '/users/details',
     previewUsers: '/previewUsers',
@@ -71,7 +72,6 @@ export const environment = {
     validateSegmentsImport: '/segments/import/validation',
     importSegments: '/segments/import',
     exportSegments: '/segments/export/json',
-    exportSegment: '/segments/export',
     exportSegmentCSV: '/segments/export/csv',
     getGroupAssignmentStatus: '/experiments/getGroupAssignmentStatus',
   },

--- a/frontend/projects/upgrade/src/environments/environment.bsnl.ts
+++ b/frontend/projects/upgrade/src/environments/environment.bsnl.ts
@@ -1,4 +1,6 @@
-export const environment = {
+import { Environment } from './environment-types';
+
+export const environment: Environment = {
   appName: 'UpGrade',
   envName: 'bsnl',
   apiBaseUrl: 'http://new-bsnl-upgrade-experiment-app.eba-gp6psjut.us-east-1.elasticbeanstalk.com/api',
@@ -25,7 +27,6 @@ export const environment = {
     exportExperiment: '/experiments/export',
     exportAllExperiment: '/experiments/export/all',
     updateExperiments: '/experiments',
-    experimentContext: '/experiments/context',
     getExperimentById: '/experiments/single',
     getAllAuditLogs: '/audit',
     getAllErrorLogs: '/error',

--- a/frontend/projects/upgrade/src/environments/environment.demo.prod.ts
+++ b/frontend/projects/upgrade/src/environments/environment.demo.prod.ts
@@ -1,4 +1,6 @@
-export const environment = {
+import { Environment } from './environment-types';
+
+export const environment: Environment = {
   appName: 'UpGrade',
   envName: 'PROD',
   apiBaseUrl: 'https://upgrade-demo.carnegielearning.com/api',
@@ -25,7 +27,6 @@ export const environment = {
     exportExperiment: '/experiments/export',
     exportAllExperiment: '/experiments/export/all',
     updateExperiments: '/experiments',
-    experimentContext: '/experiments/context',
     getExperimentById: '/experiments/single',
     getAllAuditLogs: '/audit',
     getAllErrorLogs: '/error',

--- a/frontend/projects/upgrade/src/environments/environment.local.example.ts
+++ b/frontend/projects/upgrade/src/environments/environment.local.example.ts
@@ -3,7 +3,9 @@
 // `ng build --env=prod` then `environment.prod.ts` will be used instead.
 // The list of which env maps to which file can be found in `.angular-cli.json`.
 
-export const environment = {
+import { Environment } from './environment-types';
+
+export const environment: Environment = {
   appName: 'UpGrade',
   envName: 'DEV',
   apiBaseUrl: 'http://localhost:3030/api',
@@ -30,7 +32,6 @@ export const environment = {
     exportExperiment: '/experiments/export',
     exportAllExperiment: '/experiments/export/all',
     updateExperiments: '/experiments',
-    experimentContext: '/experiments/context',
     getExperimentById: '/experiments/single',
     getAllAuditLogs: '/audit',
     getAllErrorLogs: '/error',
@@ -71,6 +72,7 @@ export const environment = {
     getVersion: '/version',
     contextMetaData: '/experiments/contextMetaData',
     segments: '/segments',
+    getPaginatedSegments: '/segments/paginated',
     validateSegments: '/segments/validation',
     validateSegmentsImport: '/segments/import/validation',
     importSegments: '/segments/import',

--- a/frontend/projects/upgrade/src/environments/environment.prod.ts
+++ b/frontend/projects/upgrade/src/environments/environment.prod.ts
@@ -1,4 +1,6 @@
-export const environment = {
+import { Environment } from './environment-types';
+
+export const environment: Environment = {
   appName: 'UpGrade',
   envName: 'PROD',
   apiBaseUrl: '%API_BASE_URL%',
@@ -25,7 +27,6 @@ export const environment = {
     exportExperiment: '/experiments/export',
     exportAllExperiment: '/experiments/export/all',
     updateExperiments: '/experiments',
-    experimentContext: '/experiments/context',
     getExperimentById: '/experiments/single',
     getAllAuditLogs: '/audit',
     getAllErrorLogs: '/error',

--- a/frontend/projects/upgrade/src/environments/environment.qa.ts
+++ b/frontend/projects/upgrade/src/environments/environment.qa.ts
@@ -1,4 +1,6 @@
-export const environment = {
+import { Environment } from './environment-types';
+
+export const environment: Environment = {
   appName: 'UpGrade',
   envName: 'qa',
   apiBaseUrl: '%API_BASE_URL%',
@@ -25,7 +27,6 @@ export const environment = {
     exportExperiment: '/experiments/export',
     exportAllExperiment: '/experiments/export/all',
     updateExperiments: '/experiments',
-    experimentContext: '/experiments/context',
     getExperimentById: '/experiments/single',
     getAllAuditLogs: '/audit',
     getAllErrorLogs: '/error',
@@ -71,7 +72,6 @@ export const environment = {
     validateSegmentsImport: '/segments/import/validation',
     importSegments: '/segments/import',
     exportSegments: '/segments/export/json',
-    exportSegment: '/segments/export',
     exportSegmentCSV: '/segments/export/csv',
     getGroupAssignmentStatus: '/experiments/getGroupAssignmentStatus',
   },

--- a/frontend/projects/upgrade/src/environments/environment.staging.ts
+++ b/frontend/projects/upgrade/src/environments/environment.staging.ts
@@ -1,4 +1,6 @@
-export const environment = {
+import { Environment } from './environment-types';
+
+export const environment: Environment = {
   appName: 'UpGrade',
   envName: 'staging',
   apiBaseUrl: '%API_BASE_URL%',
@@ -25,7 +27,6 @@ export const environment = {
     exportExperiment: '/experiments/export',
     exportAllExperiment: '/experiments/export/all',
     updateExperiments: '/experiments',
-    experimentContext: '/experiments/context',
     getExperimentById: '/experiments/single',
     getAllAuditLogs: '/audit',
     getAllErrorLogs: '/error',

--- a/frontend/projects/upgrade/src/environments/environment.test.ts
+++ b/frontend/projects/upgrade/src/environments/environment.test.ts
@@ -1,7 +1,0 @@
-export const environment = {
-  appName: 'UpGrade',
-  envName: 'TEST',
-  production: false,
-  test: true,
-  baseHrefPrefix: '',
-};


### PR DESCRIPTION
@zackcl made a comment in pr about wishing there was a way to enforce checking the environment.ts file so we would catch when an endpoint or something was added.... there is! we have an Environment type already but we weren't actually using it to strongly type the environment files themselves.