### PR TITLE
enable sourcemaps in all envs except prod in angular.json

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -178,7 +178,7 @@
               ],
               "optimization": true,
               "outputHashing": "all",
-              "sourceMap": false,
+              "sourceMap": true,
               "namedChunks": false,
               "extractLicenses": true,
               "budgets": [
@@ -218,7 +218,7 @@
               ],
               "optimization": true,
               "outputHashing": "all",
-              "sourceMap": false,
+              "sourceMap": true,
               "namedChunks": false,
               "extractLicenses": true,
               "budgets": [
@@ -258,7 +258,7 @@
               ],
               "optimization": true,
               "outputHashing": "all",
-              "sourceMap": false,
+              "sourceMap": true,
               "namedChunks": false,
               "extractLicenses": true,
               "budgets": [
@@ -298,7 +298,7 @@
               ],
               "optimization": true,
               "outputHashing": "all",
-              "sourceMap": false,
+              "sourceMap": true,
               "namedChunks": false,
               "extractLicenses": true,
               "budgets": [


### PR DESCRIPTION
pretty sure these used to be on at least for local dev.