### PR TITLE
create separate card for global exclude segments

### DIFF
--- a/frontend/projects/upgrade/src/app/core/segments/segments.data.service.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/segments.data.service.ts
@@ -18,6 +18,11 @@ export class SegmentsDataService {
     return this.http.post<SegmentsPaginationInfo>(url, params);
   }
 
+  fetchGlobalSegments() {
+    const url = this.environment.api.globalSegments;
+    return this.http.get(url);
+  }
+
   createNewSegment(segment: SegmentInput) {
     const url = this.environment.api.segments;
     return this.http.post(url, segment);

--- a/frontend/projects/upgrade/src/app/core/segments/segments.module.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/segments.module.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { EffectsModule } from '@ngrx/effects';
 import { SegmentsEffects } from './store/segments.effects';
 import { StoreModule } from '@ngrx/store';
-import { segmentsReducer } from './store/segments.reducer';
+import { segmentsReducer, globalSegmentsReducer } from './store/segments.reducer';
 import { SegmentsService } from './segments.service';
 import { SegmentsDataService } from './segments.data.service';
 
@@ -13,6 +13,7 @@ import { SegmentsDataService } from './segments.data.service';
     CommonModule,
     EffectsModule.forFeature([SegmentsEffects]),
     StoreModule.forFeature('segments', segmentsReducer),
+    StoreModule.forFeature('globalSegments', globalSegmentsReducer),
   ],
   providers: [SegmentsService, SegmentsDataService],
 })

--- a/frontend/projects/upgrade/src/app/core/segments/segments.service.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/segments.service.ts
@@ -19,6 +19,10 @@ import {
   selectSortAs,
   selectSegmentLists,
   selectSegmentUsageData,
+  selectIsLoadingGlobalSegments,
+  selectGlobalTableState,
+  selectGlobalSortKey,
+  selectGlobalSortAs,
 } from './store/segments.selectors';
 import {
   LIST_OPTION_TYPE,
@@ -47,15 +51,19 @@ export class SegmentsService {
 
   isLoadingSegments$ = this.store$.pipe(select(selectIsLoadingSegments));
   setIsLoadingImportSegment$ = this.store$.pipe(select(selectIsLoadingSegments));
+  isLoadingGlobalSegments$ = this.store$.pipe(select(selectIsLoadingGlobalSegments));
   selectAllSegments$ = this.store$.pipe(select(selectAllSegments));
   selectedSegment$ = this.store$.pipe(select(selectSelectedSegment));
   selectRootTableState$ = this.store$.pipe(select(selectRootTableState));
+  selectGlobalTableState$ = this.store$.pipe(select(selectGlobalTableState));
   shouldUseLegacyView$ = this.store$.pipe(select(selectShouldUseLegacyUI));
   selectedSegmentOverviewDetails = this.store$.pipe(select(selectSegmentOverviewDetails));
   selectSearchString$ = this.store$.pipe(select(selectSearchString));
   selectSearchKey$ = this.store$.pipe(select(selectSearchKey));
   selectSegmentSortKey$ = this.store$.pipe(select(selectSortKey));
   selectSegmentSortAs$ = this.store$.pipe(select(selectSortAs));
+  selectGlobalSegmentSortKey$ = this.store$.pipe(select(selectGlobalSortKey));
+  selectGlobalSegmentSortAs$ = this.store$.pipe(select(selectGlobalSortAs));
   selectSegmentLists$ = this.store$.pipe(select(selectSegmentLists));
   selectSegmentListsLength$ = this.store$.pipe(
     select(selectSegmentLists),
@@ -147,6 +155,10 @@ export class SegmentsService {
     this.store$.dispatch(SegmentsActions.actionFetchSegments({ fromStarting }));
   }
 
+  fetchGlobalSegments(fromStarting?: boolean) {
+    this.store$.dispatch(SegmentsActions.actionFetchGlobalSegments({ fromStarting }));
+  }
+
   fetchAllSegments(fromStarting?: boolean) {
     this.store$.dispatch(SegmentsActions.actionfetchAllSegments({ fromStarting }));
   }
@@ -179,6 +191,16 @@ export class SegmentsService {
 
   setIsLoadingImportSegment(isLoadingSegments: boolean) {
     this.store$.dispatch(SegmentsActions.actionSetIsLoadingSegments({ isLoadingSegments })); //fix!
+  }
+
+  setGlobalSortKey(sortKey: SEGMENT_SORT_KEY) {
+    this.localStorageService.setItem(SegmentLocalStorageKeys.SEGMENT_SORT_KEY, sortKey);
+    this.store$.dispatch(SegmentsActions.actionSetGlobalSortKey({ sortKey }));
+  }
+
+  setGlobalSortingType(sortingType: SORT_AS_DIRECTION) {
+    this.localStorageService.setItem(SegmentLocalStorageKeys.SEGMENT_SORT_TYPE, sortingType);
+    this.store$.dispatch(SegmentsActions.actionSetGlobalSortingType({ sortingType }));
   }
 
   deleteSegment(segmentId: string) {

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.actions.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.actions.ts
@@ -44,6 +44,20 @@ export const actionFetchSegmentsSuccessLegacyGetAll = createAction(
 
 export const actionFetchSegmentsFailure = createAction('[Segments] Fetch Segments Failure (Legacy GET all)');
 
+export const actionFetchGlobalSegments = createAction(
+  '[Global Segments] Fetch Global Segments',
+  props<{ fromStarting?: boolean }>()
+);
+
+export const actionFetchGlobalSegmentsSuccess = createAction(
+  '[Global Segments] Fetch Global Segments Success',
+  props<{
+    globalSegments: Segment[];
+  }>()
+);
+
+export const actionFetchGlobalSegmentsFailure = createAction('[Global Segments] Fetch GLobal Segments Failure');
+
 export const actionUpsertSegment = createAction(
   '[Segments] Upsert Segment',
   props<{ segment: SegmentInput; actionType: UpsertSegmentType }>()
@@ -98,5 +112,15 @@ export const actionSetSortKey = createAction('[Segments] Set Sort key value', pr
 
 export const actionSetSortingType = createAction(
   '[Segments] Set Sorting type',
+  props<{ sortingType: SORT_AS_DIRECTION }>()
+);
+
+export const actionSetGlobalSortKey = createAction(
+  '[Global Segments] Set Sort key value',
+  props<{ sortKey: SEGMENT_SORT_KEY }>()
+);
+
+export const actionSetGlobalSortingType = createAction(
+  '[Global Segments] Set Sorting type',
   props<{ sortingType: SORT_AS_DIRECTION }>()
 );

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.effects.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.effects.ts
@@ -10,6 +10,7 @@ import { NUMBER_OF_SEGMENTS, Segment, SegmentsPaginationParams, UpsertSegmentTyp
 import {
   selectAllSegments,
   selectAreAllSegmentsFetched,
+  selectGlobalSegments,
   selectSearchKey,
   selectSearchString,
   selectSkipSegments,
@@ -112,6 +113,23 @@ export class SegmentsEffects {
             })
           ),
           catchError(() => [SegmentsActions.actionFetchSegmentsFailure()])
+        )
+      )
+    )
+  );
+
+  fetchGlobalSegments$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(SegmentsActions.actionFetchGlobalSegments),
+      withLatestFrom(this.store$.pipe(select(selectGlobalSegments))),
+      switchMap(() =>
+        this.segmentsDataService.fetchGlobalSegments().pipe(
+          map((data: any) =>
+            SegmentsActions.actionFetchGlobalSegmentsSuccess({
+              globalSegments: data,
+            })
+          ),
+          catchError(() => [SegmentsActions.actionFetchGlobalSegmentsFailure()])
         )
       )
     )

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.model.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.model.ts
@@ -225,8 +225,15 @@ export interface SegmentState extends EntityState<Segment> {
   sortAs: SORT_AS_DIRECTION;
 }
 
+export interface GlobalSegmentState extends EntityState<Segment> {
+  isLoadingGlobalSegments: boolean;
+  sortKey: SEGMENT_SORT_KEY;
+  sortAs: SORT_AS_DIRECTION;
+}
+
 export interface State extends AppState {
   segments: SegmentState;
+  globalSegments: GlobalSegmentState;
 }
 
 export interface SegmentFile {

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.reducer.spec.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.reducer.spec.ts
@@ -111,7 +111,7 @@ describe('SegmentsReducer', () => {
         individualForSegment: [],
         groupForSegment: [],
         subSegments: [],
-        type: SEGMENT_TYPE.GLOBAL_EXCLUDE,
+        type: SEGMENT_TYPE.PUBLIC,
         status: SEGMENT_STATUS.UNUSED,
       };
 

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.selectors.spec.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.selectors.spec.ts
@@ -1,11 +1,11 @@
 import { SEGMENT_STATUS, SEGMENT_TYPE } from 'upgrade_types';
 import { Segment } from './segments.model';
-import { initialState } from './segments.reducer';
+import { initialState, initalGlobalState } from './segments.reducer';
 import * as SegmentSelectors from './segments.selectors';
 
 describe('SegmentSelectors', () => {
   const mockState = { ...initialState };
-
+  const mockGlobalState = { ...initalGlobalState };
   describe('#selectIsLoadingSegments', () => {
     it('should return boolean from isLoadingSegments', () => {
       const previousState = { ...mockState };
@@ -64,6 +64,7 @@ describe('SegmentSelectors', () => {
   describe('#selectSelectedSegment', () => {
     it('should return undefined from allExperimentSegmentsExclusion if segmentId is not an entity key', () => {
       const previousState = { ...mockState };
+      const previousGLobalState = { ...mockGlobalState };
       previousState.entities = {};
 
       const result = SegmentSelectors.selectSelectedSegment.projector(
@@ -77,7 +78,8 @@ describe('SegmentSelectors', () => {
           },
           navigationId: 0,
         },
-        previousState
+        previousState,
+        previousGLobalState
       );
 
       expect(result).toEqual(undefined);
@@ -85,6 +87,7 @@ describe('SegmentSelectors', () => {
 
     it('should return entity from allExperimentSegmentsExclusion by segmentId', () => {
       const previousState = { ...mockState };
+      const previousGLobalState = { ...mockGlobalState };
       const mockSegment: Segment = {
         createdAt: 'test',
         versionNumber: 0,
@@ -115,7 +118,8 @@ describe('SegmentSelectors', () => {
           },
           navigationId: 0,
         },
-        previousState
+        previousState,
+        previousGLobalState
       );
 
       expect(result).toEqual(mockSegment);

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.selectors.spec.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.selectors.spec.ts
@@ -63,10 +63,6 @@ describe('SegmentSelectors', () => {
 
   describe('#selectSelectedSegment', () => {
     it('should return undefined from allExperimentSegmentsExclusion if segmentId is not an entity key', () => {
-      const previousState = { ...mockState };
-      const previousGLobalState = { ...mockGlobalState };
-      previousState.entities = {};
-
       const result = SegmentSelectors.selectSelectedSegment.projector(
         {
           state: {
@@ -78,8 +74,7 @@ describe('SegmentSelectors', () => {
           },
           navigationId: 0,
         },
-        previousState,
-        previousGLobalState
+        {}
       );
 
       expect(result).toEqual(undefined);
@@ -87,7 +82,6 @@ describe('SegmentSelectors', () => {
 
     it('should return entity from allExperimentSegmentsExclusion by segmentId', () => {
       const previousState = { ...mockState };
-      const previousGLobalState = { ...mockGlobalState };
       const mockSegment: Segment = {
         createdAt: 'test',
         versionNumber: 0,
@@ -118,8 +112,7 @@ describe('SegmentSelectors', () => {
           },
           navigationId: 0,
         },
-        previousState,
-        previousGLobalState
+        previousState.entities
       );
 
       expect(result).toEqual(mockSegment);

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.selectors.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.selectors.ts
@@ -57,20 +57,24 @@ export const selectFeatureFlagSegmentsExclusion = createSelector(
   (state) => state.allFeatureFlagSegmentsExclusion
 );
 
-export const selectSelectedSegment = createSelector(
-  selectRouterState,
+export const selectAllSegmentEntities = createSelector(
   selectSegmentsState,
   selectGlobalSegmentsState,
-  (routerState, segmentState, globalSegmentState) => {
-    if (routerState?.state && (segmentState?.entities || globalSegmentState?.entities)) {
+  (segmentState, globalSegmentState) => ({
+    ...segmentState.entities,
+    ...globalSegmentState.entities,
+  })
+);
+
+export const selectSelectedSegment = createSelector(
+  selectRouterState,
+  selectAllSegmentEntities,
+  (routerState, allSegmentEntities) => {
+    if (routerState?.state && allSegmentEntities) {
       const {
         state: { params },
       } = routerState;
-      return segmentState.entities[params.segmentId]
-        ? segmentState.entities[params.segmentId]
-        : globalSegmentState.entities[params.segmentId]
-        ? globalSegmentState.entities[params.segmentId]
-        : undefined;
+      return allSegmentEntities[params.segmentId] ? allSegmentEntities[params.segmentId] : undefined;
     }
   }
 );

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.selectors.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.selectors.ts
@@ -8,6 +8,7 @@ import {
   USED_BY_TYPE,
   experimentSegmentInclusionExclusionData,
   featureFlagSegmentInclusionExclusionData,
+  GlobalSegmentState,
 } from './segments.model';
 import { selectAll } from './segments.reducer';
 import { selectRouterState } from '../../core.state';
@@ -20,7 +21,16 @@ export const selectSegmentsState = createFeatureSelector<SegmentState>('segments
 
 export const selectAllSegments = createSelector(selectSegmentsState, selectAll);
 
+export const selectGlobalSegmentsState = createFeatureSelector<GlobalSegmentState>('globalSegments');
+
+export const selectGlobalSegments = createSelector(selectGlobalSegmentsState, selectAll);
+
 export const selectIsLoadingSegments = createSelector(selectSegmentsState, (state) => state.isLoadingSegments);
+
+export const selectIsLoadingGlobalSegments = createSelector(
+  selectGlobalSegmentsState,
+  (state) => state.isLoadingGlobalSegments
+);
 
 export const selectSegmentById = createSelector(
   selectSegmentsState,
@@ -50,12 +60,17 @@ export const selectFeatureFlagSegmentsExclusion = createSelector(
 export const selectSelectedSegment = createSelector(
   selectRouterState,
   selectSegmentsState,
-  (routerState, segmentState) => {
-    if (routerState?.state && segmentState?.entities) {
+  selectGlobalSegmentsState,
+  (routerState, segmentState, globalSegmentState) => {
+    if (routerState?.state && (segmentState?.entities || globalSegmentState?.entities)) {
       const {
         state: { params },
       } = routerState;
-      return segmentState.entities[params.segmentId] ? segmentState.entities[params.segmentId] : undefined;
+      return segmentState.entities[params.segmentId]
+        ? segmentState.entities[params.segmentId]
+        : globalSegmentState.entities[params.segmentId]
+        ? globalSegmentState.entities[params.segmentId]
+        : undefined;
     }
   }
 );
@@ -101,9 +116,23 @@ export const selectRootTableState = createSelector(
   })
 );
 
+export const selectGlobalTableState = createSelector(
+  selectGlobalSegments,
+  selectSearchSegmentParams,
+  (tableData, searchParams) => ({
+    tableData,
+    searchParams,
+    allSearchableProperties: Object.values(SEGMENT_SEARCH_KEY),
+  })
+);
+
 export const selectSortKey = createSelector(selectSegmentsState, (state) => state.sortKey);
 
 export const selectSortAs = createSelector(selectSegmentsState, (state) => state.sortAs);
+
+export const selectGlobalSortKey = createSelector(selectGlobalSegmentsState, (state) => state.sortKey);
+
+export const selectGlobalSortAs = createSelector(selectGlobalSegmentsState, (state) => state.sortAs);
 
 export const selectPrivateSegmentListTypeOptions = createSelector(
   selectContextMetaData,

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-global-section-card/segment-global-section-card-table/segment-global-section-card-table.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-global-section-card/segment-global-section-card-table/segment-global-section-card-table.component.html
@@ -1,0 +1,108 @@
+<div class="segment-list-table-container" #tableContainer>
+  <mat-progress-bar class="spinner" mode="indeterminate" *ngIf="isLoading$ | async"></mat-progress-bar>
+  <table
+    class="segment-list-table"
+    mat-table
+    [dataSource]="dataSource$"
+    [ngClass]="{ 'no-data': !dataSource$?.data?.length }"
+    matSort
+    (matSortChange)="changeSorting($event)"
+    [matSortActive]="segmentSortKey$ | async"
+    [matSortDirection]="segmentSortAs$ | async | lowercase"
+  >
+    <!-- Name Column -->
+    <ng-container [matColumnDef]="SEGMENT_ROOT_COLUMN_NAMES.NAME">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header class="name-column ft-14-600">
+        {{ SEGMENT_TRANSLATION_KEYS.NAME | translate }}
+      </th>
+      <td mat-cell *matCellDef="let segment" class="name-column ft-14-400">
+        <a
+          [routerLink]="['/segments', 'detail', segment.id]"
+          [matTooltip]="segment.name.length > 24 ? segment.name : null"
+          matTooltipPosition="above"
+          class="segment-name"
+        >
+          {{ segment.name | truncate : 24 }}
+        </a>
+        <br />
+        <span
+          [matTooltip]="segment.description?.length > 35 ? segment.description : null"
+          matTooltipPosition="above"
+          class="segment-description ft-10-400"
+        >
+          {{ segment.description | truncate : 35 }}
+        </span>
+      </td>
+    </ng-container>
+
+    <!-- Status Column -->
+    <ng-container [matColumnDef]="SEGMENT_ROOT_COLUMN_NAMES.STATUS">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header class="status-column ft-14-600">
+        {{ SEGMENT_TRANSLATION_KEYS.STATUS | translate }}
+      </th>
+      <td mat-cell *matCellDef="let segment" class="status-column ft-14-400">
+        <app-common-status-indicator-chip [chipClass]="segment.status.toLowerCase()">
+          <!-- TODO: Update the SEGMENT_STATUS enum to lowercase and remove toLowerCase() once the legacy Segments code is removed -->
+        </app-common-status-indicator-chip>
+      </td>
+    </ng-container>
+
+    <!-- Updated at Column -->
+    <ng-container [matColumnDef]="SEGMENT_ROOT_COLUMN_NAMES.UPDATED_AT">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header class="updated-at-column ft-14-600">
+        {{ SEGMENT_TRANSLATION_KEYS.UPDATED_AT | translate }}
+      </th>
+      <td mat-cell *matCellDef="let segment" class="updated-at-column ft-14-400">
+        {{ segment.updatedAt | date : 'MMM d, y h:mm a' }}
+      </td>
+    </ng-container>
+
+    <!-- App Context Column -->
+    <ng-container [matColumnDef]="SEGMENT_ROOT_COLUMN_NAMES.APP_CONTEXT">
+      <th mat-header-cell *matHeaderCellDef class="app-context-column ft-14-600">
+        {{ SEGMENT_TRANSLATION_KEYS.APP_CONTEXT | translate }}
+      </th>
+      <td mat-cell *matCellDef="let segment" class="ft-14-400">
+        {{ segment.context }}
+      </td>
+    </ng-container>
+
+    <!-- Tags Column -->
+    <ng-container [matColumnDef]="SEGMENT_ROOT_COLUMN_NAMES.TAGS">
+      <th mat-header-cell *matHeaderCellDef class="tags-column ft-14-600">
+        {{ SEGMENT_TRANSLATION_KEYS.TAGS | translate }}
+      </th>
+      <td mat-cell *matCellDef="let segment" class="tags-column ft-14-400 dense-2">
+        <mat-chip-listbox aria-label="Segment tags">
+          <mat-chip *ngFor="let tag of segment.tags" class="tag">
+            <span class="chip-label">{{ tag }}</span>
+          </mat-chip>
+        </mat-chip-listbox>
+      </td>
+    </ng-container>
+
+    <!-- Lists Column -->
+    <ng-container [matColumnDef]="SEGMENT_ROOT_COLUMN_NAMES.LISTS">
+      <th mat-header-cell *matHeaderCellDef class="lists-column ft-14-600">
+        {{ SEGMENT_TRANSLATION_KEYS.LISTS | translate }}
+      </th>
+      <td mat-cell *matCellDef="let segment" class="lists-column ft-14-400">
+        <span class="list-count">{{
+          segment.groupForSegment?.length + segment.individualForSegment?.length + segment.subSegments?.length
+        }}</span>
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+
+    <!-- No Data Row -->
+    <tr *matNoDataRow>
+      <td class="ft-14-400" [attr.colspan]="displayedColumns.length">
+        <ng-template #noSegments>
+          {{ 'segments.no-segments-in-table.text' | translate }}
+        </ng-template>
+      </td>
+    </tr>
+  </table>
+</div>

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-global-section-card/segment-global-section-card-table/segment-global-section-card-table.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-global-section-card/segment-global-section-card-table/segment-global-section-card-table.component.ts
@@ -1,0 +1,83 @@
+import { Observable } from 'rxjs';
+
+import { ChangeDetectionStrategy, Component, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
+
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { AsyncPipe, NgIf, NgFor } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { MatSort } from '@angular/material/sort';
+import { CommonStatusIndicatorChipComponent } from '../../../../../../../../shared-standalone-component-lib/components';
+import { SegmentsService } from '../../../../../../../../core/segments/segments.service';
+import { SharedModule } from '../../../../../../../../shared/shared.module';
+import {
+  Segment,
+  SEGMENT_ROOT_COLUMN_NAMES,
+  SEGMENT_ROOT_DISPLAYED_COLUMNS,
+  SEGMENT_TRANSLATION_KEYS,
+} from '../../../../../../../../core/segments/store/segments.model';
+
+@Component({
+  selector: 'app-segment-global-section-card-table',
+  imports: [MatTableModule, AsyncPipe, NgIf, NgFor, SharedModule, RouterModule, CommonStatusIndicatorChipComponent],
+  templateUrl: './segment-global-section-card-table.component.html',
+  styleUrl:
+    '../../segment-root-section-card/segment-root-section-card-table/segment-root-section-card-table.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SegmentGlobalSectionCardTableComponent implements OnInit {
+  @Input() dataSource$: MatTableDataSource<Segment>;
+  @Input() isLoading$: Observable<boolean>;
+  segmentSortKey$ = this.segmentsService.selectGlobalSegmentSortKey$;
+  segmentSortAs$ = this.segmentsService.selectGlobalSegmentSortAs$;
+
+  @ViewChild(MatSort, { static: true }) sort: MatSort;
+  @ViewChild('tableContainer') tableContainer: ElementRef;
+
+  constructor(private segmentsService: SegmentsService) {}
+
+  ngOnInit() {
+    this.sortTable();
+  }
+
+  ngOnChanges() {
+    this.sortTable();
+  }
+
+  private sortTable() {
+    if (this.dataSource$?.data) {
+      this.dataSource$.sortingDataAccessor = (item, property) =>
+        property === 'name' ? item.name.toLowerCase() : item[property];
+      this.dataSource$.sort = this.sort;
+    }
+  }
+
+  get displayedColumns(): string[] {
+    return SEGMENT_ROOT_DISPLAYED_COLUMNS;
+  }
+
+  get SEGMENT_TRANSLATION_KEYS() {
+    return SEGMENT_TRANSLATION_KEYS;
+  }
+
+  get SEGMENT_ROOT_COLUMN_NAMES() {
+    return SEGMENT_ROOT_COLUMN_NAMES;
+  }
+
+  changeSorting(event) {
+    if (event.direction) {
+      this.segmentsService.setGlobalSortingType(event.direction.toUpperCase());
+      this.segmentsService.setGlobalSortKey(event.active);
+    } else {
+      // When sorting is cleared, revert to default sorting
+      this.segmentsService.setGlobalSortingType(null);
+      this.segmentsService.setGlobalSortKey(null);
+      this.tableContainer.nativeElement.scroll({
+        top: 0,
+        behavior: 'smooth',
+      });
+      this.dataSource$.data = this.dataSource$.data.sort(
+        (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+      );
+    }
+  }
+}

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-global-section-card/segment-global-section-card.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-global-section-card/segment-global-section-card.component.html
@@ -1,0 +1,33 @@
+<app-common-section-card>
+  <!-- header-left -->
+  <app-common-section-card-title-header
+    header-left
+    [title]="'segments.global-segments.title.text' | translate"
+    [subtitle]="'segments.global-segments.subtitle.text' | translate"
+  ></app-common-section-card-title-header>
+
+  <!-- header-right -->
+  <app-common-section-card-action-buttons
+    header-right
+    [isSectionCardExpanded]="isSectionCardExpanded"
+    (sectionCardExpandChange)="onSectionCardExpandChange($event)"
+  ></app-common-section-card-action-buttons>
+  <!-- content -->
+  <ng-container content *ngIf="isSectionCardExpanded">
+    <ng-container *ngIf="isLoadingGlobalSegments$ | async; else table">
+      <div class="mat-spinner-container">
+        <mat-spinner diameter="60"></mat-spinner>
+      </div>
+    </ng-container>
+
+    <ng-template #table>
+      <div class="table-container">
+        <app-segment-global-section-card-table
+          [dataSource$]="dataSource$ | async"
+          [isLoading$]="isLoadingGlobalSegments$"
+        >
+        </app-segment-global-section-card-table>
+      </div>
+    </ng-template>
+  </ng-container>
+</app-common-section-card>

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-global-section-card/segment-global-section-card.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-global-section-card/segment-global-section-card.component.ts
@@ -1,0 +1,74 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import {
+  CommonSectionCardComponent,
+  CommonSectionCardActionButtonsComponent,
+  CommonSectionCardTitleHeaderComponent,
+} from '../../../../../../../shared-standalone-component-lib/components';
+import { SegmentsService } from '../../../../../../../core/segments/segments.service';
+import { AsyncPipe, NgIf, TitleCasePipe } from '@angular/common';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { RouterModule } from '@angular/router';
+import { MatTableDataSource } from '@angular/material/table';
+import { DialogService } from '../../../../../../../shared/services/common-dialog.service';
+import { Observable, map } from 'rxjs';
+import { Segment } from '../../../../../../../core/segments/store/segments.model';
+import { UserPermission } from '../../../../../../../core/auth/store/auth.models';
+import { AuthService } from '../../../../../../../core/auth/auth.service';
+import {
+  TableState,
+  CommonTableHelpersService,
+} from '../../../../../../../shared/services/common-table-helpers.service';
+import { SegmentGlobalSectionCardTableComponent } from './segment-global-section-card-table/segment-global-section-card-table.component';
+
+@Component({
+  selector: 'app-segment-global-section-card',
+  imports: [
+    CommonSectionCardComponent,
+    CommonSectionCardTitleHeaderComponent,
+    CommonSectionCardActionButtonsComponent,
+    SegmentGlobalSectionCardTableComponent,
+    AsyncPipe,
+    NgIf,
+    MatProgressSpinnerModule,
+    RouterModule,
+    TranslateModule,
+    TitleCasePipe,
+  ],
+  templateUrl: './segment-global-section-card.component.html',
+  styleUrl: '../segment-root-section-card/segment-root-section-card.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SegmentGlobalSectionCardComponent {
+  permissions$: Observable<UserPermission>;
+  dataSource$: Observable<MatTableDataSource<Segment>>;
+  isLoadingGLobalSegments$ = this.segmentService.isLoadingGlobalSegments$;
+  selectGlobalTableState$ = this.segmentService.selectGlobalTableState$;
+
+  isSectionCardExpanded = false;
+
+  constructor(
+    private segmentService: SegmentsService,
+    private translateService: TranslateService,
+    private dialogService: DialogService,
+    private authService: AuthService,
+    private tableHelpersService: CommonTableHelpersService
+  ) {}
+
+  ngOnInit() {
+    this.permissions$ = this.authService.userPermissions$;
+    this.segmentService.fetchGlobalSegments(true);
+  }
+
+  ngAfterViewInit() {
+    this.dataSource$ = this.selectGlobalTableState$.pipe(
+      map((tableState: TableState<Segment>) => {
+        return new MatTableDataSource(tableState.tableData);
+      })
+    );
+  }
+
+  onSectionCardExpandChange(isSectionCardExpanded: boolean) {
+    this.isSectionCardExpanded = isSectionCardExpanded;
+  }
+}

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-root-page-content.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-root-page-content.component.html
@@ -1,3 +1,4 @@
 <app-common-section-card-list>
+  <app-segment-global-section-card section-card></app-segment-global-section-card>
   <app-segment-root-section-card section-card></app-segment-root-section-card>
 </app-common-section-card-list>

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-root-page-content.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-root-page-content.component.ts
@@ -1,10 +1,11 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { CommonSectionCardListComponent } from '../../../../../../shared-standalone-component-lib/components';
 import { SegmentRootSectionCardComponent } from './segment-root-section-card/segment-root-section-card.component';
+import { SegmentGlobalSectionCardComponent } from './segment-global-section-card/segment-global-section-card.component';
 
 @Component({
   selector: 'app-segment-root-page-content',
-  imports: [CommonSectionCardListComponent, SegmentRootSectionCardComponent],
+  imports: [CommonSectionCardListComponent, SegmentRootSectionCardComponent, SegmentGlobalSectionCardComponent],
   templateUrl: './segment-root-page-content.component.html',
   styleUrl: './segment-root-page-content.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-root-section-card/segment-root-section-card.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-root-section-card/segment-root-section-card.component.html
@@ -11,14 +11,11 @@
   <!-- header-right -->
   <app-common-section-card-action-buttons
     header-right
-    [showSlideToggle]="true"
-    [slideToggleText]="'segments.show-global-excludes.text' | translate"
     [showPrimaryButton]="(permissions$ | async)?.segments.create"
     [primaryButtonText]="'segments.add-segments.text' | translate | titlecase"
     [menuButtonItems]="menuButtonItems"
     [showMenuButton]="(permissions$ | async)?.segments.create"
     [isSectionCardExpanded]="isSectionCardExpanded"
-    (slideToggleChange)="onSlideToggleChange($event)"
     (primaryButtonClick)="onAddSegmentButtonClick()"
     (menuButtonItemClick)="onMenuButtonItemClick($event)"
     (sectionCardExpandChange)="onSectionCardExpandChange($event)"

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-root-section-card/segment-root-section-card.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-root-section-card/segment-root-section-card.component.ts
@@ -22,7 +22,6 @@ import {
 } from '../../../../../../../shared/services/common-table-helpers.service';
 import { UserPermission } from '../../../../../../../core/auth/store/auth.models';
 import { AuthService } from '../../../../../../../core/auth/auth.service';
-import { MatSlideToggleChange } from '@angular/material/slide-toggle';
 
 @Component({
   selector: 'app-segment-root-section-card',
@@ -96,11 +95,6 @@ export class SegmentRootSectionCardComponent {
   onSearch(params: CommonSearchWidgetSearchParams<SEGMENT_SEARCH_KEY>) {
     this.segmentsService.setSearchString(params.searchString);
     this.segmentsService.setSearchKey(params.searchKey as SEGMENT_SEARCH_KEY);
-  }
-
-  onSlideToggleChange(event: MatSlideToggleChange): void {
-    const slideToggleEvent = event.source;
-    console.log(`Show Global Excludes: ${slideToggleEvent.checked}`);
   }
 
   onAddSegmentButtonClick() {

--- a/frontend/projects/upgrade/src/assets/i18n/en.json
+++ b/frontend/projects/upgrade/src/assets/i18n/en.json
@@ -459,6 +459,8 @@
   "segments.global-name.text": "Name",
   "segments.global-enable.text": "Enable",
   "segments.global-actions.text": "Actions",
+  "segments.global-segments.title.text": "Global Excludes",
+  "segments.global-segments.subtitle.text": "View the list of segments to be excluded globally.",
   "segments.global-status.text": "Status",
   "segments.global-last-update.text": "Last Update",
   "segments.global-updated-at.text": "Updated at",

--- a/frontend/projects/upgrade/src/environments/environment-types.ts
+++ b/frontend/projects/upgrade/src/environments/environment-types.ts
@@ -50,6 +50,7 @@ export interface APIEndpoints {
   contextMetaData: string;
   segments: string;
   getPaginatedSegments: string;
+  globalSegments: string;
   validateSegments: string;
   validateSegmentsImport: string;
   importSegments: string;

--- a/frontend/projects/upgrade/src/environments/environment.beanstalk.prod.ts
+++ b/frontend/projects/upgrade/src/environments/environment.beanstalk.prod.ts
@@ -67,6 +67,7 @@ export const environment: Environment = {
     getVersion: '/version',
     contextMetaData: '/experiments/contextMetaData',
     segments: '/segments',
+    globalSegments: '/segments/global',
     getPaginatedSegments: '/segments/paginated',
     validateSegments: '/segments/validation',
     validateSegmentsImport: '/segments/import/validation',

--- a/frontend/projects/upgrade/src/environments/environment.bsnl.ts
+++ b/frontend/projects/upgrade/src/environments/environment.bsnl.ts
@@ -67,6 +67,7 @@ export const environment: Environment = {
     getVersion: '/version',
     contextMetaData: '/experiments/contextMetaData',
     segments: '/segments',
+    globalSegments: '/segments/global',
     getPaginatedSegments: '/segments/paginated',
     validateSegments: '/segments/validation',
     validateSegmentsImport: '/segments/import/validation',

--- a/frontend/projects/upgrade/src/environments/environment.demo.prod.ts
+++ b/frontend/projects/upgrade/src/environments/environment.demo.prod.ts
@@ -67,6 +67,7 @@ export const environment: Environment = {
     getVersion: '/version',
     contextMetaData: '/experiments/contextMetaData',
     segments: '/segments',
+    globalSegments: '/segments/global',
     getPaginatedSegments: '/segments/paginated',
     validateSegments: '/segments/validation',
     validateSegmentsImport: '/segments/import/validation',

--- a/frontend/projects/upgrade/src/environments/environment.local.example.ts
+++ b/frontend/projects/upgrade/src/environments/environment.local.example.ts
@@ -72,6 +72,7 @@ export const environment: Environment = {
     getVersion: '/version',
     contextMetaData: '/experiments/contextMetaData',
     segments: '/segments',
+    globalSegments: '/segments/global',
     getPaginatedSegments: '/segments/paginated',
     validateSegments: '/segments/validation',
     validateSegmentsImport: '/segments/import/validation',

--- a/frontend/projects/upgrade/src/environments/environment.prod.ts
+++ b/frontend/projects/upgrade/src/environments/environment.prod.ts
@@ -67,6 +67,7 @@ export const environment: Environment = {
     getVersion: '/version',
     contextMetaData: '/experiments/contextMetaData',
     segments: '/segments',
+    globalSegments: '/segments/global',
     getPaginatedSegments: '/segments/paginated',
     validateSegments: '/segments/validation',
     validateSegmentsImport: '/segments/import/validation',

--- a/frontend/projects/upgrade/src/environments/environment.qa.ts
+++ b/frontend/projects/upgrade/src/environments/environment.qa.ts
@@ -67,6 +67,7 @@ export const environment: Environment = {
     getVersion: '/version',
     contextMetaData: '/experiments/contextMetaData',
     segments: '/segments',
+    globalSegments: '/segments/global',
     getPaginatedSegments: '/segments/paginated',
     validateSegments: '/segments/validation',
     validateSegmentsImport: '/segments/import/validation',

--- a/frontend/projects/upgrade/src/environments/environment.staging.ts
+++ b/frontend/projects/upgrade/src/environments/environment.staging.ts
@@ -67,6 +67,7 @@ export const environment: Environment = {
     getVersion: '/version',
     contextMetaData: '/experiments/contextMetaData',
     segments: '/segments',
+    globalSegments: '/segments/global',
     getPaginatedSegments: '/segments/paginated',
     validateSegments: '/segments/validation',
     validateSegmentsImport: '/segments/import/validation',

--- a/frontend/projects/upgrade/src/environments/environment.ts
+++ b/frontend/projects/upgrade/src/environments/environment.ts
@@ -73,6 +73,7 @@ export const environment = {
     getVersion: '/version',
     contextMetaData: '/experiments/contextMetaData',
     segments: '/segments',
+    globalSegments: '/segments/global',
     getPaginatedSegments: '/segments/paginated',
     validateSegments: '/segments/validation',
     validateSegmentsImport: '/segments/import/validation',


### PR DESCRIPTION
- fetches global exclude segments separately, using the new endpoint
- populates a separate segment table card, above the regular segment list table card, with the global exclude segments
- the global exclude card is collapsed by default
- global exclude table is sortable but not searchable
- "Show Global Excludes" removed from UI