### PR TITLE
Fix the local-storage.service.spec.ts to pass with the default searchKey

### DIFF
--- a/frontend/projects/upgrade/src/app/core/local-storage/local-storage.service.spec.ts
+++ b/frontend/projects/upgrade/src/app/core/local-storage/local-storage.service.spec.ts
@@ -54,7 +54,7 @@ describe('LocalStorageService', () => {
       isLoadingExperimentExport: false,
       skipExperiment: 0,
       totalExperiments: null,
-      searchKey: null,
+      searchKey: EXPERIMENT_SEARCH_KEY.ALL,
       searchString: null,
       sortKey: EXPERIMENT_SORT_KEY.NAME,
       sortAs: SORT_AS_DIRECTION.ASCENDING,


### PR DESCRIPTION
This PR fixes a failing test case caused by the new default `searchKey` added by #2355