### PR TITLE
mooclet: fixes for marking and getting persistant assignment

### DIFF
--- a/backend/packages/Upgrade/src/api/services/MoocletDataService.ts
+++ b/backend/packages/Upgrade/src/api/services/MoocletDataService.ts
@@ -217,7 +217,7 @@ export class MoocletDataService {
     requestBody: MoocletValueRequestBody,
     logger: UpgradeLogger
   ): Promise<MoocletValueResponseDetails> {
-    const endpoint = '/value';
+    const endpoint = `/value?learner=${requestBody.learner}`;
 
     const requestParams: MoocletProxyRequestParams = {
       method: 'POST',

--- a/backend/packages/Upgrade/src/api/services/MoocletExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/MoocletExperimentService.ts
@@ -1417,16 +1417,9 @@ export class MoocletExperimentService extends ExperimentService {
       return undefined;
     }
 
-    // for mooclet assignments, a user isn't "enrolled" in a version until they have sent in a reward.
-    // only then will /mooclet/policy/run start to return the same version.
-    //
-    // unfortunately this means we can't mark them the same way as a normal experiment
-    // 1. we can't infer condition from userId hash and
-    // 2. we can't call out to mooclet/policy/run to get their assignment because they aren't locked into a version yet
-    //
-    // so we have to use the condition they sent in /mark in order to enroll them.
-    // this will enroll them in upgrade, but NOT yet give them a persistant assignment until they send a reward.
-    // this is ok because after upgrade assignment, we will cache and not reach out again to mooclet, but it's a nuance to know
+    // Note: Unlike regular experiments where we infer the condition the user "should" have gotten,
+    // we have to enroll the condition the client has marked, because the Mooclet assignment won't persist on a user basis.
+    // This means that outside factors can potentially influence the intended balance.
 
     try {
       const moocletExperimentRef = await this.getMoocletExperimentRefByUpgradeExperimentId(experimentId);

--- a/backend/packages/Upgrade/src/api/services/MoocletRewardsService.ts
+++ b/backend/packages/Upgrade/src/api/services/MoocletRewardsService.ts
@@ -138,6 +138,7 @@ export class MoocletRewardsService {
             value: BinaryRewardMetricValueMap[rewardMetricValue],
             mooclet: moocletExperimentRef.moocletId,
             version: versionId,
+            learner: user.id,
           };
           logger.info({
             message: 'Sending reward to mooclet',

--- a/backend/packages/Upgrade/src/types/Mooclet.ts
+++ b/backend/packages/Upgrade/src/types/Mooclet.ts
@@ -69,7 +69,7 @@ export interface MoocletValueRequestBody {
   value: number;
   mooclet: number;
   version: number;
-  learner?: number;
+  learner?: number | string;
   policy?: number;
 }
 

--- a/backend/packages/Upgrade/test/unit/services/MoocletRewardsService.test.ts
+++ b/backend/packages/Upgrade/test/unit/services/MoocletRewardsService.test.ts
@@ -221,6 +221,7 @@ describe('MoocletRewardsService', () => {
           value: mockRewardValue,
           mooclet: 123,
           version: 456,
+          learner: 'user-1',
         },
         user: mockUser,
       });
@@ -231,6 +232,7 @@ describe('MoocletRewardsService', () => {
           value: mockRewardValue,
           mooclet: 123,
           version: 456,
+          learner: 'user-1',
         },
         mockLogger
       );


### PR DESCRIPTION
This adds "learner" to the `/value` (reward) call and adds a method to handle marking condition.

We will always "mark" and enroll the actual condition that was sent in request (if valid), like in within-subjects. That has implications for outside factors potentially causing an imbalance if one condition for some reason is more likely to get marked in client. But there's not a good way around that I can find.
