### PR TITLE
Update selectPrivateSegmentListTypeOptions to support both Feature Flag and Segment

### DIFF
--- a/frontend/projects/upgrade/src/app/core/segments/segments.service.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/segments.service.ts
@@ -105,29 +105,21 @@ export class SegmentsService {
     )
   );
 
-  selectPrivateSegmentListTypeOptions$ = this.store$.pipe(
-    select(selectContextMetaData),
-    withLatestFrom(this.store$.pipe(select(selectSelectedFeatureFlag))),
-    map(([contextMetaData, flag]) => {
-      // TODO: straighten out contextmetadata and it's selectors with a dedicated service to avoid this sweaty effort to get standard information
-      const flagAppContext = flag?.context?.[0];
-      const groupTypes = contextMetaData?.contextMetadata?.[flagAppContext]?.GROUP_TYPES ?? [];
-      const groupTypeSelectOptions = CommonTextHelpersService.formatGroupTypes(groupTypes as string[]);
-      const listOptionTypes = [
-        {
-          value: LIST_OPTION_TYPE.SEGMENT,
-          viewValue: LIST_OPTION_TYPE.SEGMENT,
-        },
-        {
-          value: LIST_OPTION_TYPE.INDIVIDUAL,
-          viewValue: LIST_OPTION_TYPE.INDIVIDUAL,
-        },
-        ...groupTypeSelectOptions,
-      ];
+  selectPrivateSegmentListTypeOptions$ = (appContext: string): Observable<{ value: string; viewValue: string }[]> => {
+    return this.store$.pipe(
+      select(selectContextMetaData),
+      map((contextMetaData) => {
+        const groupTypes = contextMetaData?.contextMetadata?.[appContext]?.GROUP_TYPES ?? [];
+        const groupTypeSelectOptions = CommonTextHelpersService.formatGroupTypes(groupTypes as string[]);
 
-      return listOptionTypes;
-    })
-  );
+        return [
+          { value: LIST_OPTION_TYPE.SEGMENT, viewValue: LIST_OPTION_TYPE.SEGMENT },
+          { value: LIST_OPTION_TYPE.INDIVIDUAL, viewValue: LIST_OPTION_TYPE.INDIVIDUAL },
+          ...groupTypeSelectOptions,
+        ];
+      })
+    );
+  };
 
   selectSegmentsByContext(appContext: string): Observable<Segment[]> {
     return this.selectAllSegments$.pipe(

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.selectors.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.selectors.ts
@@ -165,29 +165,6 @@ export const selectGlobalSortKey = createSelector(selectGlobalSegmentsState, (st
 
 export const selectGlobalSortAs = createSelector(selectGlobalSegmentsState, (state) => state.sortAs);
 
-export const selectPrivateSegmentListTypeOptions = createSelector(
-  selectContextMetaData,
-  selectSelectedFeatureFlag,
-  (contextMetaData, flag) => {
-    const flagAppContext = flag?.context?.[0];
-    const groupTypes = contextMetaData?.contextMetadata?.[flagAppContext]?.GROUP_TYPES ?? [];
-    const groupTypeSelectOptions = CommonTextHelpersService.formatGroupTypes(groupTypes as string[]);
-    const listOptionTypes = [
-      {
-        value: LIST_OPTION_TYPE.SEGMENT,
-        viewValue: LIST_OPTION_TYPE.SEGMENT,
-      },
-      {
-        value: LIST_OPTION_TYPE.INDIVIDUAL,
-        viewValue: LIST_OPTION_TYPE.INDIVIDUAL,
-      },
-      ...groupTypeSelectOptions,
-    ];
-
-    return listOptionTypes;
-  }
-);
-
 export const selectSegmentLists = createSelector(
   selectSelectedSegment,
   (segment: Segment): ParticipantListTableRow[] => {

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/modals/upsert-private-segment-list-modal/upsert-private-segment-list-modal.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/modals/upsert-private-segment-list-modal/upsert-private-segment-list-modal.component.ts
@@ -54,7 +54,7 @@ import { CommonTagInputType } from '../../../../../core/feature-flags/store/feat
 })
 export class UpsertPrivateSegmentListModalComponent {
   @ViewChild('typeSelectRef') typeSelectRef: MatSelect;
-  listOptionTypes$ = this.segmentsService.selectPrivateSegmentListTypeOptions$;
+  listOptionTypes$: Observable<{ value: string; viewValue: string }[]>;
   isLoadingUpsertFeatureFlagList$ = this.featureFlagService.isLoadingUpsertPrivateSegmentList$;
   initialFormValues$ = new BehaviorSubject<PrivateSegmentListFormData>(null);
 
@@ -83,6 +83,12 @@ export class UpsertPrivateSegmentListModalComponent {
   ngOnInit(): void {
     this.fetchData();
     this.createPrivateSegmentListForm();
+
+    // Initialize listOptionTypes$ with the app context
+    this.listOptionTypes$ = this.segmentsService.selectPrivateSegmentListTypeOptions$(
+      this.config.params.sourceAppContext
+    );
+
     this.initializeListeners();
     this.populateFormForEdit();
   }


### PR DESCRIPTION
Closes #2336

This PR resolves the issue found while QA'ing the Segment Add / Edit List modal (https://github.com/CarnegieLearningWeb/UpGrade/issues/2336#issuecomment-2804692047)

Previously, `selectPrivateSegmentListTypeOptions` relied on the selected feature flag’s app context. Now it accepts an explicit `appContext` parameter, allowing us to fetch group types for both feature flags and segments.

This PR also removes the duplicated/unused `selectPrivateSegmentListTypeOptions` selector existed in `segments.selectors.ts`.

Screenshot after change:
<img width="1000" alt="Screenshot 2025-04-15 at 9 12 24 PM" src="https://github.com/user-attachments/assets/5a6b986f-3384-4fa5-ac61-221656789589" />
