### PR TITLE
Fix parameter handling and pagination filter in segment/flag effects

### DIFF
--- a/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.effects.ts
+++ b/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.effects.ts
@@ -44,21 +44,16 @@ export class FeatureFlagsEffects {
         this.store$.pipe(select(selectSearchKey)),
         this.store$.pipe(select(selectSortKey)),
         this.store$.pipe(select(selectSortAs)),
-        this.store$.pipe(select(selectIsAllFlagsFetched))
+        this.store$.pipe(select(selectIsAllFlagsFetched)),
+        this.store$.pipe(select(selectSearchString))
       ),
-      filter(([fromStarting, skip, total, searchKey, sortKey, sortAs, isAllFlagsFetched]) => {
+      filter(([fromStarting, skip, total, searchKey, sortKey, sortAs, isAllFlagsFetched, searchString]) => {
         return !isAllFlagsFetched || skip < total || total === null || fromStarting;
       }),
       tap(() => {
         this.store$.dispatch(FeatureFlagsActions.actionSetIsLoadingFeatureFlags({ isLoadingFeatureFlags: true }));
       }),
-      switchMap(([fromStarting, skip, _, searchKey, sortKey, sortAs]) => {
-        let searchString = null;
-        // As withLatestFrom does not support more than 5 arguments
-        // TODO: Find alternative
-        this.getSearchString$().subscribe((searchInput) => {
-          searchString = searchInput;
-        });
+      switchMap(([fromStarting, skip, total, searchKey, sortKey, sortAs, isAllFlagsFetched, searchString]) => {
         let params: FeatureFlagsPaginationParams = {
           skip: fromStarting ? 0 : skip,
           take: NUMBER_OF_FLAGS,

--- a/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.selectors.ts
+++ b/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.selectors.ts
@@ -171,6 +171,25 @@ export const selectFeatureFlagExclusions = createSelector(
   }
 );
 
+export const selectFeatureFlagPaginationParams = createSelector(
+  selectSkipFlags,
+  selectTotalFlags,
+  selectSearchKey,
+  selectSortKey,
+  selectSortAs,
+  selectIsAllFlagsFetched,
+  selectSearchString,
+  (skip, total, searchKey, sortKey, sortAs, isAllFlagsFetched, searchString) => ({
+    skip,
+    total,
+    searchKey,
+    sortKey,
+    sortAs,
+    isAllFlagsFetched,
+    searchString,
+  })
+);
+
 // Helper function to determine if warning should be shown for a given flag
 const shouldShowWarningForFlag = (flag: FeatureFlag) =>
   flag?.status === FEATURE_FLAG_STATUS.ENABLED &&

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.effects.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.effects.ts
@@ -45,21 +45,16 @@ export class SegmentsEffects {
         this.store$.pipe(select(selectSearchKey)),
         this.store$.pipe(select(selectSortKey)),
         this.store$.pipe(select(selectSortAs)),
-        this.store$.pipe(select(selectAreAllSegmentsFetched))
+        this.store$.pipe(select(selectAreAllSegmentsFetched)),
+        this.store$.pipe(select(selectSearchString))
       ),
-      filter(([fromStarting, skip, total, areAllFetched]) => {
+      filter(([fromStarting, skip, total, searchKey, sortKey, sortAs, areAllFetched, searchString]) => {
         return !areAllFetched || skip < total || total === null || fromStarting;
       }),
       tap(() => {
         this.store$.dispatch(SegmentsActions.actionSetIsLoadingSegments({ isLoadingSegments: true }));
       }),
-      switchMap(([fromStarting, skip, _, searchKey, sortKey, sortAs]) => {
-        let searchString = null;
-        // As withLatestFrom does not support more than 5 arguments
-        // TODO: Find alternative
-        this.getSearchString$().subscribe((searchInput) => {
-          searchString = searchInput;
-        });
+      switchMap(([fromStarting, skip, total, searchKey, sortKey, sortAs, areAllFetched, searchString]) => {
         let params: SegmentsPaginationParams = {
           skip: fromStarting ? 0 : skip,
           take: NUMBER_OF_SEGMENTS,

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.effects.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.effects.ts
@@ -13,6 +13,7 @@ import {
   selectGlobalSegments,
   selectSearchKey,
   selectSearchString,
+  selectSegmentPaginationParams,
   selectSkipSegments,
   selectSortAs,
   selectSortKey,
@@ -39,41 +40,35 @@ export class SegmentsEffects {
     this.actions$.pipe(
       ofType(SegmentsActions.actionFetchSegments),
       map((action) => action.fromStarting),
-      withLatestFrom(
-        this.store$.pipe(select(selectSkipSegments)),
-        this.store$.pipe(select(selectTotalSegments)),
-        this.store$.pipe(select(selectSearchKey)),
-        this.store$.pipe(select(selectSortKey)),
-        this.store$.pipe(select(selectSortAs)),
-        this.store$.pipe(select(selectAreAllSegmentsFetched)),
-        this.store$.pipe(select(selectSearchString))
-      ),
-      filter(([fromStarting, skip, total, searchKey, sortKey, sortAs, areAllFetched, searchString]) => {
-        return !areAllFetched || skip < total || total === null || fromStarting;
+      withLatestFrom(this.store$.pipe(select(selectSegmentPaginationParams))),
+      filter(([fromStarting, pagination]) => {
+        return (
+          !pagination.areAllFetched || pagination.skip < pagination.total || pagination.total === null || fromStarting
+        );
       }),
       tap(() => {
         this.store$.dispatch(SegmentsActions.actionSetIsLoadingSegments({ isLoadingSegments: true }));
       }),
-      switchMap(([fromStarting, skip, total, searchKey, sortKey, sortAs, areAllFetched, searchString]) => {
+      switchMap(([fromStarting, pagination]) => {
         let params: SegmentsPaginationParams = {
-          skip: fromStarting ? 0 : skip,
+          skip: fromStarting ? 0 : pagination.skip,
           take: NUMBER_OF_SEGMENTS,
         };
-        if (sortKey) {
+        if (pagination.sortKey) {
           params = {
             ...params,
             sortParams: {
-              key: sortKey,
-              sortAs,
+              key: pagination.sortKey,
+              sortAs: pagination.sortAs,
             },
           };
         }
-        if (searchString) {
+        if (pagination.searchString) {
           params = {
             ...params,
             searchParams: {
-              key: searchKey,
-              string: searchString,
+              key: pagination.searchKey,
+              string: pagination.searchString,
             },
           };
         }

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.selectors.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.selectors.ts
@@ -1,6 +1,5 @@
-import { createSelector, createFeatureSelector, select } from '@ngrx/store';
+import { createSelector, createFeatureSelector } from '@ngrx/store';
 import {
-  LIST_OPTION_TYPE,
   SegmentState,
   ParticipantListTableRow,
   Segment,
@@ -12,9 +11,7 @@ import {
 } from './segments.model';
 import { selectAll } from './segments.reducer';
 import { selectRouterState } from '../../core.state';
-import { CommonTextHelpersService } from '../../../shared/services/common-text-helpers.service';
 import { selectContextMetaData } from '../../experiments/store/experiments.selectors';
-import { selectSelectedFeatureFlag } from '../../feature-flags/store/feature-flags.selectors';
 import { SEGMENT_SEARCH_KEY, SEGMENT_TYPE } from 'upgrade_types';
 
 export const selectSegmentsState = createFeatureSelector<SegmentState>('segments');
@@ -222,6 +219,25 @@ export const selectSegmentUsageData = createSelector(
       (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
     );
   }
+);
+
+export const selectSegmentPaginationParams = createSelector(
+  selectSkipSegments,
+  selectTotalSegments,
+  selectSearchKey,
+  selectSortKey,
+  selectSortAs,
+  selectAreAllSegmentsFetched,
+  selectSearchString,
+  (skip, total, searchKey, sortKey, sortAs, areAllFetched, searchString) => ({
+    skip,
+    total,
+    searchKey,
+    sortKey,
+    sortAs,
+    areAllFetched,
+    searchString,
+  })
 );
 
 // Helper functions for the selector


### PR DESCRIPTION
Resolves #2394 

This PR fixes two critical issues in segment and feature flag effects:

1. Parameter misalignment in filter functions that could cause incorrect pagination behavior
2. Replaces improper subscription inside switchMap with proper reactive pattern using withLatestFrom