### PR TITLE
global excludes list operation actions

### DIFF
--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.model.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.model.ts
@@ -249,7 +249,7 @@ export interface SegmentState extends EntityState<Segment> {
 }
 
 export interface GlobalSegmentState extends EntityState<Segment> {
-  isLoadingGlobalSegments: boolean;
+  isLoadingSegments: boolean;
   sortKey: SEGMENT_SORT_KEY;
   sortAs: SORT_AS_DIRECTION;
 }

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.selectors.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.selectors.ts
@@ -1,6 +1,5 @@
-import { createSelector, createFeatureSelector, select } from '@ngrx/store';
+import { createSelector, createFeatureSelector } from '@ngrx/store';
 import {
-  LIST_OPTION_TYPE,
   SegmentState,
   ParticipantListTableRow,
   Segment,
@@ -12,9 +11,7 @@ import {
 } from './segments.model';
 import { selectAll } from './segments.reducer';
 import { selectRouterState } from '../../core.state';
-import { CommonTextHelpersService } from '../../../shared/services/common-text-helpers.service';
 import { selectContextMetaData } from '../../experiments/store/experiments.selectors';
-import { selectSelectedFeatureFlag } from '../../feature-flags/store/feature-flags.selectors';
 import { SEGMENT_SEARCH_KEY, SEGMENT_TYPE } from 'upgrade_types';
 
 export const selectSegmentsState = createFeatureSelector<SegmentState>('segments');
@@ -31,7 +28,7 @@ export const isLoadingUpsertSegment = createSelector(selectSegmentsState, (state
 
 export const selectIsLoadingGlobalSegments = createSelector(
   selectGlobalSegmentsState,
-  (state) => state.isLoadingGlobalSegments
+  (state) => state.isLoadingSegments
 );
 
 export const selectSegmentById = createSelector(

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/modals/upsert-segment-modal/upsert-segment-modal.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/modals/upsert-segment-modal/upsert-segment-modal.component.ts
@@ -238,7 +238,7 @@ export class UpsertSegmentModalComponent {
   }
 
   createEditRequest({ name, description, appContext, tags }: SegmentFormData, sourceSegment: Segment): void {
-    const { id, status } = sourceSegment;
+    const { id, status, type } = sourceSegment;
     const subSegmentIds = sourceSegment.subSegments.map((subSegment) => subSegment.id);
 
     // Not allow editing segment name and context if segment is in used status:
@@ -246,6 +246,7 @@ export class UpsertSegmentModalComponent {
       name = sourceSegment.name;
       appContext = sourceSegment.context;
     }
+
     const segmentRequest: UpdateSegmentRequest = {
       id,
       name,
@@ -255,7 +256,7 @@ export class UpsertSegmentModalComponent {
       groups: [],
       subSegmentIds,
       status,
-      type: SEGMENT_TYPE.PUBLIC,
+      type,
       tags,
     };
     this.segmentService.modifySegment(segmentRequest);


### PR DESCRIPTION
This resolves issues with the global exclude list operations not updating after adding the list (store wasn't being updated). It also fixes the import list modal load spinner in the global exclude page.

This borrows add/update/delete segment list actions in GlobalExclude state in order to add the segment changes back to the correct store, and refactors to avoid the redundancy between the two reducers.

Having a separate globalExclude entity state is starting to look less ideal, this feels like a strange thing to have to do but it will have to do the trick for now without larger refactor.

