### PR TITLE
tab and menu fixes for global exclude details

### DIFF
--- a/frontend/projects/upgrade/src/app/core/auth/auth.service.ts
+++ b/frontend/projects/upgrade/src/app/core/auth/auth.service.ts
@@ -8,6 +8,7 @@ import {
   selectIsAuthenticating,
   selectCurrentUser,
   selectGoogleCredential,
+  selectUserIsAdmin,
 } from './store/auth.selectors';
 import { UserPermission } from './store/auth.models';
 import { BehaviorSubject, filter, take } from 'rxjs';
@@ -21,6 +22,7 @@ import { MatDialog } from '@angular/material/dialog';
 export class AuthService {
   isLoggedIn$ = this.store$.pipe(select(selectIsLoggedIn));
   isAuthenticating$ = this.store$.pipe(select(selectIsAuthenticating));
+  isUserAdmin$ = this.store$.pipe(select(selectUserIsAdmin));
   currentUser$ = this.store$.pipe(select(selectCurrentUser));
   getGoogleCredential$ = this.store$.pipe(select(selectGoogleCredential));
   userPermissions$ = new BehaviorSubject<UserPermission>(null);

--- a/frontend/projects/upgrade/src/app/core/auth/store/auth.selectors.ts
+++ b/frontend/projects/upgrade/src/app/core/auth/store/auth.selectors.ts
@@ -1,5 +1,6 @@
 import { createSelector, createFeatureSelector } from '@ngrx/store';
-import { State, AuthState } from './auth.models';
+import { AuthState } from './auth.models';
+import { User, UserRole } from '../../users/store/users.model';
 
 export const selectAuthState = createFeatureSelector<AuthState>('auth');
 
@@ -10,6 +11,8 @@ export const selectIsLoggedIn = createSelector(selectAuthState, (state: AuthStat
 export const selectIsAuthenticating = createSelector(selectAuthState, (state: AuthState) => state.isAuthenticating);
 
 export const selectCurrentUser = createSelector(selectAuthState, (state: AuthState) => state.user);
+
+export const selectUserIsAdmin = createSelector(selectCurrentUser, (user: User) => user.role === UserRole.ADMIN);
 
 export const selectCurrentUserEmail = createSelector(selectAuthState, (state) => state.user?.email || '');
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-content/segment-lists-section-card/segment-lists-section-card.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-content/segment-lists-section-card/segment-lists-section-card.component.html
@@ -2,7 +2,7 @@
   <!-- header-left -->
   <app-common-section-card-title-header
     header-left
-    [title]="'segments.details.lists.card.title.text' | translate"
+    [title]="title | translate"
     [subtitle]="'segments.details.lists.card.subtitle.text' | translate"
     [tableRowCount]="tableRowCount$ | async"
   ></app-common-section-card-title-header>

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-content/segment-lists-section-card/segment-lists-section-card.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-content/segment-lists-section-card/segment-lists-section-card.component.ts
@@ -6,7 +6,7 @@ import {
 } from '../../../../../../../shared-standalone-component-lib/components';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
-import { IMenuButtonItem } from 'upgrade_types';
+import { IMenuButtonItem, SEGMENT_TYPE } from 'upgrade_types';
 import { SegmentsService } from '../../../../../../../core/segments/segments.service';
 import { DialogService } from '../../../../../../../shared/services/common-dialog.service';
 import {
@@ -44,6 +44,7 @@ export class SegmentListsSectionCardComponent {
   tableRowCount$ = this.segmentsService.selectSegmentListsLength$;
   selectedSegment$ = this.segmentsService.selectedSegment$;
   subscriptions = new Subscription();
+  title = '';
 
   menuButtonItems: IMenuButtonItem[] = [
     {
@@ -66,6 +67,10 @@ export class SegmentListsSectionCardComponent {
 
   ngOnInit() {
     this.permissions$ = this.authService.userPermissions$;
+    this.title =
+      this.data.type === SEGMENT_TYPE.GLOBAL_EXCLUDE
+        ? 'segments.details.lists.card.title.global-excludes.text'
+        : 'segments.details.lists.card.title.text';
   }
 
   onAddListClick(appContext: string, segmentId: string) {

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-content/segment-overview-details-section-card/segment-overview-details-footer/segment-overview-details-footer.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-content/segment-overview-details-section-card/segment-overview-details-footer/segment-overview-details-footer.component.ts
@@ -1,5 +1,7 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { CommonTabbedSectionCardFooterComponent } from '../../../../../../../../shared-standalone-component-lib/components/common-tabbed-section-card-footer/common-tabbed-section-card-footer.component';
+import { Segment } from '../../../../../../../../core/segments/store/segments.model';
+import { SEGMENT_TYPE } from 'upgrade_types';
 
 @Component({
   selector: 'app-segment-overview-details-footer',
@@ -9,10 +11,14 @@ import { CommonTabbedSectionCardFooterComponent } from '../../../../../../../../
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SegmentOverviewDetailsFooterComponent implements OnInit {
+  @Input() segment: Segment;
   tabLabels = ['Lists', 'Used By'];
   @Output() tabChange = new EventEmitter<number>();
 
   ngOnInit(): void {
+    if (this.segment?.type === SEGMENT_TYPE.GLOBAL_EXCLUDE) {
+      this.tabLabels = ['Excluded Lists'];
+    }
     // Initialize to the first tab (Lists)
     this.tabChange.emit(0);
   }

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-content/segment-overview-details-section-card/segment-overview-details-section-card.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-content/segment-overview-details-section-card/segment-overview-details-section-card.component.html
@@ -12,7 +12,7 @@
   <!-- header-right -->
   <app-common-section-card-action-buttons
     header-right
-    [showMenuButton]="true"
+    [showMenuButton]="(isUserAdmin$ | async)"
     [menuButtonItems]="menuButtonItems$ | async"
     [isSectionCardExpanded]="isSectionCardExpanded"
     (menuButtonItemClick)="onMenuButtonItemClick($event, segment)"
@@ -30,6 +30,7 @@
   <!-- footer -->
   <app-segment-overview-details-footer
     footer
+    [segment]=segment
     (tabChange)="onSelectedTabChange($event)"
   ></app-segment-overview-details-footer>
 </app-common-section-card>

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-content/segment-overview-details-section-card/segment-overview-details-section-card.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-content/segment-overview-details-section-card/segment-overview-details-section-card.component.ts
@@ -41,6 +41,7 @@ export class SegmentOverviewDetailsSectionCardComponent implements OnInit, OnDes
     this.segment$,
     this.permissions$,
   ]).pipe(map(([segment, permissions]) => ({ segment, permissions })));
+  isUserAdmin$ = this.authService.isUserAdmin$;
 
   subscriptions = new Subscription();
   segmentOverviewDetails$ = this.segmentsService.selectedSegmentOverviewDetails;

--- a/frontend/projects/upgrade/src/assets/i18n/en.json
+++ b/frontend/projects/upgrade/src/assets/i18n/en.json
@@ -521,6 +521,7 @@
   "segments.upsert-list-modal.values-placeholder.text": "Values separated by commas",
   "segments.upsert-list-modal.name-hint.text": "The name for this list.",
   "segments.details.lists.card.title.text": "Lists",
+  "segments.details.lists.card.title.global-excludes.text": "Excluded Lists",
   "segments.details.lists.card.subtitle.text": "Define lists for this segment.",
   "segments.details.add-list.button.text": "Add List",
   "segments.details.lists.card.no-data-row.text": "No lists defined for this segment. Add a new list.",


### PR DESCRIPTION
in global exclude details page, hides menu entirely if a non-admin, hides used by tab, and uses Excluded Lists as text for the first tab.