### PR TITLE
replace fetchall segment upsert behavior with listSegmentOptions store and selectors

### DIFF
--- a/frontend/projects/upgrade/src/app/core/local-storage/local-storage.service.ts
+++ b/frontend/projects/upgrade/src/app/core/local-storage/local-storage.service.ts
@@ -94,6 +94,7 @@ export class LocalStorageService {
       sortKey: (segmentSortKey as SEGMENT_SORT_KEY) || SEGMENT_SORT_KEY.NAME,
       sortAs: (segmentSortType as SORT_AS_DIRECTION) || SORT_AS_DIRECTION.ASCENDING,
       isLoadingUpsertSegment: false,
+      listSegmentOptions: [],
     };
 
     const state = {

--- a/frontend/projects/upgrade/src/app/core/segments/segments.service.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/segments.service.ts
@@ -25,26 +25,25 @@ import {
   selectGlobalSortAs,
   isLoadingUpsertSegment,
   selectSegmentIdAfterNavigation,
+  selectListSegmentOptionsByContext,
 } from './store/segments.selectors';
 import {
   AddPrivateSegmentListRequest,
   AddSegmentRequest,
   EditPrivateSegmentListRequest,
   LIST_OPTION_TYPE,
-  Segment,
   SegmentInput,
   SegmentLocalStorageKeys,
   UpdateSegmentRequest,
   UpsertSegmentType,
 } from './store/segments.model';
-import { filter, map, withLatestFrom } from 'rxjs/operators';
+import { filter, map } from 'rxjs/operators';
 import { BehaviorSubject, Observable, combineLatest } from 'rxjs';
 import { SegmentsDataService } from './segments.data.service';
 import { SEGMENT_SEARCH_KEY, SORT_AS_DIRECTION, SEGMENT_SORT_KEY, DuplicateSegmentNameError } from 'upgrade_types';
 import { LocalStorageService } from '../local-storage/local-storage.service';
 import { selectShouldUseLegacyUI } from './store/segments.selectors';
 import { selectContextMetaData } from '../experiments/store/experiments.selectors';
-import { selectSelectedFeatureFlag } from '../feature-flags/store/feature-flags.selectors';
 import { CommonTextHelpersService } from '../../shared/services/common-text-helpers.service';
 import { actionFetchContextMetaData } from '../experiments/store/experiments.actions';
 
@@ -121,15 +120,8 @@ export class SegmentsService {
     );
   };
 
-  selectSegmentsByContext(appContext: string): Observable<Segment[]> {
-    return this.selectAllSegments$.pipe(
-      map((segments) => {
-        const filteredSegments = segments.filter((segment) => {
-          return segment.context === appContext;
-        });
-        return filteredSegments;
-      })
-    );
+  selectListSegmentOptionsByContext(context: string) {
+    return this.store$.pipe(select(selectListSegmentOptionsByContext(context)));
   }
 
   fetchSegmentById(segmentId: string) {
@@ -156,6 +148,10 @@ export class SegmentsService {
 
   fetchAllSegments(fromStarting?: boolean) {
     this.store$.dispatch(SegmentsActions.actionfetchAllSegments({ fromStarting }));
+  }
+
+  fetchAllSegmentListOptions() {
+    this.store$.dispatch(SegmentsActions.actionFetchListSegmentOptions());
   }
 
   createNewSegment(segment: SegmentInput) {

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.actions.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.actions.ts
@@ -3,6 +3,7 @@ import {
   AddPrivateSegmentListRequest,
   AddSegmentRequest,
   EditPrivateSegmentListRequest,
+  ListSegmentOption,
   Segment,
   SegmentInput,
   UpdateSegmentRequest,
@@ -48,6 +49,21 @@ export const actionFetchSegmentsSuccessLegacyGetAll = createAction(
 );
 
 export const actionFetchSegmentsFailure = createAction('[Segments] Fetch Segments Failure (Legacy GET all)');
+
+export const actionFetchListSegmentOptions = createAction(
+  '[Segments] Fetch Segments Legacy GET All for listSegmentOptions'
+);
+
+export const actionFetchListSegmentOptionsSuccess = createAction(
+  '[Segments] Fetch Segments Success Legacy GET All for listSegmentOptions',
+  props<{
+    listSegmentOptions: ListSegmentOption[];
+  }>()
+);
+
+export const actionFetchListSegmentOptionsFailure = createAction(
+  '[Segments] Fetch Segments Failure Legacy GET All for listSegmentOptions'
+);
 
 export const actionFetchGlobalSegments = createAction(
   '[Global Segments] Fetch Global Segments',

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.effects.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.effects.ts
@@ -9,15 +9,9 @@ import * as SegmentsActions from './segments.actions';
 import { NUMBER_OF_SEGMENTS, Segment, SegmentsPaginationParams, UpsertSegmentType } from './segments.model';
 import {
   selectAllSegments,
-  selectAreAllSegmentsFetched,
   selectGlobalSegments,
-  selectSearchKey,
   selectSearchString,
   selectSegmentPaginationParams,
-  selectSkipSegments,
-  selectSortAs,
-  selectSortKey,
-  selectTotalSegments,
 } from './segments.selectors';
 import JSZip from 'jszip';
 import { of } from 'rxjs';
@@ -109,6 +103,27 @@ export class SegmentsEffects {
             })
           ),
           catchError(() => [SegmentsActions.actionFetchSegmentsFailure()])
+        )
+      )
+    )
+  );
+
+  fetchListSegmentOptions$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(SegmentsActions.actionFetchListSegmentOptions),
+      switchMap(() =>
+        this.segmentsDataService.fetchAllSegments().pipe(
+          map((data: { segmentsData: Segment[] }) => {
+            const listSegmentOptions = data.segmentsData.map(({ name, id, context }) => {
+              return {
+                name,
+                id,
+                context,
+              };
+            });
+            return SegmentsActions.actionFetchListSegmentOptionsSuccess({ listSegmentOptions });
+          }),
+          catchError(() => [SegmentsActions.actionFetchListSegmentOptionsFailure()])
         )
       )
     )

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.model.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.model.ts
@@ -246,6 +246,13 @@ export interface SegmentState extends EntityState<Segment> {
   searchString: string;
   sortKey: SEGMENT_SORT_KEY;
   sortAs: SORT_AS_DIRECTION;
+  listSegmentOptions: ListSegmentOption[];
+}
+
+export interface ListSegmentOption {
+  id: string;
+  name: string;
+  context: string;
 }
 
 export interface GlobalSegmentState extends EntityState<Segment> {

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.reducer.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.reducer.ts
@@ -26,6 +26,7 @@ export const initialState: SegmentState = adapter.getInitialState({
   sortKey: SEGMENT_SORT_KEY.NAME,
   sortAs: SORT_AS_DIRECTION.ASCENDING,
   isLoadingUpsertSegment: false,
+  listSegmentOptions: [],
 });
 
 const reducer = createReducer(
@@ -88,6 +89,12 @@ const reducer = createReducer(
       return adapter.upsertMany(segments, { ...newState, isLoadingSegments: false });
     }
   ),
+  on(SegmentsActions.actionFetchListSegmentOptionsSuccess, (state, { listSegmentOptions }) => {
+    return {
+      ...state,
+      listSegmentOptions,
+    };
+  }),
   on(
     SegmentsActions.actionFetchSegmentsFailure,
     SegmentsActions.actionUpsertSegmentFailure,

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.selectors.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.selectors.ts
@@ -240,6 +240,18 @@ export const selectSegmentPaginationParams = createSelector(
   })
 );
 
+export const selectListSegmentOptionsByContext = (context: string) => {
+  return createSelector(selectSegmentsState, (segmentState: SegmentState) => {
+    if (!segmentState || !segmentState.listSegmentOptions) {
+      return [];
+    }
+    // filter by context and sort alphabetically by name
+    return segmentState.listSegmentOptions
+      .filter((option) => option.context === context)
+      .sort((a, b) => a.name.localeCompare(b.name));
+  });
+};
+
 // Helper functions for the selector
 function processExperimentSegments(
   segmentData: experimentSegmentInclusionExclusionData[],

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-details-page-content.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-details-page-content.component.ts
@@ -10,6 +10,7 @@ import { Observable, Subscription } from 'rxjs';
 import { FeatureFlag } from '../../../../../../core/feature-flags/store/feature-flags.model';
 import { ActivatedRoute } from '@angular/router';
 import { SharedModule } from '../../../../../../shared/shared.module';
+import { SegmentsService } from '../../../../../../core/segments/segments.service';
 
 @Component({
   selector: 'app-feature-flag-details-page-content',
@@ -33,7 +34,11 @@ export class FeatureFlagDetailsPageContentComponent implements OnInit, OnDestroy
 
   featureFlagIdSub: Subscription;
 
-  constructor(private featureFlagsService: FeatureFlagsService, private _Activatedroute: ActivatedRoute) {}
+  constructor(
+    private featureFlagsService: FeatureFlagsService,
+    private _Activatedroute: ActivatedRoute,
+    private segmentService: SegmentsService
+  ) {}
   ngOnInit() {
     this.featureFlagIdSub = this._Activatedroute.paramMap.subscribe((params) => {
       const featureFlagIdFromParams = params.get('flagId');
@@ -41,6 +46,7 @@ export class FeatureFlagDetailsPageContentComponent implements OnInit, OnDestroy
     });
 
     this.featureFlag$ = this.featureFlagsService.selectedFeatureFlag$;
+    this.segmentService.fetchAllSegmentListOptions();
   }
 
   onSectionCardExpandChange(expanded: boolean) {

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/new-experiment/new-experiment.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/modal/new-experiment/new-experiment.component.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../../../../core/experiments/store/experiments.model';
 import { ExperimentService } from '../../../../../../core/experiments/experiments.service';
 import { ExperimentDesignStepperService } from '../../../../../../core/experiment-design-stepper/experiment-design-stepper.service';
+import { SegmentsService } from '../../../../../../core/segments/segments.service';
 
 @Component({
   selector: 'home-new-experiment',
@@ -31,6 +32,7 @@ export class NewExperimentComponent implements OnInit {
     private dialogRef: MatDialogRef<NewExperimentComponent>,
     private experimentService: ExperimentService,
     private experimentDesignStepperService: ExperimentDesignStepperService,
+    private segmentService: SegmentsService,
     @Inject(MAT_DIALOG_DATA) public data: any
   ) {
     if (this.data) {
@@ -41,6 +43,7 @@ export class NewExperimentComponent implements OnInit {
   ngOnInit() {
     // Used to fetch contextMetaData only once
     this.experimentService.fetchContextMetaData();
+    this.segmentService.fetchAllSegmentListOptions();
   }
 
   ngOnDestroy() {

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/root/home.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/root/home.component.ts
@@ -27,7 +27,6 @@ export class HomeComponent implements OnInit {
   constructor(
     private experimentService: ExperimentService,
     public dialog: MatDialog,
-    private segmentsService: SegmentsService,
     private stratificationFactorsService: StratificationFactorsService,
     private authService: AuthService,
     private previewUsersService: PreviewUsersService,
@@ -37,7 +36,6 @@ export class HomeComponent implements OnInit {
   ngOnInit() {
     this.permissions$ = this.authService.userPermissions$;
     this.experimentService.loadExperiments(true);
-    this.segmentsService.fetchSegmentsPaginated(true);
     this.stratificationFactorsService.fetchStratificationFactors(true);
     this.experimentService.fetchAllExperimentNames();
     this.previewUsersService.fetchPreviewUsers(true);

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/components/modal/import-segment/import-segment.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/components/modal/import-segment/import-segment.component.ts
@@ -45,7 +45,6 @@ export class ImportSegmentComponent {
         this.segmentDataService.importSegments(this.fileData)
       )) as importError[];
       this.showNotification(importResult);
-      this.segmentsService.fetchAllSegmentListOptions();
     } catch (error) {
       console.error('Error during segment import:', error);
     }

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/components/modal/import-segment/import-segment.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/components/modal/import-segment/import-segment.component.ts
@@ -45,7 +45,7 @@ export class ImportSegmentComponent {
         this.segmentDataService.importSegments(this.fileData)
       )) as importError[];
       this.showNotification(importResult);
-      this.segmentsService.fetchAllSegments(true);
+      this.segmentsService.fetchAllSegmentListOptions();
     } catch (error) {
       console.error('Error during segment import:', error);
     }

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/components/modal/new-segment/new-segment.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/components/modal/new-segment/new-segment.component.ts
@@ -36,6 +36,7 @@ export class NewSegmentComponent implements OnInit {
 
   ngOnInit() {
     this.experimentService.fetchContextMetaData();
+    this.segmentService.fetchAllSegmentListOptions();
   }
 
   onNoClick(): void {

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/components/segment-members/segment-members.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/components/segment-members/segment-members.component.ts
@@ -45,7 +45,7 @@ export class SegmentMembersComponent implements OnInit, OnChanges {
   contextMetaData: IContextMetaData | Record<string, unknown> = {};
   contextMetaDataSub: Subscription;
   allSegmentOptions: ListSegmentOption[];
-  allSegmentsSub: Subscription;
+  allSegmentsSub = new Subscription();
 
   segmentMemberTypes: any[];
   subSegmentIds: string[] = [];
@@ -99,17 +99,16 @@ export class SegmentMembersComponent implements OnInit, OnChanges {
       this.contextMetaData = contextMetaData;
     });
 
-    this.allSegmentsSub = this.segmentsService
-      .selectListSegmentOptionsByContext(this.segmentInfo.context)
-      .subscribe((allSegments) => {
-        this.allSegmentOptions = allSegments;
-      });
-
     this.segmentMembersForm = this._formBuilder.group({
       members: this._formBuilder.array([this.addMembers()]),
     });
 
     if (this.segmentInfo) {
+      this.allSegmentsSub.add(
+        this.segmentsService.selectListSegmentOptionsByContext(this.segmentInfo.context).subscribe((allSegments) => {
+          this.allSegmentOptions = allSegments;
+        })
+      );
       this.members.removeAt(0);
       this.segmentInfo.individualForSegment.forEach((id) => {
         this.members.push(this.addMembers(MemberTypes.INDIVIDUAL, id.userId));

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/components/segment-members/segment-members.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments-legacy/components/segment-members/segment-members.component.ts
@@ -17,6 +17,7 @@ import { ExperimentService } from '../../../../../core/experiments/experiments.s
 import { IContextMetaData } from '../../../../../core/experiments/store/experiments.model';
 import { SegmentsService } from '../../../../../core/segments/segments.service';
 import {
+  ListSegmentOption,
   MemberTypes,
   NewSegmentDialogData,
   NewSegmentDialogEvents,
@@ -43,7 +44,7 @@ export class SegmentMembersComponent implements OnInit, OnChanges {
   membersDataSource = new BehaviorSubject<AbstractControl[]>([]);
   contextMetaData: IContextMetaData | Record<string, unknown> = {};
   contextMetaDataSub: Subscription;
-  allSegments: Segment[];
+  allSegmentOptions: ListSegmentOption[];
   allSegmentsSub: Subscription;
 
   segmentMemberTypes: any[];
@@ -98,9 +99,11 @@ export class SegmentMembersComponent implements OnInit, OnChanges {
       this.contextMetaData = contextMetaData;
     });
 
-    this.allSegmentsSub = this.segmentsService.allSegments$.subscribe((allSegments) => {
-      this.allSegments = allSegments;
-    });
+    this.allSegmentsSub = this.segmentsService
+      .selectListSegmentOptionsByContext(this.segmentInfo.context)
+      .subscribe((allSegments) => {
+        this.allSegmentOptions = allSegments;
+      });
 
     this.segmentMembersForm = this._formBuilder.group({
       members: this._formBuilder.array([this.addMembers()]),
@@ -155,16 +158,15 @@ export class SegmentMembersComponent implements OnInit, OnChanges {
   }
 
   selectSubSegments(): void {
-    if (!this.allSegments) {
+    if (!this.allSegmentOptions) {
       return;
     }
 
     const isContextAll = this.currentContext === 'ALL';
 
-    this.allSegments
+    this.allSegmentOptions
       .filter(
         (segment) =>
-          segment.type !== SEGMENT_TYPE.GLOBAL_EXCLUDE &&
           (isContextAll || segment.context === this.currentContext) &&
           (!this.segmentInfo || segment.id !== this.segmentInfo.id)
       )

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-content/segment-details-page-content.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-content/segment-details-page-content.component.ts
@@ -32,6 +32,7 @@ export class SegmentDetailsPageContentComponent implements OnInit {
 
   ngOnInit() {
     this.segment$ = this.segmentsService.selectedSegment$;
+    this.segmentsService.fetchAllSegmentListOptions();
   }
 
   onSectionCardExpandChange(expanded: boolean) {


### PR DESCRIPTION
This was in response to comments on https://github.com/CarnegieLearningWeb/UpGrade/pull/2396 and this convo https://carnegielearning.slack.com/archives/C055CGCRP6Z/p1744900743288969.

The idea is that although we now use a paginated call to gather proper 'new-style' segment data, we still have a use for getting all segment data for populating list segment selections. However, continuing to upsert these incomplete segments into the main entity store no longer makes sense.

This instead repurposes the fetch-all with a new store value `listSegmentOptions` that contains just id, name, and context of each segment, with a selector to get all by context. It will be called wherever a modal in the new or old experience needs a dropdown with these items to select a segment in that context.

For legacy usage:
1) this meant a small refactor of the "old" experiments modal for participants and the old segment edit modal, since it will still be accessible. These depended on fetch-all from the root page which was removed. Luckily it works fine just replacing the source and tweaking the timing of the fetch.

2) There are still 2 places that call fetch-all in the old manner, I left those in there because if the segments toggle is off technically these would still need that functionality, but they are not accessible in the new view and will be easy to remove for good once we are committed to the new UI.

