### PR TITLE
Truncate Lengthy Tags on Root/Details Pages

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.html
@@ -79,20 +79,11 @@
         {{ FLAG_TRANSLATION_KEYS.TAGS | translate }}
       </th>
       <td mat-cell *matCellDef="let flag" class="tags-column ft-14-400 dense-2">
-        <mat-chip-listbox aria-label="Flag tags">
-          <mat-chip
-            *ngFor="let tag of flag.tags"
-            class="tag"
-            (click)="filterFeatureFlagByChips(tag, FeatureFlagSearchKey.TAG)"
-          >
-          <span
-            class="chip-label"
-            [matTooltip]="tag.length > 16 ? tag : null"
-            matTooltipPosition="above">
-              {{ tag | truncate : 16 }}
-          </span>
-          </mat-chip>
-        </mat-chip-listbox>
+        <app-common-tag-list
+          [tags]="flag.tags"
+          ariaLabel="Flag tags"
+          (tagClick)="filterFeatureFlagByChips($event, FeatureFlagSearchKey.TAG)"
+        ></app-common-tag-list>
       </td>
     </ng-container>
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.html
@@ -85,7 +85,12 @@
             class="tag"
             (click)="filterFeatureFlagByChips(tag, FeatureFlagSearchKey.TAG)"
           >
-            <span class="chip-label">{{ tag }}</span>
+          <span
+            class="chip-label"
+            [matTooltip]="tag.length > 16 ? tag : null"
+            matTooltipPosition="above">
+              {{ tag | truncate : 16 }}
+          </span>
           </mat-chip>
         </mat-chip-listbox>
       </td>

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.ts
@@ -12,14 +12,26 @@ import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { AsyncPipe, NgIf, NgFor } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { MatSort } from '@angular/material/sort';
-import { CommonStatusIndicatorChipComponent } from '../../../../../../../../shared-standalone-component-lib/components';
+import {
+  CommonStatusIndicatorChipComponent,
+  CommonTagListComponent,
+} from '../../../../../../../../shared-standalone-component-lib/components';
 import { FeatureFlagsService } from '../../../../../../../../core/feature-flags/feature-flags.service';
 import { SharedModule } from '../../../../../../../../shared/shared.module';
 import { FEATURE_FLAG_STATUS, FILTER_MODE, FLAG_SEARCH_KEY } from 'upgrade_types';
 
 @Component({
   selector: 'app-feature-flag-root-section-card-table',
-  imports: [MatTableModule, AsyncPipe, NgIf, NgFor, SharedModule, RouterModule, CommonStatusIndicatorChipComponent],
+  imports: [
+    MatTableModule,
+    AsyncPipe,
+    NgIf,
+    NgFor,
+    SharedModule,
+    RouterModule,
+    CommonStatusIndicatorChipComponent,
+    CommonTagListComponent,
+  ],
   templateUrl: './feature-flag-root-section-card-table.component.html',
   styleUrl: './feature-flag-root-section-card-table.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-root-section-card/segment-root-section-card-table/segment-root-section-card-table.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-root-section-card/segment-root-section-card-table/segment-root-section-card-table.component.html
@@ -78,20 +78,11 @@
         {{ SEGMENT_TRANSLATION_KEYS.TAGS | translate }}
       </th>
       <td mat-cell *matCellDef="let segment" class="tags-column ft-14-400 dense-2">
-        <mat-chip-listbox aria-label="Segment tags">
-          <mat-chip
-            *ngFor="let tag of segment.tags"
-            class="tag"
-            (click)="filterSegmentByChips(tag, SegmentSearchKey.TAG)"
-          >
-          <span
-            class="chip-label"
-            [matTooltip]="tag.length > 16 ? tag : null"
-            matTooltipPosition="above">
-              {{ tag | truncate : 16 }}
-          </span>
-          </mat-chip>
-        </mat-chip-listbox>
+        <app-common-tag-list
+          [tags]="segment.tags"
+          ariaLabel="Segment tags"
+          (tagClick)="filterSegmentByChips($event, SegmentSearchKey.TAG)"
+        ></app-common-tag-list>
       </td>
     </ng-container>
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-root-section-card/segment-root-section-card-table/segment-root-section-card-table.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-root-section-card/segment-root-section-card-table/segment-root-section-card-table.component.html
@@ -84,7 +84,12 @@
             class="tag"
             (click)="filterSegmentByChips(tag, SegmentSearchKey.TAG)"
           >
-            <span class="chip-label">{{ tag }}</span>
+          <span
+            class="chip-label"
+            [matTooltip]="tag.length > 16 ? tag : null"
+            matTooltipPosition="above">
+              {{ tag | truncate : 16 }}
+          </span>
           </mat-chip>
         </mat-chip-listbox>
       </td>

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-root-section-card/segment-root-section-card-table/segment-root-section-card-table.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-root-section-card/segment-root-section-card-table/segment-root-section-card-table.component.ts
@@ -6,7 +6,10 @@ import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { AsyncPipe, NgIf, NgFor } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { MatSort } from '@angular/material/sort';
-import { CommonStatusIndicatorChipComponent } from '../../../../../../../../shared-standalone-component-lib/components';
+import {
+  CommonStatusIndicatorChipComponent,
+  CommonTagListComponent,
+} from '../../../../../../../../shared-standalone-component-lib/components';
 import { SegmentsService } from '../../../../../../../../core/segments/segments.service';
 import { SharedModule } from '../../../../../../../../shared/shared.module';
 import { SEGMENT_SEARCH_KEY } from 'upgrade_types';
@@ -19,7 +22,16 @@ import {
 
 @Component({
   selector: 'app-segment-root-section-card-table',
-  imports: [MatTableModule, AsyncPipe, NgIf, NgFor, SharedModule, RouterModule, CommonStatusIndicatorChipComponent],
+  imports: [
+    MatTableModule,
+    AsyncPipe,
+    NgIf,
+    NgFor,
+    SharedModule,
+    RouterModule,
+    CommonStatusIndicatorChipComponent,
+    CommonTagListComponent,
+  ],
   templateUrl: './segment-root-section-card-table.component.html',
   styleUrl: './segment-root-section-card-table.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-overview-details/common-section-card-overview-details.component.html
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-overview-details/common-section-card-overview-details.component.html
@@ -5,8 +5,12 @@
       <span *ngIf="item.key !== 'Tags'" class="ft-14-400 item-value">{{ item.value }}</span>
       <mat-chip-listbox *ngIf="item.key === 'Tags'" class="chips-container">
         <mat-chip *ngFor="let tag of item.value">
-          <span class="chip-label" (click)="searchByTag(tag)">
-            {{ tag }}
+          <span
+            class="chip-label"
+            (click)="searchByTag(tag)"
+            [matTooltip]="tag.length > 16 ? tag : null"
+            matTooltipPosition="above">
+              {{ tag | truncate : 16 }}
           </span>
         </mat-chip>
       </mat-chip-listbox>

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-overview-details/common-section-card-overview-details.component.html
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-overview-details/common-section-card-overview-details.component.html
@@ -3,17 +3,12 @@
     <div class="item-key-value">
       <span class="ft-14-600">{{ item.key }}:</span>
       <span *ngIf="item.key !== 'Tags'" class="ft-14-400 item-value">{{ item.value }}</span>
-      <mat-chip-listbox *ngIf="item.key === 'Tags'" class="chips-container">
-        <mat-chip *ngFor="let tag of item.value">
-          <span
-            class="chip-label"
-            (click)="searchByTag(tag)"
-            [matTooltip]="tag.length > 16 ? tag : null"
-            matTooltipPosition="above">
-              {{ tag | truncate : 16 }}
-          </span>
-        </mat-chip>
-      </mat-chip-listbox>
+      <app-common-tag-list
+        *ngIf="item.key === 'Tags'"
+        class="chips-container"
+        [tags]="item.value"
+        (tagClick)="searchByTag($event)"
+      ></app-common-tag-list>
     </div>
   </div>
 </div>

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-overview-details/common-section-card-overview-details.component.ts
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-overview-details/common-section-card-overview-details.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 import { SharedModule } from '../../../shared/shared.module';
+import { CommonTagListComponent } from '../common-tag-list/common-tag-list.component';
 
 export interface KeyValueFormat {
   [key: string]: string | string[];
@@ -8,7 +9,7 @@ export interface KeyValueFormat {
 
 @Component({
   selector: 'app-common-section-card-overview-details',
-  imports: [SharedModule],
+  imports: [SharedModule, CommonTagListComponent],
   templateUrl: './common-section-card-overview-details.component.html',
   styleUrl: './common-section-card-overview-details.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-tag-input/common-tag-input.component.html
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-tag-input/common-tag-input.component.html
@@ -18,8 +18,12 @@
           [removable]="isChipRemovable"
           (removed)="removeChip(componentTag)"
         >
-          <span class="chip-label">
-            {{ componentTag }}
+          <span
+            class="chip-label"
+            [matTooltip]="componentTag.length > 16 ? componentTag : null"
+            matTooltipPosition="above"
+          >
+              {{ componentTag | truncate : 16 }}
           </span>
           <mat-icon matChipRemove *ngIf="isChipRemovable">cancel</mat-icon>
         </mat-chip-row>

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-tag-input/common-tag-input.component.ts
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-tag-input/common-tag-input.component.ts
@@ -11,6 +11,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { CommonTagInputType } from '../../../core/feature-flags/store/feature-flags.model';
 import { CommonImportContainerComponent } from '../common-import-container/common-import-container.component';
 import { BehaviorSubject, from, mergeMap, Observable, reduce } from 'rxjs';
+import { SharedModule } from '../../../shared/shared.module';
 
 // This Component is made to manage a list of tags using mat-chips.
 // It uses ControlValueAccessor which implements methods to synchronize the component's value with the parent form control.
@@ -54,6 +55,7 @@ import { BehaviorSubject, from, mergeMap, Observable, reduce } from 'rxjs';
     MatInputModule,
     TranslateModule,
     CommonImportContainerComponent,
+    SharedModule,
   ],
 })
 export class CommonTagsInputComponent implements ControlValueAccessor, OnInit {

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-tag-list/common-tag-list.component.html
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-tag-list/common-tag-list.component.html
@@ -1,0 +1,7 @@
+<mat-chip-listbox [attr.aria-label]="ariaLabel">
+  <app-common-tag
+    *ngFor="let tag of tags"
+    [tag]="tag"
+    (tagClick)="onTagClick($event)">
+  </app-common-tag>
+</mat-chip-listbox>

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-tag-list/common-tag-list.component.ts
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-tag-list/common-tag-list.component.ts
@@ -1,0 +1,34 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SharedModule } from '../../../shared/shared.module';
+import { MatChipsModule } from '@angular/material/chips';
+import { CommonTagComponent } from '../common-tag/common-tag.component';
+
+/**
+ * CommonTagListComponent provides a consistent way to display a list of tags
+ * throughout the application.
+ *
+ * Example usage:
+ * ```html
+ * <app-common-tag-list
+ *   [tags]="tags"
+ *   (tagClick)="handleTagClick($event)">
+ * </app-common-tag-list>
+ * ```
+ */
+@Component({
+  selector: 'app-common-tag-list',
+  imports: [CommonModule, SharedModule, MatChipsModule, CommonTagComponent],
+  templateUrl: './common-tag-list.component.html',
+  styleUrls: ['./common-tag-list.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CommonTagListComponent {
+  @Input() tags: string[] = [];
+  @Input() ariaLabel = 'Tags';
+  @Output() tagClick = new EventEmitter<string>();
+
+  onTagClick(tag: string): void {
+    this.tagClick.emit(tag);
+  }
+}

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-tag/common-tag.component.html
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-tag/common-tag.component.html
@@ -1,0 +1,8 @@
+<mat-chip class="tag" (click)="onTagClick()">
+  <span
+    class="chip-label"
+    [matTooltip]="tag.length > 16 ? tag : null"
+    matTooltipPosition="above">
+    {{ tag | truncate : 16 }}
+  </span>
+</mat-chip>

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-tag/common-tag.component.scss
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-tag/common-tag.component.scss
@@ -1,0 +1,3 @@
+.tag {
+  cursor: pointer;
+}

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-tag/common-tag.component.ts
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-tag/common-tag.component.ts
@@ -1,0 +1,33 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { SharedModule } from '../../../shared/shared.module';
+import { MatChipsModule } from '@angular/material/chips';
+
+/**
+ * CommonTagComponent provides a consistent way to display individual tag chips
+ * throughout the application with proper truncation and tooltips.
+ *
+ * Example usage:
+ * ```html
+ * <app-common-tag
+ *   [tag]="tag"
+ *   (tagClick)="handleTagClick($event)">
+ * </app-common-tag>
+ * ```
+ */
+@Component({
+  selector: 'app-common-tag',
+  imports: [CommonModule, MatTooltipModule, SharedModule, MatChipsModule],
+  templateUrl: './common-tag.component.html',
+  styleUrls: ['./common-tag.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CommonTagComponent {
+  @Input() tag = '';
+  @Output() tagClick = new EventEmitter<string>();
+
+  onTagClick(): void {
+    this.tagClick.emit(this.tag);
+  }
+}

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/index.ts
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/index.ts
@@ -10,6 +10,8 @@ import { CommonStatusIndicatorChipComponent } from './common-status-indicator-ch
 import { CommonSectionCardTitleHeaderComponent } from './common-section-card-title-header/common-section-card-title-header.component';
 import { CommonSectionCardOverviewDetailsComponent } from './common-section-card-overview-details/common-section-card-overview-details.component';
 import { CommonTagsInputComponent } from './common-tag-input/common-tag-input.component';
+import { CommonTagComponent } from './common-tag/common-tag.component';
+import { CommonTagListComponent } from './common-tag-list/common-tag-list.component';
 
 export {
   CommonPageComponent,
@@ -24,4 +26,6 @@ export {
   CommonModalComponent,
   CommonStatusIndicatorChipComponent,
   CommonTagsInputComponent,
+  CommonTagComponent,
+  CommonTagListComponent,
 };

--- a/frontend/projects/upgrade/src/styles.scss
+++ b/frontend/projects/upgrade/src/styles.scss
@@ -293,6 +293,7 @@ button[mat-icon-button] {
     font-size: 12px;
     font-weight: 400;
     color: var(--black-2);
+    -webkit-font-smoothing: antialiased;
   }
 
   &.status-indicator {


### PR DESCRIPTION
Resolves #2420

This PR truncates tags longer than 16 characters and displays the full tag string in a tooltip when truncated. This prevents long tags from affecting the column width of the root table and keeps the layout clean.

Screenshots after change:

<img width="1000" alt="Screenshot 2025-04-22 at 1 58 09 AM" src="https://github.com/user-attachments/assets/82f2a80a-a317-436c-a8f8-18e9428e8964" />
<img width="1000" alt="Screenshot 2025-04-22 at 1 58 22 AM" src="https://github.com/user-attachments/assets/3e0ba17a-f6a2-4db0-aefd-44c0f77cc7ef" />
