### PR TITLE
remove mention of status in segment search string

### DIFF
--- a/backend/packages/Upgrade/src/api/services/SegmentService.ts
+++ b/backend/packages/Upgrade/src/api/services/SegmentService.ts
@@ -251,9 +251,6 @@ export class SegmentService {
       case SEGMENT_SEARCH_KEY.NAME:
         searchString.push("coalesce(segment.name::TEXT,'')");
         break;
-      case SEGMENT_SEARCH_KEY.STATUS:
-        searchString.push("coalesce(segment.status::TEXT,'')");
-        break;
       case SEGMENT_SEARCH_KEY.CONTEXT:
         searchString.push("coalesce(segment.context::TEXT,'')");
         break;
@@ -262,7 +259,6 @@ export class SegmentService {
         break;
       default:
         searchString.push("coalesce(segment.name::TEXT,'')");
-        searchString.push("coalesce(feature_flag.status::TEXT,'')");
         searchString.push("coalesce(segment.context::TEXT,'')");
         searchString.push("coalesce(segment.tags::TEXT,'')");
         break;


### PR DESCRIPTION
The error in #2418 seems to be that segment "status" is being tied into search 'all', but we aren't supporting searching/filtering by status.

I'm not sure of the typeorm here but this seems like the fix to me, we won't be searching by 'status' so that can be removed, and when 'all' (which falls through to the default of the switch statement), it tried to fetch `feature_flag.status`, which is maybe a typo or something but even if it was `segment.status` it would be removed.