### PR TITLE
fix segments table UI pagination issues

### DIFF
--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.actions.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.actions.ts
@@ -29,6 +29,7 @@ export const actionFetchSegmentsSuccess = createAction(
     experimentSegmentExclusion: experimentSegmentInclusionExclusionData[];
     featureFlagSegmentInclusion: featureFlagSegmentInclusionExclusionData[];
     featureFlagSegmentExclusion: featureFlagSegmentInclusionExclusionData[];
+    fromStarting?: boolean;
   }>()
 );
 

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.effects.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.effects.ts
@@ -68,9 +68,7 @@ export class SegmentsEffects {
         }
         return this.segmentsDataService.fetchSegmentsPaginated(params).pipe(
           switchMap((data: any) => {
-            const actions = fromStarting ? [SegmentsActions.actionSetSkipSegments({ skipSegments: 0 })] : [];
             return [
-              ...actions,
               SegmentsActions.actionFetchSegmentsSuccess({
                 segments: data.nodes.segmentsData,
                 totalSegments: data.total,
@@ -78,6 +76,7 @@ export class SegmentsEffects {
                 experimentSegmentExclusion: data.nodes.experimentSegmentExclusionData,
                 featureFlagSegmentInclusion: data.nodes.featureFlagSegmentInclusionData,
                 featureFlagSegmentExclusion: data.nodes.featureFlagSegmentExclusionData,
+                fromStarting,
               }),
             ];
           }),

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.reducer.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.reducer.ts
@@ -51,19 +51,27 @@ const reducer = createReducer(
         experimentSegmentInclusion,
         featureFlagSegmentInclusion,
         featureFlagSegmentExclusion,
+        fromStarting,
       }
     ) => {
       const newState = {
         ...state,
-        segments,
         totalSegments,
-        skipSegments: state.skipSegments + segments.length,
         allExperimentSegmentsInclusion: experimentSegmentInclusion,
         allExperimentSegmentsExclusion: experimentSegmentExclusion,
         allFeatureFlagSegmentsInclusion: featureFlagSegmentInclusion,
         allFeatureFlagSegmentsExclusion: featureFlagSegmentExclusion,
       };
-      return adapter.upsertMany(segments, { ...newState, isLoadingSegments: false });
+
+      if (fromStarting) {
+        // when going fromStarting (on any fetch other than fetch more on scroll)
+        newState.skipSegments = segments.length;
+        return adapter.setAll(segments, { ...newState, isLoadingSegments: false });
+      } else {
+        // when fetching more
+        newState.skipSegments = state.skipSegments + segments.length;
+        return adapter.upsertMany(segments, { ...newState, isLoadingSegments: false });
+      }
     }
   ),
   on(

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-root-section-card/segment-root-section-card-table/segment-root-section-card-table.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-root-section-card/segment-root-section-card-table/segment-root-section-card-table.component.ts
@@ -11,6 +11,7 @@ import { SegmentsService } from '../../../../../../../../core/segments/segments.
 import { SharedModule } from '../../../../../../../../shared/shared.module';
 import { SEGMENT_SEARCH_KEY } from 'upgrade_types';
 import {
+  NUMBER_OF_SEGMENTS,
   Segment,
   SEGMENT_ROOT_COLUMN_NAMES,
   SEGMENT_ROOT_DISPLAYED_COLUMNS,
@@ -65,7 +66,11 @@ export class SegmentRootSectionCardTableComponent implements OnInit {
     };
 
     this.observer = new IntersectionObserver((entries) => {
-      if (entries[0].isIntersecting) {
+      // if the list is short, this will trigger again on page load because the bottom trigger is within range already
+      // if the size of the filtered set is less than the number of segments to take though, fetching more will not be needed
+      const isFilteredSetLessThanTake = this.dataSource$?.filteredData?.length < NUMBER_OF_SEGMENTS;
+
+      if (entries[0].isIntersecting && !isFilteredSetLessThanTake) {
         this.fetchSegmentsOnScroll();
       }
     }, options);

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-root-section-card/segment-root-section-card-table/segment-root-section-card-table.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-root-section-card/segment-root-section-card-table/segment-root-section-card-table.component.ts
@@ -129,8 +129,9 @@ export class SegmentRootSectionCardTableComponent implements OnInit {
         behavior: 'smooth',
       });
       this.dataSource$.data = this.dataSource$.data.sort(
-        (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
       );
     }
+    this.segmentsService.fetchSegmentsPaginated(true);
   }
 }

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-root-section-card/segment-root-section-card.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-root-section-card/segment-root-section-card.component.ts
@@ -16,12 +16,12 @@ import { DialogService } from '../../../../../../../shared/services/common-dialo
 import { Observable, map } from 'rxjs';
 import { Segment, SEGMENTS_BUTTON_ACTION } from '../../../../../../../core/segments/store/segments.model';
 import { CommonSearchWidgetSearchParams } from '../../../../../../../shared-standalone-component-lib/components/common-section-card-search-header/common-section-card-search-header.component';
+import { UserPermission } from '../../../../../../../core/auth/store/auth.models';
+import { AuthService } from '../../../../../../../core/auth/auth.service';
 import {
   CommonTableHelpersService,
   TableState,
 } from '../../../../../../../shared/services/common-table-helpers.service';
-import { UserPermission } from '../../../../../../../core/auth/store/auth.models';
-import { AuthService } from '../../../../../../../core/auth/auth.service';
 
 @Component({
   selector: 'app-segment-root-section-card',
@@ -95,6 +95,7 @@ export class SegmentRootSectionCardComponent {
   onSearch(params: CommonSearchWidgetSearchParams<SEGMENT_SEARCH_KEY>) {
     this.segmentsService.setSearchString(params.searchString);
     this.segmentsService.setSearchKey(params.searchKey as SEGMENT_SEARCH_KEY);
+    this.segmentsService.fetchSegmentsPaginated(true);
   }
 
   onAddSegmentButtonClick() {


### PR DESCRIPTION
Sharing this to show some things if we want to bandaid this to mimic the experiments table behavior.

On sort or filter click, it will perform a call to pagination endpoint, with (fromStarting = true) to set the skip back to 0 before fetching.

This will mimick experiment list behavior so we're consistent, maybe that's good enough for now. But the pattern for fetching data on sort/filter change in experiments seems completely wrong/unintuitive to me also, so I'm not sure this is much of an improvement. some convo here: https://carnegielearning.slack.com/archives/C055CGCRP6Z/p1745269308177459


