### PR TITLE
Fix/2376 duplicate name and status

### DIFF
--- a/backend/packages/Upgrade/test/unit/services/SegmentService.test.ts
+++ b/backend/packages/Upgrade/test/unit/services/SegmentService.test.ts
@@ -548,7 +548,7 @@ describe('Segment Service Testing', () => {
     }).rejects.toThrow(dupeError);
 
     // Verify checkIsDuplicateSegmentName was called with correct parameters
-    expect(service.checkIsDuplicateSegmentName).toHaveBeenCalledWith(segVal.name, segVal.context, logger);
+    expect(service.checkIsDuplicateSegmentName).toHaveBeenCalledWith(segVal.name, segVal.context, undefined, logger);
 
     // Verify addSegmentDataInDB was never called
     expect(service.addSegmentDataInDB).not.toHaveBeenCalled();

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.effects.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.effects.ts
@@ -229,7 +229,10 @@ export class SegmentsEffects {
               SegmentsActions.actionGetSegmentById({ segmentId: response.id }),
             ];
           }),
-          catchError(() => {
+          catchError((error) => {
+            if (error?.error?.type === SERVER_ERROR.SEGMENT_DUPLICATE_NAME) {
+              this.segmentsService.setDuplicateSegmentNameError(error.error);
+            }
             return of(SegmentsActions.actionUpdateSegmentFailure());
           })
         );

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.effects.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.effects.ts
@@ -15,7 +15,7 @@ import {
 } from './segments.selectors';
 import JSZip from 'jszip';
 import { of } from 'rxjs';
-import { SERVER_ERROR } from 'upgrade_types';
+import { SEGMENT_STATUS, SERVER_ERROR } from 'upgrade_types';
 import { SegmentsService } from '../segments.service';
 import { CommonModalEventsService } from '../../../shared/services/common-modal-event.service';
 
@@ -183,6 +183,10 @@ export class SegmentsEffects {
         return action.pipe(
           map((data: Segment) => {
             if (actionType === UpsertSegmentType.CREATE_NEW_SEGMENT) {
+              data = {
+                ...data,
+                status: data.status || SEGMENT_STATUS.UNUSED,
+              };
               this.router.navigate(['/segments']);
             }
             return SegmentsActions.actionUpsertSegmentSuccess({ segment: data });


### PR DESCRIPTION
Fixes two bugs found QAing old style segment regressions:
- Duplicate was broken because new old-style segment were not getting a value for 'status': fixed by adding 'Unused' on create in the effect
- It's possible to have two segments with the same name by editing one of them: fix by checking for duplicates on edit as well as create.