### PR TITLE
segments: search only substring

### DIFF
--- a/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
+++ b/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
@@ -204,7 +204,7 @@ export class FeatureFlagService {
 
     let queryBuilder = this.featureFlagRepository.createQueryBuilder('feature_flag');
     if (searchParams) {
-      const customSearchString = searchParams.string.split(' ').join(`:*&`);
+      const customSearchString = searchParams.key;
       // add search query
       const postgresSearchString = this.postgresSearchString(searchParams.key);
       queryBuilder = queryBuilder


### PR DESCRIPTION
- Switches from tokenizing, lexeme-based search to simple substring-based search for segments root page.
- Omit private segments when looking for duplicates on edit/add segment.
- Feature flag search: remove tokenization of search string - to support spaces and special characters.

Note: the change to simple substring-based search is not implemented for feature flags or experiments.