### PR TITLE
Preserve Original Key Field Value When Editing Enabled Feature Flag

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-modal/upsert-feature-flag-modal.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/modals/upsert-feature-flag-modal/upsert-feature-flag-modal.component.ts
@@ -80,16 +80,19 @@ export class UpsertFeatureFlagModalComponent {
     this.featureFlagsService.setIsDuplicateKey(false);
     this.experimentService.fetchContextMetaData();
     this.createFeatureFlagForm();
+
+    // Disable restricted fields BEFORE setting up listeners
+    if (this.isDisabled()) {
+      this.disableRestrictedFields();
+    }
+
+    // Add listeners AFTER form is fully set up
     this.listenOnKeyChangesToRemoveWarning();
     this.listenOnNameChangesToUpdateKey();
     this.listenForIsInitialFormValueChanged();
     this.listenForPrimaryButtonDisabled();
     this.listenForDuplicateKey();
     this.listenOnContext();
-
-    if (this.isDisabled()) {
-      this.disableRestrictedFields();
-    }
   }
 
   isDisabled() {
@@ -135,7 +138,7 @@ export class UpsertFeatureFlagModalComponent {
     this.subscriptions.add(
       this.featureFlagForm.get('name')?.valueChanges.subscribe((name) => {
         const keyControl = this.featureFlagForm.get('key');
-        if (keyControl && !keyControl.dirty) {
+        if (keyControl && !keyControl.dirty && !keyControl.disabled) {
           keyControl.setValue(CommonTextHelpersService.convertStringToFeatureFlagKeyFormat(name));
         }
       })


### PR DESCRIPTION
Resolves #2438

This PR fixes the two parts:

1. Disable restricted fields BEFORE setting up listeners
2. Update listenOnNameChangesToUpdateKey method to check for disabled state (Only auto-generate key when the key field is not disabled)