### PR TITLE
fix attribute case; don't create extra queries on mooclet exp. import

### DIFF
--- a/backend/packages/Upgrade/src/api/services/ImportExportService.ts
+++ b/backend/packages/Upgrade/src/api/services/ImportExportService.ts
@@ -128,7 +128,7 @@ export class ImportExportService {
             throw error;
           }
           // remove currentPosteriors from moocletPolicyParameters for export
-          const { currentPosteriors: _, ...filteredPolictParameters } = experimentRecord.moocletPolicyParameters;
+          const { current_posteriors: _, ...filteredPolictParameters } = experimentRecord.moocletPolicyParameters;
 
           experimentRecord.moocletPolicyParameters = filteredPolictParameters;
         }

--- a/backend/packages/Upgrade/src/api/services/MoocletExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/MoocletExperimentService.ts
@@ -207,11 +207,12 @@ export class MoocletExperimentService extends ExperimentService {
       });
       throw error;
     }
+    if (!queries.some((query) => query?.metric?.key === rewardMetricKey)) {
+      // if it's not already present, append default reward metric query to existing experimentDTO queries before saving
+      const defaultRewardMetricQuery = this.moocletRewardsService.getRewardMetricQuery(rewardMetricKey);
 
-    // append default reward metric query to existing experimentDTO queries before saving
-    const defaultRewardMetricQuery = this.moocletRewardsService.getRewardMetricQuery(rewardMetricKey);
-
-    queries.push(defaultRewardMetricQuery);
+      queries.push(defaultRewardMetricQuery);
+    }
 
     // create Upgrade Experiment. If this fails, then mooclet resources will not be created, and the UpGrade experiment transaction will abort
     const experimentResponse = await this.createExperiment(manager, params);


### PR DESCRIPTION
- corrects the casing 'currentPosteriors' -> 'current_posteriors'
- avoids creating duplicate queries for the reward metric on import