### PR TITLE
Move Values Count Logic to a Function

### DIFF
--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-details-participant-list-table/common-details-participant-list-table.component.html
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-details-participant-list-table/common-details-participant-list-table.component.html
@@ -22,14 +22,8 @@
         {{ PARTICIPANT_LIST_TRANSLATION_KEYS.VALUES | translate }}
       </th>
       <td mat-cell *matCellDef="let rowData" class="values-column ft-14-400">
-        <ng-container *ngIf="rowData.segment">
-          {{
-            (rowData.listType?.toLowerCase() === memberTypes.INDIVIDUAL.toLowerCase()
-              ? rowData.segment.individualForSegment?.length
-              : rowData.listType?.toLowerCase() === memberTypes.SEGMENT.toLowerCase()
-              ? rowData.segment.subSegments?.length
-              : rowData.segment.groupForSegment?.length) + ' Values'
-          }}
+        <ng-container *ngIf="rowData?.segment">
+          {{ getValuesCount(rowData) }} Values
         </ng-container>
       </td>
     </ng-container>

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-details-participant-list-table/common-details-participant-list-table.component.ts
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-details-participant-list-table/common-details-participant-list-table.component.ts
@@ -83,6 +83,18 @@ export class CommonDetailsParticipantListTableComponent {
         : ['type', 'values', 'name', 'actions'];
   }
 
+  getValuesCount(rowData: ParticipantListTableRow): number {
+    const listType = rowData.listType?.toLowerCase();
+
+    if (listType === this.memberTypes.INDIVIDUAL.toLowerCase()) {
+      return rowData.segment.individualForSegment?.length || 0;
+    } else if (listType === this.memberTypes.SEGMENT.toLowerCase()) {
+      return rowData.segment.subSegments?.length || 0;
+    } else {
+      return rowData.segment.groupForSegment?.length || 0;
+    }
+  }
+
   onSlideToggleChange(event: MatSlideToggleChange, rowData: ParticipantListTableRow): void {
     const slideToggleEvent = event.source;
     const action = slideToggleEvent.checked ? PARTICIPANT_LIST_ROW_ACTION.ENABLE : PARTICIPANT_LIST_ROW_ACTION.DISABLE;


### PR DESCRIPTION
This PR moves/improves the values count logic on the Segment details page to a function for better code organization and safety. 

This was the part of the changes in PR #2396 that was closed due to another PR that resolved the same issue.

