### PR TITLE
Display the name and description tooltips on the right

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card-table/feature-flag-root-section-card-table.component.html
@@ -19,7 +19,7 @@
         <a
           [routerLink]="['/featureflags', 'detail', flag.id]"
           [matTooltip]="flag.name.length > 24 ? flag.name : null"
-          matTooltipPosition="above"
+          matTooltipPosition="right"
           class="flag-name"
         >
           {{ flag.name | truncate : 24 }}
@@ -27,7 +27,7 @@
         <br />
         <span
           [matTooltip]="flag.description?.length > 35 ? flag.description : null"
-          matTooltipPosition="above"
+          matTooltipPosition="right"
           class="flag-description ft-10-400"
         >
           {{ flag.description | truncate : 35 }}

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-list/experiment-list.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-list/experiment-list.component.html
@@ -110,7 +110,7 @@
               [routerLink]="['/home', 'detail', experiment.id]"
               [matTooltip]="experiment.name"
               class="experiment-name"
-              matTooltipPosition="above"
+              matTooltipPosition="right"
             >
               {{ experiment.name | truncate : 30 }}
             </a>
@@ -126,7 +126,7 @@
             <span
               class="experiment-description ft-10-400"
               [matTooltip]="experiment.description"
-              matTooltipPosition="above"
+              matTooltipPosition="right"
             >
               {{ experiment.description | truncate : 35 }}
             </span>

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-root-section-card/segment-root-section-card-table/segment-root-section-card-table.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-root-section-card/segment-root-section-card-table/segment-root-section-card-table.component.html
@@ -19,7 +19,7 @@
         <a
           [routerLink]="['/segments', 'detail', segment.id]"
           [matTooltip]="segment.name.length > 24 ? segment.name : null"
-          matTooltipPosition="above"
+          matTooltipPosition="right"
           class="segment-name"
         >
           {{ segment.name | truncate : 24 }}
@@ -27,7 +27,7 @@
         <br />
         <span
           [matTooltip]="segment.description?.length > 35 ? segment.description : null"
-          matTooltipPosition="above"
+          matTooltipPosition="right"
           class="segment-description ft-10-400"
         >
           {{ segment.description | truncate : 35 }}


### PR DESCRIPTION
Resolves #2469

From my research, there was no straightforward way to change or unset the width of the tooltip box.