### PR TITLE
Update Global Exclude status to 'Excluded'

### DIFF
--- a/backend/packages/Upgrade/src/api/controllers/SegmentController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/SegmentController.ts
@@ -273,7 +273,7 @@ export class SegmentController {
     return globalExcludeSegments.map((segment) => {
       return {
         ...segment,
-        status: SEGMENT_STATUS.GLOBAL,
+        status: SEGMENT_STATUS.EXCLUDED,
       };
     });
   }

--- a/backend/packages/Upgrade/src/api/services/SegmentService.ts
+++ b/backend/packages/Upgrade/src/api/services/SegmentService.ts
@@ -336,7 +336,7 @@ export class SegmentService {
 
       const segmentsDataWithStatus = segmentsData.map((segment) => {
         if (segment.type === SEGMENT_TYPE.GLOBAL_EXCLUDE) {
-          return { ...segment, status: SEGMENT_STATUS.GLOBAL };
+          return { ...segment, status: SEGMENT_STATUS.EXCLUDED };
         } else if (segmentsUsedList.has(segment.id)) {
           return { ...segment, status: SEGMENT_STATUS.USED };
         } else {

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-content/segment-overview-details-section-card/segment-overview-details-section-card.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-content/segment-overview-details-section-card/segment-overview-details-section-card.component.ts
@@ -96,7 +96,7 @@ export class SegmentOverviewDetailsSectionCardComponent implements OnInit, OnDes
             label: 'segments.details.menu-button.delete-segment.text',
             action: SEGMENT_DETAILS_PAGE_ACTIONS.DELETE,
             disabled:
-              !permissions?.segments?.delete || [SEGMENT_STATUS.USED, SEGMENT_STATUS.GLOBAL].includes(segment?.status),
+              !permissions?.segments?.delete || [SEGMENT_STATUS.USED, SEGMENT_STATUS.EXCLUDED].includes(segment?.status),
           },
         ];
       })

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-global-section-card/segment-global-section-card-table/segment-global-section-card-table.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-global-section-card/segment-global-section-card-table/segment-global-section-card-table.component.html
@@ -19,7 +19,7 @@
         <a
           [routerLink]="['/segments', 'detail', segment.id]"
           [matTooltip]="segment.name.length > 24 ? segment.name : null"
-          matTooltipPosition="above"
+          matTooltipPosition="right"
           class="segment-name"
         >
           {{ segment.name | truncate : 24 }}
@@ -27,7 +27,7 @@
         <br />
         <span
           [matTooltip]="segment.description?.length > 35 ? segment.description : null"
-          matTooltipPosition="above"
+          matTooltipPosition="right"
           class="segment-description ft-10-400"
         >
           {{ segment.description | truncate : 35 }}

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-status-indicator-chip/common-status-indicator-chip.component.scss
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-status-indicator-chip/common-status-indicator-chip.component.scss
@@ -57,10 +57,10 @@
       background-color: var(--status-archived-alpha);
     }
 
-    &.global {
-      --mdc-chip-label-text-color: var(--status-global);
-      border: 1px solid var(--status-global);
-      background-color: var(--status-global-alpha);
+    &.excluded {
+      --mdc-chip-label-text-color: var(--status-excluded);
+      border: 1px solid var(--status-excluded);
+      background-color: var(--status-excluded-alpha);
     }
 
     &.unused {

--- a/frontend/projects/upgrade/src/app/shared/pipes/segment-status.pipe.spec.ts
+++ b/frontend/projects/upgrade/src/app/shared/pipes/segment-status.pipe.spec.ts
@@ -12,8 +12,8 @@ describe('ExperimentStatePipe', () => {
     expect(segmentStatusPipe.transform(SEGMENT_STATUS.UNUSED, SegmentStatusPipeType.COLOR)).toBe('#D8D8D8');
   });
 
-  it('should return #FD9099 color for Global Status', () => {
-    expect(segmentStatusPipe.transform(SEGMENT_STATUS.GLOBAL, SegmentStatusPipeType.COLOR)).toBe('#FD9099');
+  it('should return #FD9099 color for Excluded Status', () => {
+    expect(segmentStatusPipe.transform(SEGMENT_STATUS.EXCLUDED, SegmentStatusPipeType.COLOR)).toBe('#FD9099');
   });
 
   it('should return #0CDDA5 color for Locked Status', () => {

--- a/frontend/projects/upgrade/src/app/shared/pipes/segment-status.pipe.ts
+++ b/frontend/projects/upgrade/src/app/shared/pipes/segment-status.pipe.ts
@@ -21,8 +21,8 @@ export class SegmentStatusPipe implements PipeTransform {
         return type === SegmentStatusPipeType.TEXT ? 'Used (Locked)' : '#0CDDA5';
       case SEGMENT_STATUS.UNLOCKED:
         return type === SegmentStatusPipeType.TEXT ? 'Unlocked' : '#829CF8';
-      case SEGMENT_STATUS.GLOBAL:
-        return type === SegmentStatusPipeType.TEXT ? 'Global' : '#FD9099';
+      case SEGMENT_STATUS.EXCLUDED:
+        return type === SegmentStatusPipeType.TEXT ? 'Excluded' : '#FD9099';
     }
   }
 }

--- a/frontend/projects/upgrade/src/styles/variables.scss
+++ b/frontend/projects/upgrade/src/styles/variables.scss
@@ -17,7 +17,7 @@
   --status-enrollment-complete: #33cc66;
   --status-cancelled: #ff3333;
   --status-archived: #999999;
-  --status-global: #ff3333;
+  --status-excluded: #ff3333;
   --status-unused: #999999;
   --status-used: #3366ff;
   --status-disabled-alpha: #ff99330c;
@@ -28,7 +28,7 @@
   --status-enrollment-complete-alpha: #33cc660c;
   --status-cancelled-alpha: #ff33330c;
   --status-archived-alpha: #9999990c;
-  --status-global-alpha: #ff33330c;
+  --status-excluded-alpha: #ff33330c;
   --status-unused-alpha: #9999990c;
   --status-used-alpha: #3366ff0c;
 

--- a/types/src/Experiment/enums.ts
+++ b/types/src/Experiment/enums.ts
@@ -205,7 +205,7 @@ export enum SEGMENT_TYPE {
 export enum SEGMENT_STATUS {
   USED = 'Used',
   UNUSED = 'Unused',
-  GLOBAL = 'Global',
+  EXCLUDED = 'Excluded',
   LOCKED = 'Locked',
   UNLOCKED = 'Unlocked',
 }
@@ -281,7 +281,7 @@ export enum CACHE_PREFIX {
 }
 
 export enum STATUS_INDICATOR_CHIP_TYPE {
-  GLOBAL = 'global',
+  EXCLUDED = 'excluded',
   USED = 'used',
   UNUSED = 'unused',
   ENABLED = 'enabled',


### PR DESCRIPTION
Resolves #2461

This PR updates the status for Global Excludes from "Global" to "Excluded" for consistency with other status labels. The PR also includes fixes for tooltips on Global Excludes to display correctly on the right side, which was missed in PR #2487.

I've also considered updating the `/segments/global` endpoint to `/segments/global-exclude` (as well as related function names) for better clarity, but decided this isn't critical for the current implementation.