### PR TITLE
Disallow creation/update/import of exps/flags/segments with unknown app contexts via API

### DIFF
--- a/backend/packages/Upgrade/src/api/DTO/ExperimentDTO.ts
+++ b/backend/packages/Upgrade/src/api/DTO/ExperimentDTO.ts
@@ -1,4 +1,5 @@
 import {
+  ArrayMinSize,
   IsAlphanumeric,
   IsArray,
   IsBoolean,
@@ -353,6 +354,7 @@ abstract class BaseExperimentWithoutPayload {
 
   @IsNotEmpty()
   @IsArray()
+  @ArrayMinSize(1)
   @IsString({ each: true })
   public context: string[];
 

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
@@ -975,6 +975,11 @@ export class ExperimentController {
   ): Promise<ExperimentDTO> {
     request.logger.child({ user: currentUser });
 
+    const validationError = this.experimentService.validateExperimentContext(experiment);
+    if (validationError) {
+      throw new BadRequestError(validationError);
+    }
+
     if ('moocletPolicyParameters' in experiment) {
       if (!env.mooclets?.enabled) {
         throw new BadRequestError(
@@ -1186,6 +1191,11 @@ export class ExperimentController {
     @Req() request: AppRequest
   ): Promise<ExperimentDTO> {
     request.logger.child({ user: currentUser });
+
+    const validationError = this.experimentService.validateExperimentContext(experiment);
+    if (validationError) {
+      throw new BadRequestError(validationError);
+    }
 
     // TODO: there is a story to refactor these duplicate warnings, adding here same way as others for now
     if ('moocletPolicyParameters' in experiment) {

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
@@ -975,9 +975,9 @@ export class ExperimentController {
   ): Promise<ExperimentDTO> {
     request.logger.child({ user: currentUser });
 
-    const validationError = this.experimentService.validateExperimentContext(experiment);
-    if (validationError) {
-      throw new BadRequestError(validationError);
+    const contextValidationError = this.experimentService.validateExperimentContext(experiment);
+    if (contextValidationError) {
+      throw new BadRequestError(contextValidationError);
     }
 
     if ('moocletPolicyParameters' in experiment) {
@@ -1192,9 +1192,9 @@ export class ExperimentController {
   ): Promise<ExperimentDTO> {
     request.logger.child({ user: currentUser });
 
-    const validationError = this.experimentService.validateExperimentContext(experiment);
-    if (validationError) {
-      throw new BadRequestError(validationError);
+    const contextValidationError = this.experimentService.validateExperimentContext(experiment);
+    if (contextValidationError) {
+      throw new BadRequestError(contextValidationError);
     }
 
     // TODO: there is a story to refactor these duplicate warnings, adding here same way as others for now

--- a/backend/packages/Upgrade/src/api/controllers/FeatureFlagController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/FeatureFlagController.ts
@@ -11,6 +11,7 @@ import {
   Patch,
   Res,
   CurrentUser,
+  BadRequestError,
 } from 'routing-controllers';
 import { FeatureFlagService } from '../services/FeatureFlagService';
 import { FeatureFlag } from '../models/FeatureFlag';
@@ -314,6 +315,11 @@ export class FeatureFlagsController {
     @CurrentUser() currentUser: UserDTO,
     @Req() request: AppRequest
   ): Promise<FeatureFlag> {
+    const contextValidationError = this.featureFlagService.validateFeatureFlagContext(flag);
+    if (contextValidationError) {
+      throw new BadRequestError(contextValidationError);
+    }
+
     return this.featureFlagService.create(flag, currentUser, request.logger);
   }
 
@@ -462,6 +468,11 @@ export class FeatureFlagsController {
     @CurrentUser() currentUser: UserDTO,
     @Req() request: AppRequest
   ): Promise<FeatureFlag> {
+    const contextValidationError = this.featureFlagService.validateFeatureFlagContext(flag);
+    if (contextValidationError) {
+      throw new BadRequestError(contextValidationError);
+    }
+
     return this.featureFlagService.update({ ...flag, id }, currentUser, request.logger);
   }
 

--- a/backend/packages/Upgrade/src/api/controllers/SegmentController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/SegmentController.ts
@@ -1,4 +1,15 @@
-import { JsonController, Get, Delete, Authorized, Post, Req, Body, QueryParams, Params } from 'routing-controllers';
+import {
+  JsonController,
+  Get,
+  Delete,
+  Authorized,
+  Post,
+  Req,
+  Body,
+  QueryParams,
+  Params,
+  BadRequestError,
+} from 'routing-controllers';
 import { SegmentService, SegmentWithStatus } from '../services/SegmentService';
 import { Segment } from '../models/Segment';
 import { AppRequest, PaginationResponse } from '../../types';
@@ -478,6 +489,11 @@ export class SegmentController {
     @Body({ validate: true }) segment: SegmentInputValidator,
     @Req() request: AppRequest
   ): Promise<Segment> {
+    const contextValidationError = this.segmentService.validateSegmentContext(segment);
+    if (contextValidationError) {
+      throw new BadRequestError(contextValidationError);
+    }
+
     return this.segmentService.upsertSegment(segment, request.logger);
   }
 

--- a/backend/packages/Upgrade/src/api/controllers/validators/FeatureFlagValidator.ts
+++ b/backend/packages/Upgrade/src/api/controllers/validators/FeatureFlagValidator.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsDefined, IsString, IsArray, IsEnum, IsOptional, ValidateNested, IsUUID } from 'class-validator';
+import { IsNotEmpty, IsDefined, IsString, IsArray, IsEnum, IsOptional, ValidateNested, IsUUID, ArrayMinSize } from 'class-validator';
 import { FILTER_MODE, FEATURE_FLAG_STATUS, FEATURE_FLAG_LIST_FILTER_MODE } from 'upgrade_types';
 import { Type } from 'class-transformer';
 import { FeatureFlagListValidator } from './FeatureFlagListValidator';
@@ -26,6 +26,7 @@ export class FeatureFlagCoreValidation {
 
   @IsNotEmpty()
   @IsArray()
+  @ArrayMinSize(1)
   @IsString({ each: true })
   public context: string[];
 

--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -1594,10 +1594,6 @@ export class ExperimentService {
   }
 
   public validateExperimentContext(experiment: ExperimentDTO): string | null {
-    if (!experiment.context || !Array.isArray(experiment.context) || experiment.context.length === 0) {
-      return `The experiment "${experiment.name}" requires a valid app context.`;
-    }
-
     const experimentContext = experiment.context[0];
     const contextMetadata = env.initialization.contextMetadata;
 

--- a/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
+++ b/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
@@ -1034,10 +1034,6 @@ export class FeatureFlagService {
   }
 
   public validateFeatureFlagContext(flag: { name: string; context: string[] }): string | null {
-    if (!flag.context || !Array.isArray(flag.context) || flag.context.length === 0) {
-      return `The feature flag "${flag.name}" requires a valid app context.`;
-    }
-
     const flagContext = flag.context[0];
     const contextMetadata = env.initialization.contextMetadata;
 

--- a/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
+++ b/backend/packages/Upgrade/src/api/services/FeatureFlagService.ts
@@ -1033,6 +1033,21 @@ export class FeatureFlagService {
     return fileStatusArray;
   }
 
+  public validateFeatureFlagContext(flag: { name: string; context: string[] }): string | null {
+    if (!flag.context || !Array.isArray(flag.context) || flag.context.length === 0) {
+      return `The feature flag "${flag.name}" requires a valid app context.`;
+    }
+
+    const flagContext = flag.context[0];
+    const contextMetadata = env.initialization.contextMetadata;
+
+    if (!contextMetadata[flagContext]) {
+      return `The app context "${flagContext}" is not defined in CONTEXT_METADATA.`;
+    }
+
+    return null;
+  }
+
   public async validateImportFeatureFlags(
     featureFlagFiles: IFeatureFlagFile[],
     logger: UpgradeLogger
@@ -1115,34 +1130,41 @@ export class FeatureFlagService {
     }
 
     if (compatibilityType === IMPORT_COMPATIBILITY_TYPE.COMPATIBLE) {
-      const keyExists = existingFeatureFlags?.find(
-        (existingFlag) => existingFlag.key === flag.key && existingFlag.context[0] === flag.context[0]
-      );
-
-      if (keyExists) {
+      const contextValidationError = this.validateFeatureFlagContext(flag);
+      if (contextValidationError) {
         compatibilityType = IMPORT_COMPATIBILITY_TYPE.INCOMPATIBLE;
-      } else {
-        const segmentIdsSet = new Set([
-          ...flag.featureFlagSegmentInclusion.flatMap((segmentInclusion) => {
-            return segmentInclusion.segment.subSegments.map((subSegment) => subSegment.id);
-          }),
-          ...flag.featureFlagSegmentExclusion.flatMap((segmentExclusion) => {
-            return segmentExclusion.segment.subSegments.map((subSegment) => subSegment.id);
-          }),
-        ]);
+      }
 
-        const segmentIds = Array.from(segmentIdsSet);
-        const segments = await this.segmentService.getSegmentByIds(segmentIds);
+      if (compatibilityType === IMPORT_COMPATIBILITY_TYPE.COMPATIBLE) {
+        const keyExists = existingFeatureFlags?.find(
+          (existingFlag) => existingFlag.key === flag.key && existingFlag.context[0] === flag.context[0]
+        );
 
-        if (segmentIds.length !== segments.length) {
-          compatibilityType = IMPORT_COMPATIBILITY_TYPE.WARNING;
-        }
+        if (keyExists) {
+          compatibilityType = IMPORT_COMPATIBILITY_TYPE.INCOMPATIBLE;
+        } else {
+          const segmentIdsSet = new Set([
+            ...flag.featureFlagSegmentInclusion.flatMap((segmentInclusion) => {
+              return segmentInclusion.segment.subSegments.map((subSegment) => subSegment.id);
+            }),
+            ...flag.featureFlagSegmentExclusion.flatMap((segmentExclusion) => {
+              return segmentExclusion.segment.subSegments.map((subSegment) => subSegment.id);
+            }),
+          ]);
 
-        segments.forEach((segment) => {
-          if (segment == undefined || segment.context !== flag.context[0]) {
+          const segmentIds = Array.from(segmentIdsSet);
+          const segments = await this.segmentService.getSegmentByIds(segmentIds);
+
+          if (segmentIds.length !== segments.length) {
             compatibilityType = IMPORT_COMPATIBILITY_TYPE.WARNING;
           }
-        });
+
+          segments.forEach((segment) => {
+            if (segment == undefined || segment.context !== flag.context[0]) {
+              compatibilityType = IMPORT_COMPATIBILITY_TYPE.WARNING;
+            }
+          });
+        }
       }
     }
 

--- a/backend/packages/Upgrade/src/api/services/SegmentService.ts
+++ b/backend/packages/Upgrade/src/api/services/SegmentService.ts
@@ -537,16 +537,6 @@ export class SegmentService {
     return validatedLists.importErrors;
   }
 
-  public validateSegmentContext(segment: { name: string; context: string }): string | null {
-    const contextMetadata = env.initialization.contextMetadata;
-
-    if (!contextMetadata[segment.context]) {
-      return `The app context "${segment.context}" is not defined in CONTEXT_METADATA.`;
-    }
-
-    return null;
-  }
-
   public async checkSegmentsValidity(fileData: SegmentFile[], listImport = false): Promise<SegmentValidationObj> {
     const importFileErrors: SegmentImportError[] = [];
     const segments = fileData.filter((segment) => path.extname(segment.fileName) === '.json');
@@ -690,13 +680,6 @@ export class SegmentService {
     const collectErrors = async (segment: SegmentInputValidator, contexts: string[], isList: boolean) => {
       let errorMessage = '';
       let compatibilityType = IMPORT_COMPATIBILITY_TYPE.COMPATIBLE;
-
-      const contextValidationError = this.validateSegmentContext(segment);
-      if (contextValidationError) {
-        errorMessage += contextValidationError;
-        compatibilityType = IMPORT_COMPATIBILITY_TYPE.INCOMPATIBLE;
-      }
-
       let invalidSubSegments = '';
       segment.subSegmentIds.forEach((subSegmentId) => {
         const subSegment = allSubSegmentsData

--- a/backend/packages/Upgrade/src/api/services/SegmentService.ts
+++ b/backend/packages/Upgrade/src/api/services/SegmentService.ts
@@ -537,6 +537,16 @@ export class SegmentService {
     return validatedLists.importErrors;
   }
 
+  public validateSegmentContext(segment: { name: string; context: string }): string | null {
+    const contextMetadata = env.initialization.contextMetadata;
+
+    if (!contextMetadata[segment.context]) {
+      return `The app context "${segment.context}" is not defined in CONTEXT_METADATA.`;
+    }
+
+    return null;
+  }
+
   public async checkSegmentsValidity(fileData: SegmentFile[], listImport = false): Promise<SegmentValidationObj> {
     const importFileErrors: SegmentImportError[] = [];
     const segments = fileData.filter((segment) => path.extname(segment.fileName) === '.json');
@@ -680,6 +690,13 @@ export class SegmentService {
     const collectErrors = async (segment: SegmentInputValidator, contexts: string[], isList: boolean) => {
       let errorMessage = '';
       let compatibilityType = IMPORT_COMPATIBILITY_TYPE.COMPATIBLE;
+
+      const contextValidationError = this.validateSegmentContext(segment);
+      if (contextValidationError) {
+        errorMessage += contextValidationError;
+        compatibilityType = IMPORT_COMPATIBILITY_TYPE.INCOMPATIBLE;
+      }
+
       let invalidSubSegments = '';
       segment.subSegmentIds.forEach((subSegmentId) => {
         const subSegment = allSubSegmentsData

--- a/backend/packages/Upgrade/src/api/services/SegmentService.ts
+++ b/backend/packages/Upgrade/src/api/services/SegmentService.ts
@@ -537,6 +537,16 @@ export class SegmentService {
     return validatedLists.importErrors;
   }
 
+  public validateSegmentContext(segment: { name: string; context: string }): string | null {
+    const contextMetadata = env.initialization.contextMetadata;
+
+    if (!contextMetadata[segment.context]) {
+      return `The app context "${segment.context}" is not defined in CONTEXT_METADATA.`;
+    }
+
+    return null;
+  }
+
   public async checkSegmentsValidity(fileData: SegmentFile[], listImport = false): Promise<SegmentValidationObj> {
     const importFileErrors: SegmentImportError[] = [];
     const segments = fileData.filter((segment) => path.extname(segment.fileName) === '.json');
@@ -722,7 +732,7 @@ export class SegmentService {
           ? IMPORT_COMPATIBILITY_TYPE.WARNING
           : compatibilityType;
       }
-      if (!contexts.includes(segment.context)) {
+      if (!contexts.includes(segment.context) || !contextMetaDataOptions.includes(segment.context)) {
         errorMessage =
           errorMessage + 'Context ' + segment.context + ' not found. Please enter valid context in segment. ';
         compatibilityType = IMPORT_COMPATIBILITY_TYPE.INCOMPATIBLE;


### PR DESCRIPTION
Resolves #2479

## Experiments

This PR implements validation in the `POST /api/experiments` and `PUT /api/experiments/:id` endpoints to check if the provided app context exists in `CONTEXT_METADATA`. Also, the validation is applied when `POST /api/experiments/validation` or `POST /api/experiments/import` is requested.

### How to test

Make a `POST /api/experiments` request with the following body:
```json
{"name":"MyTestExp0516","description":"","consistencyRule":"individual","assignmentUnit":"individual","type":"Simple","context":["foo"],"assignmentAlgorithm":"random","stratificationFactor":null,"tags":[],"conditions":[{"id":"3526bac1-9a37-4588-a3c6-7c2511221344","conditionCode":"question-hint-default","assignmentWeight":50,"description":null,"order":1,"name":""},{"id":"d24c1e7d-b075-46af-9bf0-9160f5b47f7c","conditionCode":"question-hint-tutorbot","assignmentWeight":50,"description":null,"order":2,"name":""}],"conditionPayloads":[{"id":"27731aeb-4f12-4d3e-a430-fd0eb0a397a9","payload":{"type":"string","value":"question-hint-default"},"parentCondition":"3526bac1-9a37-4588-a3c6-7c2511221344","decisionPoint":"4cd58858-f661-45b1-85a6-fc06f0213539"},{"id":"d5ce668f-905f-4c4b-80ce-96ddc3cdfce7","payload":{"type":"string","value":"question-hint-tutorbot"},"parentCondition":"d24c1e7d-b075-46af-9bf0-9160f5b47f7c","decisionPoint":"4cd58858-f661-45b1-85a6-fc06f0213539"}],"partitions":[{"id":"4cd58858-f661-45b1-85a6-fc06f0213539","site":"lesson-stream","target":"question-hint","description":"","order":1,"excludeIfReached":false}],"experimentSegmentInclusion":{"segment":{"individualForSegment":[],"groupForSegment":[],"subSegments":[],"type":"private"}},"experimentSegmentExclusion":{"segment":{"individualForSegment":[],"groupForSegment":[],"subSegments":[],"type":"private"}},"filterMode":"excludeAll","queries":[],"endOn":null,"enrollmentCompleteCondition":null,"startOn":null,"state":"inactive","postExperimentRule":"continue","revertTo":null}
```
You will get a response:
```
{
    "httpCode": 400,
    "name": "BadRequestError",
    "message": "The app context \"foo\" is not defined in CONTEXT_METADATA."
}
```

You can test similarly with `PUT /api/experiments/:id`, `POST /api/experiments/validation` and `POST /api/experiments/import` endpoints.

When using a valid context (e.g., "mathstream"), the request should proceed normally.

## Feature Flags

This PR implements validation in the `POST /api/flags` and `PUT /api/flags/:id` endpoints to check if the provided app context exists in `CONTEXT_METADATA`. Also, the validation is applied when `POST /api/flags/import/validation` or `POST /api/flags/import` is requested.

### How to test

Make a `POST /api/flags` request with the following body:
```json
{"name":"MyTestFlag0519","key":"MYTESTFLAG0519","description":"","context":["foo"],"tags":[],"status":"disabled","filterMode":"excludeAll"}
```
You will get a response:
```
{
    "httpCode": 400,
    "name": "BadRequestError",
    "message": "The app context \"foo\" is not defined in CONTEXT_METADATA."
}
```

You can test similarly with `PUT /api/flags/:id`, `POST /api/flags/import/validation`, and `POST /api/flags/import` endpoints.

When using a valid context (e.g., "mathstream"), the request should proceed normally.


## Segments

This PR implements validation in the `POST /api/segments` endpoint to check if the provided app context exists in `CONTEXT_METADATA`. Also, the validation is applied when `POST /api/segments/validation` (not sure when this is called), `POST /api/segments/import/validation`, or `POST /api/segments/import` is requested.

### How to test

Make a `POST /api/segments` request with the following body:
```json
{"name":"MyTestSeg0519","description":"","context":"foo","userIds":[],"groups":[],"subSegmentIds":[],"status":"Unused","type":"public","tags":[]}
```
You will get a response:
```
{
    "httpCode": 400,
    "name": "BadRequestError",
    "message": "The app context \"foo\" is not defined in CONTEXT_METADATA."
}
```

You can test similarly with `POST /api/segments/validation`, `POST /api/segments/import/validation`, and `POST /api/segments/import` endpoints.

When using a valid context (e.g., "mathstream"), the request should proceed normally.