### PR TITLE
Make experiment breadcrumb look consistent with other pages

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
@@ -1,8 +1,9 @@
 <mat-card appearance="raised" class="experiment-container" *ngIf="experiment">
-  <span class="ft-16-400">
-    <a [routerLink]="['/home']" class="ft-16-400 experiment-link"
-      >{{ 'home.view-experiment.experiments.text' | translate }}
+  <span class="ft-14-400">
+    <a [routerLink]="['/home']" class="ft-14-400 experiment-link">
+      {{ 'home.view-experiment.experiments.text' | translate }}
     </a>
+    >
     <b> {{ experiment?.name }} </b>
   </span>
   <mat-card appearance="raised" class="experiment">

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.scss
@@ -7,6 +7,10 @@ $font-size-small: 15px;
 
   .experiment-link {
     text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 
   .experiment {


### PR DESCRIPTION
Resolves #2496

Screenshot after fix:
<img width="1000" alt="Screenshot 2025-05-20 at 9 49 04 PM" src="https://github.com/user-attachments/assets/3830838d-aedf-4eae-a9de-6523f868bcab" />
