### PR TITLE
remove joins from queries and use plain ids

### DIFF
--- a/backend/packages/Upgrade/src/api/models/GroupEnrollment.ts
+++ b/backend/packages/Upgrade/src/api/models/GroupEnrollment.ts
@@ -13,6 +13,9 @@ export class GroupEnrollment extends BaseModel {
   @ManyToOne(() => Experiment, { onDelete: 'CASCADE' })
   public experiment: Experiment;
 
+  @Column({ name: 'experimentId' })
+  experimentId?: string;
+
   @Index()
   @ManyToOne(() => DecisionPoint, { onDelete: 'CASCADE' })
   public partition: DecisionPoint;
@@ -22,4 +25,7 @@ export class GroupEnrollment extends BaseModel {
 
   @ManyToOne(() => ExperimentCondition, { onDelete: 'CASCADE' })
   public condition: ExperimentCondition;
+
+  @Column({ name: 'conditionId' })
+  conditionId?: string;
 }

--- a/backend/packages/Upgrade/src/api/models/GroupExclusion.ts
+++ b/backend/packages/Upgrade/src/api/models/GroupExclusion.ts
@@ -13,6 +13,9 @@ export class GroupExclusion extends BaseModel {
   @ManyToOne(() => Experiment, { onDelete: 'CASCADE' })
   public experiment: Experiment;
 
+  @Column({ name: 'experimentId' })
+  public experimentId?: string;
+
   @IsNotEmpty()
   @Column({ type: 'enum', enum: EXCLUSION_CODE, nullable: true })
   public exclusionCode: EXCLUSION_CODE;

--- a/backend/packages/Upgrade/src/api/models/IndividualEnrollment.ts
+++ b/backend/packages/Upgrade/src/api/models/IndividualEnrollment.ts
@@ -16,6 +16,9 @@ export class IndividualEnrollment extends BaseModel {
   @ManyToOne(() => Experiment, { onDelete: 'CASCADE' })
   public experiment: Experiment;
 
+  @Column({ name: 'experimentId' })
+  experimentId?: string;
+
   @Index()
   @ManyToOne(() => DecisionPoint, { onDelete: 'CASCADE' })
   public partition: DecisionPoint;
@@ -23,6 +26,9 @@ export class IndividualEnrollment extends BaseModel {
   @Index()
   @ManyToOne(() => ExperimentUser, { onDelete: 'CASCADE' })
   public user: ExperimentUser;
+
+  @Column({ name: 'userId' })
+  userId?: string;
 
   @Column({ nullable: true })
   public groupId?: string;
@@ -34,4 +40,7 @@ export class IndividualEnrollment extends BaseModel {
   @Index()
   @ManyToOne(() => ExperimentCondition, { onDelete: 'CASCADE' })
   public condition: ExperimentCondition;
+
+  @Column({ name: 'conditionId' })
+  public conditionId?: string;
 }

--- a/backend/packages/Upgrade/src/api/models/IndividualExclusion.ts
+++ b/backend/packages/Upgrade/src/api/models/IndividualExclusion.ts
@@ -14,6 +14,9 @@ export class IndividualExclusion extends BaseModel {
   @ManyToOne(() => Experiment, { onDelete: 'CASCADE' })
   public experiment: Experiment;
 
+  @Column({ name: 'experimentId' })
+  public experimentId?: string;
+
   @IsNotEmpty()
   @Column({ type: 'enum', enum: EXCLUSION_CODE, nullable: true })
   public exclusionCode: EXCLUSION_CODE;
@@ -21,4 +24,7 @@ export class IndividualExclusion extends BaseModel {
   @Index()
   @ManyToOne(() => ExperimentUser, { onDelete: 'CASCADE' })
   public user: ExperimentUser;
+
+  @Column({ name: 'userId' })
+  public userId?: string;
 }

--- a/backend/packages/Upgrade/src/api/repositories/GroupEnrollmentRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/GroupEnrollmentRepository.ts
@@ -8,8 +8,8 @@ import { UpgradeLogger } from 'src/lib/logger/UpgradeLogger';
 export class GroupEnrollmentRepository extends Repository<GroupEnrollment> {
   public findEnrollments(groupIds: string[], experimentIds: string[]): Promise<GroupEnrollment[]> {
     return this.find({
-      where: { experiment: { id: In(experimentIds) }, groupId: In(groupIds) },
-      relations: ['experiment', 'condition'],
+      where: { experimentId: In(experimentIds), groupId: In(groupIds) },
+      select: ['groupId', 'experimentId', 'conditionId'],
     });
   }
 

--- a/backend/packages/Upgrade/src/api/repositories/GroupExclusionRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/GroupExclusionRepository.ts
@@ -42,7 +42,6 @@ export class GroupExclusionRepository extends Repository<GroupExclusion> {
       return [...selectedPrimaryKey, ...accu];
     }, []);
     return this.createQueryBuilder('groupExclusion')
-      .leftJoinAndSelect('groupExclusion.experiment', 'experiment')
       .whereInIds(primaryKeys)
       .getMany()
       .catch((errorMsg: any) => {

--- a/backend/packages/Upgrade/src/api/repositories/IndividualEnrollmentRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/IndividualEnrollmentRepository.ts
@@ -6,8 +6,8 @@ import { IndividualEnrollment } from '../models/IndividualEnrollment';
 export class IndividualEnrollmentRepository extends Repository<IndividualEnrollment> {
   public findEnrollments(userId: string, experimentIds: string[]): Promise<IndividualEnrollment[]> {
     return this.find({
-      where: { experiment: { id: In(experimentIds) }, user: { id: userId } },
-      relations: ['experiment', 'condition', 'partition'],
+      where: { experimentId: In(experimentIds), userId: userId },
+      select: ['id', 'experimentId', 'enrollmentCode', 'conditionId'],
     });
   }
 

--- a/backend/packages/Upgrade/src/api/repositories/IndividualExclusionRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/IndividualExclusionRepository.ts
@@ -39,8 +39,6 @@ export class IndividualExclusionRepository extends Repository<IndividualExclusio
       return `${experimentId}_${userId}`;
     });
     return await this.createQueryBuilder('individualExclusion')
-      .leftJoinAndSelect('individualExclusion.experiment', 'experiment')
-      .leftJoinAndSelect('individualExclusion.user', 'user')
       .whereInIds(primaryKeys)
       .getMany()
       .catch((errorMsg: any) => {

--- a/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
@@ -406,23 +406,23 @@ export class ExperimentAssignmentService {
       const experimentAssignment = await Promise.all(
         filteredExperiments.map(async (experiment) => {
           const individualEnrollment = mergedIndividualAssignment.find((assignment) => {
-            return assignment.experiment.id === experiment.id;
+            return assignment.experimentId === experiment.id;
           });
 
           const groupEnrollment = groupEnrollments.find((assignment) => {
             return (
-              assignment.experiment.id === experiment.id &&
+              assignment.experimentId === experiment.id &&
               assignment.groupId === experimentUserDoc.workingGroup[experiment.group]
             );
           });
 
           const individualExclusion = individualExclusions.find((exclusion) => {
-            return exclusion.experiment.id === experiment.id;
+            return exclusion.experimentId === experiment.id;
           });
 
           const groupExclusion = groupExclusions.find((exclusion) => {
             return (
-              exclusion.experiment.id === experiment.id &&
+              exclusion.experimentId === experiment.id &&
               exclusion.groupId === experimentUserDoc.workingGroup[experiment.group]
             );
           });
@@ -654,11 +654,11 @@ export class ExperimentAssignmentService {
     const unassignedPools = experimentPools.filter((pool) => {
       return !pool.some((experiment) => {
         const hasIndividualEnrollment = individualEnrollments.some((enrollment) => {
-          return enrollment.experiment.id === experiment.id;
+          return enrollment.experimentId === experiment.id;
         });
         const hasGroupEnrollment = groupEnrollments.some((enrollment) => {
           return (
-            enrollment.experiment.id === experiment.id &&
+            enrollment.experimentId === experiment.id &&
             enrollment.groupId === experimentUser.workingGroup[experiment.group]
           );
         });
@@ -676,11 +676,11 @@ export class ExperimentAssignmentService {
     const priorSelectedExperiments = experimentPools.map((pool) => {
       return pool.filter((experiment) => {
         const individualEnrollment = individualEnrollments.some((enrollment) => {
-          return enrollment.experiment.id === experiment.id;
+          return enrollment.experimentId === experiment.id;
         });
         const groupEnrollment = groupEnrollments.some((enrollment) => {
           return (
-            enrollment.experiment.id === experiment.id &&
+            enrollment.experimentId === experiment.id &&
             enrollment.groupId === experimentUser.workingGroup[experiment.group]
           );
         });
@@ -987,7 +987,7 @@ export class ExperimentAssignmentService {
 
     // check assignments for group experiment
     const experimentAssignedIds = individualEnrollments.map((assignment) => {
-      return assignment.experiment.id;
+      return assignment.experimentId;
     });
 
     // create set of experiment ids
@@ -1680,10 +1680,11 @@ export class ExperimentAssignmentService {
   ): Promise<ExperimentCondition | void> {
     const userId = user.id;
     const individualEnrollmentCondition = experiment.conditions.find(
-      (condition) => condition.id === individualEnrollment?.condition?.id
+      (condition) =>
+        condition.id === individualEnrollment?.conditionId || condition.id === individualEnrollment?.condition?.id
     );
     const groupEnrollmentCondition = experiment.conditions.find(
-      (condition) => condition.id === groupEnrollment?.condition?.id
+      (condition) => condition.id === groupEnrollment?.conditionId || condition.id === groupEnrollment?.condition?.id
     );
     if (experiment.state === EXPERIMENT_STATE.ENROLLMENT_COMPLETE && userId) {
       if (experiment.postExperimentRule === POST_EXPERIMENT_RULE.CONTINUE) {
@@ -1886,10 +1887,9 @@ export class ExperimentAssignmentService {
       )
       .map((experiment) => experiment.id);
     const experimentsEnrolled = await this.individualEnrollmentRepository.find({
-      where: { experiment: In(experimentIdsForIndividualConsistency), user: { id: experimentUser.id } },
-      relations: ['experiment'],
+      where: { experimentId: In(experimentIdsForIndividualConsistency), userId: experimentUser.id },
     });
-    const experimentsEnrolledIds = experimentsEnrolled.map((enrollment) => enrollment.experiment.id);
+    const experimentsEnrolledIds = experimentsEnrolled.map((enrollment) => enrollment.experimentId);
 
     // creates segment Object for all experiments
     experiments.forEach((exp) => {

--- a/backend/packages/Upgrade/src/api/services/ExperimentUserService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentUserService.ts
@@ -413,24 +413,23 @@ export class ExperimentUserService {
     ]);
 
     const enrolledExperimentIds = individualEnrollments.map(
-      (individualAssignment) => individualAssignment.experiment.id
+      (individualAssignment) => individualAssignment.experimentId
     );
     if (enrolledExperimentIds.length > 0) {
       await this.individualEnrollmentRepository.deleteEnrollmentsOfUserInExperiments(userId, enrolledExperimentIds);
     }
 
     // remove individual exclusion related to that group
-    const excludedExperimentIds = individualExclusions.map((individualExclusion) => individualExclusion.experiment.id);
+    const excludedExperimentIds = individualExclusions.map((individualExclusion) => individualExclusion.experimentId);
 
     if (excludedExperimentIds.length > 0) {
       await this.individualExclusionRepository.deleteExperimentsForUserId(userId, excludedExperimentIds);
 
       // check if other individual exclusions are present for that group
       const otherExclusions = await this.individualExclusionRepository.find({
-        where: { experiment: { id: In(excludedExperimentIds) } },
-        relations: ['experiment'],
+        where: { experimentId: In(excludedExperimentIds) },
       });
-      const otherExcludedExperimentIds = otherExclusions.map((otherExclusion) => otherExclusion.experiment.id);
+      const otherExcludedExperimentIds = otherExclusions.map((otherExclusion) => otherExclusion.experimentId);
       // remove group exclusion
       const toRemoveExperimentFromGroupExclusions = excludedExperimentIds.filter((experimentId) => {
         return !otherExcludedExperimentIds.includes(experimentId);
@@ -455,16 +454,15 @@ export class ExperimentUserService {
     const individualExclusions = await this.individualExclusionRepository.findExcluded(userId, filteredExperimentIds);
 
     // remove individual exclusion related to that group
-    const excludedExperimentIds = individualExclusions.map((individualExclusion) => individualExclusion.experiment.id);
+    const excludedExperimentIds = individualExclusions.map((individualExclusion) => individualExclusion.experimentId);
 
     if (excludedExperimentIds.length > 0) {
       await this.individualExclusionRepository.deleteExperimentsForUserId(userId, excludedExperimentIds);
 
       const otherExclusions = await this.individualExclusionRepository.find({
-        where: { experiment: { id: In(excludedExperimentIds) }, user: { id: Not(userId) } },
-        relations: ['experiment', 'user'],
+        where: { experimentId: In(excludedExperimentIds), userId: Not(userId) },
       });
-      const otherExcludedExperimentIds = otherExclusions.map((otherExclusion) => otherExclusion.experiment.id);
+      const otherExcludedExperimentIds = otherExclusions.map((otherExclusion) => otherExclusion.experimentId);
       // remove group exclusion
       const toRemoveExperimentFromGroupExclusions = excludedExperimentIds.filter((experimentId) => {
         return !otherExcludedExperimentIds.includes(experimentId);

--- a/backend/packages/Upgrade/src/api/services/MoocletRewardsService.ts
+++ b/backend/packages/Upgrade/src/api/services/MoocletRewardsService.ts
@@ -109,7 +109,7 @@ export class MoocletRewardsService {
       await Promise.all(
         experimentsMatchingLoggedRewardKey.map(async ({ moocletExperimentRef, rewardMetricValue }) => {
           const enrollment = enrollments.find(
-            (enrollment) => enrollment.experiment.id === moocletExperimentRef.experimentId
+            (enrollment) => enrollment.experimentId === moocletExperimentRef.experimentId
           );
 
           // not sure if this even possible in reality, but should be handled
@@ -213,7 +213,7 @@ export class MoocletRewardsService {
     logger: UpgradeLogger
   ): number | null {
     const map = moocletExperimentRef.versionConditionMaps.find(
-      (map) => enrollment.condition?.id === map.experimentConditionId
+      (map) => enrollment.conditionId === map.experimentConditionId
     );
     if (!map) {
       logger.error({

--- a/backend/packages/Upgrade/test/unit/repositories/GroupEnrollmentRepository.test.ts
+++ b/backend/packages/Upgrade/test/unit/repositories/GroupEnrollmentRepository.test.ts
@@ -53,8 +53,8 @@ describe('GroupEnrollmentRepository Testing', () => {
 
     expect(repo.find).toHaveBeenCalledTimes(1);
     expect(repo.find).toHaveBeenCalledWith({
-      where: { experiment: { id: In([exp.id]) }, groupId: In([group.id]) },
-      relations: ['experiment', 'condition'],
+      where: { experimentId: In([exp.id]), groupId: In([group.id]) },
+      select: ['groupId', 'experimentId', 'conditionId'],
     });
 
     expect(res).toEqual(result);
@@ -69,8 +69,8 @@ describe('GroupEnrollmentRepository Testing', () => {
 
     expect(repo.find).toHaveBeenCalledTimes(1);
     expect(repo.find).toHaveBeenCalledWith({
-      where: { experiment: { id: In([exp.id]) }, groupId: In([group.id]) },
-      relations: ['experiment', 'condition'],
+      where: { experimentId: In([exp.id]), groupId: In([group.id]) },
+      select: ['groupId', 'experimentId', 'conditionId'],
     });
   });
 

--- a/backend/packages/Upgrade/test/unit/repositories/GroupExclusionRepository.test.ts
+++ b/backend/packages/Upgrade/test/unit/repositories/GroupExclusionRepository.test.ts
@@ -143,7 +143,6 @@ describe('GroupExclusionRepository Testing', () => {
 
     expect(repo.createQueryBuilder).toHaveBeenCalledTimes(1);
 
-    expect(mock.leftJoinAndSelect).toHaveBeenCalledTimes(1);
     expect(mock.whereInIds).toHaveBeenCalledTimes(1);
     expect(mock.getMany).toHaveBeenCalledTimes(1);
 
@@ -159,7 +158,6 @@ describe('GroupExclusionRepository Testing', () => {
 
     expect(repo.createQueryBuilder).toHaveBeenCalledTimes(1);
 
-    expect(mock.leftJoinAndSelect).toHaveBeenCalledTimes(1);
     expect(mock.whereInIds).toHaveBeenCalledTimes(1);
     expect(mock.getMany).toHaveBeenCalledTimes(1);
   });

--- a/backend/packages/Upgrade/test/unit/repositories/IndividualEnrollmentRepository.test.ts
+++ b/backend/packages/Upgrade/test/unit/repositories/IndividualEnrollmentRepository.test.ts
@@ -83,8 +83,8 @@ describe('IndividualEnrollmentRepository Testing', () => {
 
     expect(repo.find).toHaveBeenCalledTimes(1);
     expect(repo.find).toHaveBeenCalledWith({
-      where: { experiment: { id: In([exp.id]) }, user: { id: individual.id } },
-      relations: ['experiment', 'condition', 'partition'],
+      where: { experimentId: In([exp.id]), userId: individual.id },
+      select: ['id', 'experimentId', 'enrollmentCode', 'conditionId'],
     });
 
     expect(res).toEqual(result);
@@ -99,8 +99,8 @@ describe('IndividualEnrollmentRepository Testing', () => {
 
     expect(repo.find).toHaveBeenCalledTimes(1);
     expect(repo.find).toHaveBeenCalledWith({
-      where: { experiment: { id: In([exp.id]) }, user: { id: individual.id } },
-      relations: ['experiment', 'condition', 'partition'],
+      where: { experimentId: In([exp.id]), userId: individual.id },
+      select: ['id', 'experimentId', 'enrollmentCode', 'conditionId'],
     });
   });
 

--- a/backend/packages/Upgrade/test/unit/repositories/IndividualExclusionRepository.test.ts
+++ b/backend/packages/Upgrade/test/unit/repositories/IndividualExclusionRepository.test.ts
@@ -146,7 +146,6 @@ describe('IndividualExclusionRepository Testing', () => {
 
     expect(repo.createQueryBuilder).toHaveBeenCalledTimes(1);
 
-    expect(mock.leftJoinAndSelect).toHaveBeenCalledTimes(2);
     expect(mock.whereInIds).toHaveBeenCalledTimes(1);
     expect(mock.getMany).toHaveBeenCalledTimes(1);
 
@@ -162,7 +161,6 @@ describe('IndividualExclusionRepository Testing', () => {
 
     expect(repo.createQueryBuilder).toHaveBeenCalledTimes(1);
 
-    expect(mock.leftJoinAndSelect).toHaveBeenCalledTimes(2);
     expect(mock.whereInIds).toHaveBeenCalledTimes(1);
     expect(mock.getMany).toHaveBeenCalledTimes(1);
   });

--- a/backend/packages/Upgrade/test/unit/services/MoocletRewardsService.test.ts
+++ b/backend/packages/Upgrade/test/unit/services/MoocletRewardsService.test.ts
@@ -178,8 +178,8 @@ describe('MoocletRewardsService', () => {
       const enrollments = [
         {
           id: 'enrollment-1',
-          condition: { id: 'condition-1' },
-          experiment: { id: 'exp-1' },
+          conditionId: 'condition-1',
+          experimentId: 'exp-1',
         },
       ] as IndividualEnrollment[];
 
@@ -290,8 +290,8 @@ describe('MoocletRewardsService', () => {
       const enrollments = [
         {
           id: 'enrollment-1',
-          condition: { id: 'condition-1' },
-          experiment: { id: 'exp-1' },
+          conditionId: 'condition-1',
+          experimentId: 'exp-1',
         },
       ] as IndividualEnrollment[];
 
@@ -707,6 +707,7 @@ describe('MoocletRewardsService', () => {
       // Arrange
       const enrollment = {
         id: 'enrollment-1',
+        conditionId: 'condition-1',
         condition: {
           id: 'condition-1',
           name: 'Control',
@@ -743,6 +744,7 @@ describe('MoocletRewardsService', () => {
       // Arrange
       const enrollment = {
         id: 'enrollment-1',
+        conditionId: 'condition-4', // Not in the maps
         condition: {
           id: 'condition-4', // Not in the maps
           name: 'Unknown',
@@ -810,6 +812,7 @@ describe('MoocletRewardsService', () => {
       // Arrange
       const enrollment = {
         id: 'enrollment-1',
+        conditionId: 'condition-1',
         condition: {
           id: 'condition-1',
           name: 'Control',
@@ -838,6 +841,7 @@ describe('MoocletRewardsService', () => {
       // Arrange
       const enrollment = {
         id: 'enrollment-1',
+        conditionId: 'condition-3',
         condition: {
           id: 'condition-3',
           name: 'Treatment B',


### PR DESCRIPTION
- Removes the joins on other tables from `findEnrollments()` and `findExclusions()` methods for individuals and groups.
- Changes references to nested objects' Ids to the plain foreign key ids on the entities.

This intention of this slight increase in complexity is an optimization of queries that are made potentially multiple times per /assign call (they're also made in /init and /mark calls).