### PR TITLE
Fix experiment search localStorage persistence when switching filter types

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-list/experiment-list.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-list/experiment-list.component.html
@@ -17,9 +17,9 @@
           <input
             class="ft-14-400 search-input"
             matInput
-            #searchInput
             [(ngModel)]="searchValue"
-            (keyup)="applyFilter($event.target.value)"
+            (keyup)="onSearchInputKeyup($event)"
+            (input)="onSearchInputChange($event)"
             [placeholder]="'global.search.text' | translate"
           />
         </div>
@@ -27,17 +27,16 @@
           <input
             class="ft-14-400 search-input"
             matInput
-            #searchInput
             [(ngModel)]="searchValue"
-            (keyup)="applyFilter($event.target.value)"
+            (keyup)="onSearchInputKeyup($event)"
+            (input)="onSearchInputChange($event)"
             [placeholder]="'global.search.text' | translate"
-            [formControl]="searchControl"
             [matAutocomplete]="autoCompleteStatus"
           />
           <mat-autocomplete
             #autoCompleteStatus="matAutocomplete"
             panelWidth="fit-content"
-            (optionSelected)="applyFilter($event.option.value)"
+            (optionSelected)="onAutocompleteSelected($event)"
           >
             <mat-option class="ft-14-400" *ngFor="let filterOption of filteredStatusOptions" [value]="filterOption">
               {{ filterOption | titlecase }}

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-list/experiment-list.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-list/experiment-list.component.html
@@ -19,7 +19,7 @@
             matInput
             [(ngModel)]="searchValue"
             (keyup)="onSearchInputKeyup($event)"
-            (input)="onSearchInputChange($event)"
+            (ngModelChange)="onSearchInputChange($event)"
             [placeholder]="'global.search.text' | translate"
           />
         </div>
@@ -29,7 +29,7 @@
             matInput
             [(ngModel)]="searchValue"
             (keyup)="onSearchInputKeyup($event)"
-            (input)="onSearchInputChange($event)"
+            (ngModelChange)="onSearchInputChange($event)"
             [placeholder]="'global.search.text' | translate"
             [matAutocomplete]="autoCompleteStatus"
           />

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-list/experiment-list.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-list/experiment-list.component.ts
@@ -263,10 +263,8 @@ export class ExperimentListComponent implements OnInit, OnDestroy, AfterViewInit
     this.applyFilter(target.value);
   }
 
-  onSearchInputChange(event: Event): void {
-    const target = event.target as HTMLInputElement;
-    // Use the subject for debounced localStorage updates
-    this.searchSubject.next(target.value);
+  onSearchInputChange(value: string): void {
+    this.searchSubject.next(value);
   }
 
   onAutocompleteSelected(event: any): void {

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-list/experiment-list.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-list/experiment-list.component.ts
@@ -267,7 +267,7 @@ export class ExperimentListComponent implements OnInit, OnDestroy, AfterViewInit
     this.searchSubject.next(value);
   }
 
-  onAutocompleteSelected(event: any): void {
+  onAutocompleteSelected(event: MatAutocompleteSelectedEvent): void {
     const selectedValue = event.option.value;
     this.applyFilter(selectedValue);
     this.setSearchString(selectedValue);

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-list/experiment-list.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-list/experiment-list.component.ts
@@ -16,6 +16,7 @@ import { UserPermission } from '../../../../../core/auth/store/auth.models';
 import { AuthService } from '../../../../../core/auth/auth.service';
 import { ImportExperimentComponent } from '../modal/import-experiment/import-experiment.component';
 import { ExportModalComponent } from '../modal/export-experiment/export-experiment.component';
+import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
 
 @Component({
   selector: 'home-experiment-list',


### PR DESCRIPTION
Resolves #2518


Changes
- Removed `fromEvent` subscription tied to DOM elements
- Added template event handlers: `(keyup)` for immediate filtering, `(input)` for debounced localStorage updates
- Implemented `Subject`-based debouncing for localStorage writes
- Enhanced autocomplete handling with dedicated `(optionSelected)` handler
- Cleaned up unused code: `FormControl`, `@ViewChild('searchInput')`, template references
