### PR TITLE
add parent segments list to 'Used By' status of segments

### DIFF
--- a/backend/packages/Upgrade/src/api/repositories/SegmentRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/SegmentRepository.ts
@@ -46,8 +46,21 @@ export class SegmentRepository extends Repository<Segment> {
       .where('segment.type=:type', { type })
       .getMany()
       .catch((errorMsg: any) => {
-        const errorMsgString = repositoryError('segmentRepository', 'getAllGlobalExcludeSegment', {}, errorMsg);
+        const errorMsgString = repositoryError('segmentRepository', 'getAllSegmentByType', {}, errorMsg);
         logger.error(errorMsg);
+        throw errorMsgString;
+      });
+  }
+
+  public async getAllParentSegments(ids: string[]): Promise<Segment[]> {
+    return this.createQueryBuilder('segment')
+      .leftJoinAndSelect('segment.subSegments', 'subSegments')
+      .leftJoinAndSelect('subSegments.subSegments', 'subSubSegments')
+      .where('subSegments.listType=:type', { type: 'Segment' })
+      .andWhere('subSubSegments.id IN (:...ids)', { ids })
+      .getMany()
+      .catch((errorMsg: any) => {
+        const errorMsgString = repositoryError('segmentRepository', 'getAllParentSegments', {}, errorMsg);
         throw errorMsgString;
       });
   }

--- a/backend/packages/Upgrade/test/unit/services/SegmentService.test.ts
+++ b/backend/packages/Upgrade/test/unit/services/SegmentService.test.ts
@@ -214,6 +214,7 @@ describe('Segment Service Testing', () => {
             delete: jest.fn(),
             countBy: jest.fn().mockResolvedValue(segmentArr.length),
             getAllSegments: jest.fn().mockResolvedValue(segmentArr),
+            getAllParentSegments: jest.fn().mockResolvedValue(segmentArr),
             deleteSegment: jest.fn().mockImplementation((seg) => {
               return seg;
             }),
@@ -383,6 +384,7 @@ describe('Segment Service Testing', () => {
       experimentSegmentInclusionData: [{ experiment: exp, segment: seg1 }],
       featureFlagSegmentExclusionData: [{ featureFlag: ff, segment: seg1 }],
       featureFlagSegmentInclusionData: [{ featureFlag: ff, segment: seg1 }],
+      allParentSegments: [seg1, seg2],
     };
     const segments = await service.getAllSegmentWithStatus(logger);
     expect(segments).toEqual(res);
@@ -406,6 +408,7 @@ describe('Segment Service Testing', () => {
       experimentSegmentInclusionData: [{ experiment: exp, segment: seg1 }],
       featureFlagSegmentExclusionData: [{ featureFlag: ff, segment: seg1 }],
       featureFlagSegmentInclusionData: [{ featureFlag: ff, segment: seg1 }],
+      allParentSegments: [seg1, seg2],
     };
     const segments = await service.getAllSegmentWithStatus(logger);
     expect(segments).toEqual(res);
@@ -425,6 +428,7 @@ describe('Segment Service Testing', () => {
       experimentSegmentInclusionData: [{ experiment: exp, segment: seg1 }],
       featureFlagSegmentExclusionData: [{ featureFlag: ff, segment: seg1 }],
       featureFlagSegmentInclusionData: [{ featureFlag: ff, segment: seg1 }],
+      allParentSegments: [seg1, seg2],
     };
     const segment = await service.getSingleSegmentWithStatus(seg1.id, logger);
     expect(segment).toEqual(res);
@@ -689,6 +693,7 @@ describe('Segment Service Testing', () => {
         experimentSegmentInclusionData: [{ experiment: exp, segment: seg1 }],
         featureFlagSegmentExclusionData: [{ featureFlag: ff, segment: seg1 }],
         featureFlagSegmentInclusionData: [{ featureFlag: ff, segment: seg1 }],
+        allParentSegments: [seg1, seg2],
       },
       2,
     ];
@@ -718,6 +723,7 @@ describe('Segment Service Testing', () => {
         experimentSegmentInclusionData: [{ experiment: exp, segment: seg1 }],
         featureFlagSegmentExclusionData: [{ featureFlag: ff, segment: seg1 }],
         featureFlagSegmentInclusionData: [{ featureFlag: ff, segment: seg1 }],
+        allParentSegments: [seg1, seg2],
       },
       2,
     ];
@@ -747,6 +753,7 @@ describe('Segment Service Testing', () => {
         experimentSegmentInclusionData: [{ experiment: exp, segment: seg1 }],
         featureFlagSegmentExclusionData: [{ featureFlag: ff, segment: seg1 }],
         featureFlagSegmentInclusionData: [{ featureFlag: ff, segment: seg1 }],
+        allParentSegments: [seg1, seg2],
       },
       2,
     ];
@@ -776,6 +783,7 @@ describe('Segment Service Testing', () => {
         experimentSegmentInclusionData: [{ experiment: exp, segment: seg1 }],
         featureFlagSegmentExclusionData: [{ featureFlag: ff, segment: seg1 }],
         featureFlagSegmentInclusionData: [{ featureFlag: ff, segment: seg1 }],
+        allParentSegments: [seg1, seg2],
       },
       2,
     ];
@@ -805,6 +813,7 @@ describe('Segment Service Testing', () => {
         experimentSegmentInclusionData: [{ experiment: exp, segment: seg1 }],
         featureFlagSegmentExclusionData: [{ featureFlag: ff, segment: seg1 }],
         featureFlagSegmentInclusionData: [{ featureFlag: ff, segment: seg1 }],
+        allParentSegments: [seg1, seg2],
       },
       2,
     ];

--- a/frontend/projects/upgrade/src/app/core/local-storage/local-storage.service.ts
+++ b/frontend/projects/upgrade/src/app/core/local-storage/local-storage.service.ts
@@ -88,6 +88,7 @@ export class LocalStorageService {
       allExperimentSegmentsExclusion: null,
       allFeatureFlagSegmentsInclusion: null,
       allFeatureFlagSegmentsExclusion: null,
+      allParentSegments: null,
       skipSegments: 0,
       totalSegments: null,
       searchKey: (segmentSearchKey as SEGMENT_SEARCH_KEY) || SEGMENT_SEARCH_KEY.ALL,

--- a/frontend/projects/upgrade/src/app/core/segments/segments.service.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/segments.service.ts
@@ -26,6 +26,7 @@ import {
   isLoadingUpsertSegment,
   selectSegmentIdAfterNavigation,
   selectListSegmentOptionsByContext,
+  selectParentSegments,
 } from './store/segments.selectors';
 import {
   AddPrivateSegmentListRequest,
@@ -81,6 +82,7 @@ export class SegmentsService {
   allExperimentSegmentsExclusion$ = this.store$.pipe(select(selectExperimentSegmentsExclusion));
   allFeatureFlagSegmentsExclusion$ = this.store$.pipe(select(selectFeatureFlagSegmentsExclusion));
   allFeatureFlagSegmentsInclusion$ = this.store$.pipe(select(selectFeatureFlagSegmentsInclusion));
+  allParentSegments$ = this.store$.pipe(select(selectParentSegments));
   segmentUsageData$ = this.store$.pipe(select(selectSegmentUsageData));
   duplicateSegmentNameError$ = new BehaviorSubject<DuplicateSegmentNameError>(null);
   selectSegmentIdAfterNavigation$ = this.store$.pipe(select(selectSegmentIdAfterNavigation));

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.actions.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.actions.ts
@@ -29,6 +29,7 @@ export const actionFetchSegmentsSuccess = createAction(
     experimentSegmentExclusion: experimentSegmentInclusionExclusionData[];
     featureFlagSegmentInclusion: featureFlagSegmentInclusionExclusionData[];
     featureFlagSegmentExclusion: featureFlagSegmentInclusionExclusionData[];
+    allParentSegments: Segment[];
     fromStarting?: boolean;
   }>()
 );
@@ -46,6 +47,7 @@ export const actionFetchSegmentsSuccessLegacyGetAll = createAction(
     experimentSegmentExclusion: experimentSegmentInclusionExclusionData[];
     featureFlagSegmentInclusion: featureFlagSegmentInclusionExclusionData[];
     featureFlagSegmentExclusion: featureFlagSegmentInclusionExclusionData[];
+    allParentSegments: Segment[];
   }>()
 );
 
@@ -123,6 +125,7 @@ export const actionGetSegmentByIdSuccess = createAction(
     experimentSegmentExclusion: experimentSegmentInclusionExclusionData[];
     featureFlagSegmentInclusion: featureFlagSegmentInclusionExclusionData[];
     featureFlagSegmentExclusion: featureFlagSegmentInclusionExclusionData[];
+    allParentSegments: Segment[];
   }>()
 );
 

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.effects.spec.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.effects.spec.ts
@@ -77,6 +77,7 @@ describe('SegmentsEffects', () => {
           experimentSegmentExclusionData: [],
           featureFlagSegmentInclusionData: [],
           featureFlagSegmentExclusionData: [],
+          allParentSegments: [],
         })
       );
       selectAllSegments.setResult([{ ...mockSegment }]);
@@ -87,6 +88,7 @@ describe('SegmentsEffects', () => {
         experimentSegmentExclusion: [],
         featureFlagSegmentInclusion: [],
         featureFlagSegmentExclusion: [],
+        allParentSegments: [],
       });
 
       service.fetchAllSegments$.subscribe((result) => {

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.effects.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.effects.ts
@@ -76,6 +76,7 @@ export class SegmentsEffects {
                 experimentSegmentExclusion: data.nodes.experimentSegmentExclusionData,
                 featureFlagSegmentInclusion: data.nodes.featureFlagSegmentInclusionData,
                 featureFlagSegmentExclusion: data.nodes.featureFlagSegmentExclusionData,
+                allParentSegments: data.nodes.allParentSegments,
                 fromStarting,
               }),
             ];
@@ -99,6 +100,7 @@ export class SegmentsEffects {
               experimentSegmentExclusion: data.experimentSegmentExclusionData,
               featureFlagSegmentInclusion: data.featureFlagSegmentInclusionData,
               featureFlagSegmentExclusion: data.featureFlagSegmentExclusionData,
+              allParentSegments: data.allParentSegments,
             })
           ),
           catchError(() => [SegmentsActions.actionFetchSegmentsFailure()])
@@ -159,6 +161,7 @@ export class SegmentsEffects {
               experimentSegmentExclusion: data.experimentSegmentExclusionData,
               featureFlagSegmentInclusion: data.featureFlagSegmentInclusionData,
               featureFlagSegmentExclusion: data.featureFlagSegmentExclusionData,
+              allParentSegments: data.allParentSegments,
             });
           }),
           catchError(() => [SegmentsActions.actionGetSegmentByIdFailure()])

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.model.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.model.ts
@@ -191,6 +191,7 @@ export interface UsedByTableRow {
 export enum USED_BY_TYPE {
   EXPERIMENT = 'Experiment',
   FEATURE_FLAG = 'Feature Flag',
+  SEGMENT = 'Segment',
 }
 
 export interface SegmentsPaginationInfo {
@@ -240,6 +241,7 @@ export interface SegmentState extends EntityState<Segment> {
   allExperimentSegmentsExclusion: any;
   allFeatureFlagSegmentsInclusion: any;
   allFeatureFlagSegmentsExclusion: any;
+  allParentSegments: any;
   skipSegments: number;
   totalSegments: number;
   searchKey: SEGMENT_SEARCH_KEY;

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.reducer.spec.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.reducer.spec.ts
@@ -34,6 +34,7 @@ describe('SegmentsReducer', () => {
         experimentSegmentInclusion: [],
         featureFlagSegmentExclusion: [],
         featureFlagSegmentInclusion: [],
+        allParentSegments: [],
       });
 
       const newState = segmentsReducer(previousState, testAction);
@@ -121,6 +122,7 @@ describe('SegmentsReducer', () => {
         experimentSegmentInclusion: [],
         featureFlagSegmentExclusion: [],
         featureFlagSegmentInclusion: [],
+        allParentSegments: [],
       });
 
       const newState = segmentsReducer(previousState, testAction);

--- a/frontend/projects/upgrade/src/app/core/segments/store/segments.reducer.ts
+++ b/frontend/projects/upgrade/src/app/core/segments/store/segments.reducer.ts
@@ -19,6 +19,7 @@ export const initialState: SegmentState = adapter.getInitialState({
   allExperimentSegmentsExclusion: null,
   allFeatureFlagSegmentsInclusion: null,
   allFeatureFlagSegmentsExclusion: null,
+  allParentSegments: null,
   skipSegments: 0,
   totalSegments: null,
   searchKey: SEGMENT_SEARCH_KEY.ALL,
@@ -51,6 +52,7 @@ const reducer = createReducer(
         experimentSegmentInclusion,
         featureFlagSegmentInclusion,
         featureFlagSegmentExclusion,
+        allParentSegments,
         fromStarting,
       }
     ) => {
@@ -61,6 +63,7 @@ const reducer = createReducer(
         allExperimentSegmentsExclusion: experimentSegmentExclusion,
         allFeatureFlagSegmentsInclusion: featureFlagSegmentInclusion,
         allFeatureFlagSegmentsExclusion: featureFlagSegmentExclusion,
+        allParentSegments,
       };
 
       if (fromStarting) {
@@ -84,6 +87,7 @@ const reducer = createReducer(
         experimentSegmentInclusion,
         featureFlagSegmentInclusion,
         featureFlagSegmentExclusion,
+        allParentSegments,
       }
     ) => {
       const newState = {
@@ -93,6 +97,7 @@ const reducer = createReducer(
         allExperimentSegmentsExclusion: experimentSegmentExclusion,
         allFeatureFlagSegmentsInclusion: featureFlagSegmentInclusion,
         allFeatureFlagSegmentsExclusion: featureFlagSegmentExclusion,
+        allParentSegments,
       };
       return adapter.upsertMany(segments, { ...newState, isLoadingSegments: false });
     }
@@ -124,6 +129,7 @@ const reducer = createReducer(
         experimentSegmentInclusion,
         featureFlagSegmentInclusion,
         featureFlagSegmentExclusion,
+        allParentSegments,
       }
     ) => {
       const newState = {
@@ -132,6 +138,7 @@ const reducer = createReducer(
         allExperimentSegmentsExclusion: experimentSegmentExclusion,
         allFeatureFlagSegmentsInclusion: featureFlagSegmentInclusion,
         allFeatureFlagSegmentsExclusion: featureFlagSegmentExclusion,
+        allParentSegments,
       };
       if (segment.type !== SEGMENT_TYPE.GLOBAL_EXCLUDE) {
         return adapter.upsertOne(segment, { ...newState, isLoadingSegments: false });

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-content/segment-overview-details-section-card/segment-overview-details-footer/segment-overview-details-footer.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-content/segment-overview-details-section-card/segment-overview-details-footer/segment-overview-details-footer.component.html
@@ -1,4 +1,5 @@
 <app-common-tabbed-section-card-footer
   [tabLabels]="tabLabels"
+  [selectedIndex]="selectedIndex"
   (selectedTabChange)="onSelectedTabChange($event)"
 ></app-common-tabbed-section-card-footer>

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-content/segment-overview-details-section-card/segment-overview-details-footer/segment-overview-details-footer.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-content/segment-overview-details-section-card/segment-overview-details-footer/segment-overview-details-footer.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output, SimpleChanges } from '@angular/core';
 import { CommonTabbedSectionCardFooterComponent } from '../../../../../../../../shared-standalone-component-lib/components/common-tabbed-section-card-footer/common-tabbed-section-card-footer.component';
 import { Segment } from '../../../../../../../../core/segments/store/segments.model';
 import { SEGMENT_TYPE } from 'upgrade_types';
@@ -13,17 +13,29 @@ import { SEGMENT_TYPE } from 'upgrade_types';
 export class SegmentOverviewDetailsFooterComponent implements OnInit {
   @Input() segment: Segment;
   tabLabels = ['Lists', 'Used By'];
+  selectedIndex = 0;
   @Output() tabChange = new EventEmitter<number>();
 
   ngOnInit(): void {
+    this.resetTabs();
+  }
+
+  ngOnChanges(): void {
+    this.resetTabs();
+  }
+
+  private resetTabs(): void {
     if (this.segment?.type === SEGMENT_TYPE.GLOBAL_EXCLUDE) {
       this.tabLabels = ['Exclude Lists'];
+    } else {
+      this.tabLabels = ['Lists', 'Used By'];
     }
-    // Initialize to the first tab (Lists)
-    this.tabChange.emit(0);
+    // Reset the selected index to the first tab
+    this.onSelectedTabChange(0);
   }
 
   onSelectedTabChange(selectedTabIndex: number): void {
+    this.selectedIndex = selectedTabIndex; // Update the selected index
     this.tabChange.emit(selectedTabIndex);
   }
 }

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-tabbed-section-card-footer/common-tabbed-section-card-footer.component.html
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-tabbed-section-card-footer/common-tabbed-section-card-footer.component.html
@@ -3,6 +3,7 @@
     mat-stretch-tabs="false"
     mat-align-tabs="start"
     animationDuration="250ms"
+    [(selectedIndex)]="selectedIndex"
     (selectedTabChange)="onSelectedTabChange($event)"
     class="new-tab-group"
   >

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-tabbed-section-card-footer/common-tabbed-section-card-footer.component.ts
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-tabbed-section-card-footer/common-tabbed-section-card-footer.component.ts
@@ -24,6 +24,7 @@ import { MatTabChangeEvent, MatTabsModule } from '@angular/material/tabs';
 })
 export class CommonTabbedSectionCardFooterComponent {
   @Input() tabLabels = [];
+  @Input() selectedIndex = 0; // Default to the first tab
   @Output() selectedTabChange = new EventEmitter<number>();
 
   onSelectedTabChange(event: MatTabChangeEvent) {

--- a/frontend/projects/upgrade/src/assets/i18n/en.json
+++ b/frontend/projects/upgrade/src/assets/i18n/en.json
@@ -537,7 +537,7 @@
   "segments.details.add-exclude-list.button.text": "Add Exclude List",
   "segments.details.lists.card.no-data-row.text": "No lists defined for this segment. Add a new list.",
   "segments.details.used-by.card.title.text": "Used By",
-  "segments.details.used-by.card.subtitle.text": "View the list of experiments and feature flags that currently use this segment.",
+  "segments.details.used-by.card.subtitle.text": "View the list of experiments, feature flags, and segments that currently use this segment.",
   "segments.details.used-by.card.no-data-row.text": "This segment is currently not being used by any experiments or feature flags.",
   "segments.segment-experiment-list-title.text": "Used by ({{ numberOfUses }}) ",
   "segments.segment-experiment-list-name.text": "Name",


### PR DESCRIPTION
- Adds an array of all segments that are parent segments of any of the segments corresponding to the supplied segment IDs to the return value from the backend  for any segments 'with status' call
- Uses that data in the frontend to determine 'Used' status and 'Used By' data
- Display of parent segment info in the 'Used By' tab follows that of experiments and feature flags, including a link to the parent segment's details page; 'Status' defaults to 'Active' for all segments.