### PR TITLE
don't await response from csv export endpoint

### DIFF
--- a/frontend/projects/upgrade/src/app/core/experiments/store/experiments.effects.spec.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/store/experiments.effects.spec.ts
@@ -85,6 +85,7 @@ describe('ExperimentEffects', () => {
     };
     notificationService = {
       showError: jest.fn(),
+      showInfo: jest.fn(),
       showSuccess: jest.fn(),
     };
     translate = {

--- a/frontend/projects/upgrade/src/app/core/experiments/store/experiments.effects.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/store/experiments.effects.ts
@@ -456,8 +456,12 @@ export class ExperimentEffects {
         this.experimentDataService.exportExperimentInfo(experimentId, email).pipe(
           tap(() => {
             email
-              ? this.notificationService.showSuccess(`Email will be sent to ${email}`)
-              : this.notificationService.showSuccess('Email will be sent to registered email');
+              ? this.notificationService.showInfo(
+                  `Export requested. If the export succeeds, email will be sent to ${email}`
+                )
+              : this.notificationService.showInfo(
+                  'Export requested. If the export succeeds, email will be sent to registered email'
+                );
           }),
           map(() => experimentAction.actionExportExperimentInfoSuccess()),
           catchError(() => [experimentAction.actionExportExperimentInfoFailure()])


### PR DESCRIPTION
- Move calls to get experiment enrollment and log info into a separate async function, and don't await the results from calling it in the 'get csv data' service method.
- Change the snackbar from 'Success' to 'Info' and add wording.