### PR TITLE
Use new 'repeated_enrollment' table for within-subject experiments

### DIFF
--- a/backend/packages/Upgrade/src/api/Algorithms.ts
+++ b/backend/packages/Upgrade/src/api/Algorithms.ts
@@ -4,7 +4,7 @@ import { Experiment } from './models/Experiment';
 import { CONDITION_ORDER, EXPERIMENT_TYPE, IExperimentAssignmentv5, IPayload } from 'upgrade_types';
 import { FactorDTO } from './DTO/FactorDTO';
 import { ExperimentCondition } from './models/ExperimentCondition';
-import { DecisionPoint } from 'src/api/models/DecisionPoint';
+import { DecisionPoint } from './models/DecisionPoint';
 
 export function withInSubjectType(
   experiment: Experiment,

--- a/backend/packages/Upgrade/src/api/Algorithms.ts
+++ b/backend/packages/Upgrade/src/api/Algorithms.ts
@@ -4,31 +4,31 @@ import { Experiment } from './models/Experiment';
 import { CONDITION_ORDER, EXPERIMENT_TYPE, IExperimentAssignmentv5, IPayload } from 'upgrade_types';
 import { FactorDTO } from './DTO/FactorDTO';
 import { ExperimentCondition } from './models/ExperimentCondition';
+import { DecisionPoint } from 'src/api/models/DecisionPoint';
 
 export function withInSubjectType(
   experiment: Experiment,
   conditionPayloads: ConditionPayloadDTO[],
-  site: string,
-  target: string,
+  decisionPoint: DecisionPoint,
   factors: FactorDTO[],
   userID: string,
-  monitoredDecisionPointLogsLength: number
+  repeatedEnrollmentLength: number
 ): IExperimentAssignmentv5 {
-  let assignedData = convertToAssignedCondition(experiment, conditionPayloads, site, target, factors);
+  let assignedData = convertToAssignedCondition(experiment, conditionPayloads, decisionPoint, factors);
 
   // passing assigned conditions data converted into queue based on selected algorithm
   if (assignedData.assignedCondition.length > 1) {
     switch (experiment.conditionOrder) {
       case CONDITION_ORDER.RANDOM: {
-        assignedData = randomCondition(experiment, assignedData, userID, monitoredDecisionPointLogsLength);
+        assignedData = randomCondition(experiment, assignedData, userID, repeatedEnrollmentLength);
         break;
       }
       case CONDITION_ORDER.RANDOM_ROUND_ROBIN: {
-        assignedData = randomRoundRobinCondition(experiment, assignedData, userID, monitoredDecisionPointLogsLength);
+        assignedData = randomRoundRobinCondition(experiment, assignedData, userID, repeatedEnrollmentLength);
         break;
       }
       case CONDITION_ORDER.ORDERED_ROUND_ROBIN: {
-        assignedData = rotateElements(assignedData, monitoredDecisionPointLogsLength);
+        assignedData = rotateElements(assignedData, repeatedEnrollmentLength);
         break;
       }
       default: {
@@ -44,7 +44,7 @@ export function randomCondition(
   experiment,
   assignedData: IExperimentAssignmentv5,
   userID: string,
-  monitoredDecisionPointLogsLength: number
+  repeatedEnrollmentLength: number
 ): IExperimentAssignmentv5 {
   const randomConditionArray: IExperimentAssignmentv5['assignedCondition'] = [];
   const assignedFactorsArray: Record<string, { level: string; payload: IPayload }>[] = [];
@@ -69,15 +69,15 @@ export function randomCondition(
     experimentType: experiment.type,
   };
 
-  // rotate elements in assigned condition array based on number of monitored decision point
-  return rotateElements(randomAssignData, monitoredDecisionPointLogsLength);
+  // rotate elements in assigned condition array based on number of repeated enrollments
+  return rotateElements(randomAssignData, repeatedEnrollmentLength);
 }
 
 export function randomRoundRobinCondition(
   experiment,
   assignedData: IExperimentAssignmentv5,
   userID: string,
-  monitoredDecisionPointLogsLength: number
+  repeatedEnrollmentLength: number
 ): IExperimentAssignmentv5 {
   const randomRoundRobinConditionArray: IExperimentAssignmentv5['assignedCondition'] = [];
   const assignedFactorsArray: Record<string, { level: string; payload: IPayload }>[] = [];
@@ -112,16 +112,16 @@ export function randomRoundRobinCondition(
     experimentType: experiment.type,
   };
 
-  // rotate elements in assigned condition array based on number of monitored decision point
-  return rotateElements(randomRoundRobinAssignData, monitoredDecisionPointLogsLength);
+  // rotate elements in assigned condition array based on number of repeated enrollments
+  return rotateElements(randomRoundRobinAssignData, repeatedEnrollmentLength);
 }
 
 export function rotateElements(
   assignedData: IExperimentAssignmentv5,
-  monitoredDecisionPointLogsLength: number
+  repeatedEnrollmentLength: number
 ): IExperimentAssignmentv5 {
-  if (monitoredDecisionPointLogsLength > 0 && assignedData.assignedCondition.length >= 2) {
-    const totalloopIteration = monitoredDecisionPointLogsLength % assignedData.assignedCondition.length;
+  if (repeatedEnrollmentLength > 0 && assignedData.assignedCondition.length >= 2) {
+    const totalloopIteration = repeatedEnrollmentLength % assignedData.assignedCondition.length;
 
     for (let i = 0; i < totalloopIteration; i++) {
       const assignedCondition = assignedData.assignedCondition.shift();
@@ -139,8 +139,7 @@ export function rotateElements(
 function convertToAssignedCondition(
   experiment: Experiment,
   conditionPayloads: ConditionPayloadDTO[],
-  site: string,
-  target: string,
+  decisionPoint: DecisionPoint,
   factors: FactorDTO[]
 ): IExperimentAssignmentv5 {
   const assignedConditionArray: IExperimentAssignmentv5['assignedCondition'] = [];
@@ -157,8 +156,7 @@ function convertToAssignedCondition(
     } else {
       // checking alias condition for simple experiment
       conditionPayload = conditionPayloads.find(
-        (cP) =>
-          cP.parentCondition.id === condition.id && cP.decisionPoint.site === site && cP.decisionPoint.target === target
+        (cP) => cP.parentCondition.id === condition.id && cP.decisionPoint.id === decisionPoint.id
       );
     }
 
@@ -173,8 +171,8 @@ function convertToAssignedCondition(
   });
 
   return {
-    site: site,
-    target: target,
+    site: decisionPoint.site,
+    target: decisionPoint.target,
     assignedCondition: assignedConditionArray,
     assignedFactor: experiment.type === EXPERIMENT_TYPE.FACTORIAL ? assignedFactorsArray : null,
     experimentType: experiment.type,

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v6.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v6.ts
@@ -29,7 +29,6 @@ import { LogValidatorv6 } from './validators/LogValidator';
 import { MetricService } from '../services/MetricService';
 import { ExperimentUserAliasesValidatorv6 } from './validators/ExperimentUserAliasesValidator';
 import { AppRequest } from '../../types';
-import { MonitoredDecisionPointLog } from '../models/MonitoredDecisionPointLog';
 import { MarkExperimentValidatorv6 } from './validators/MarkExperimentValidator.v6';
 import { Log } from '../models/Log';
 import { ExperimentUserValidatorv6 } from './validators/ExperimentUserValidator';
@@ -42,7 +41,6 @@ interface IMonitoredDecisionPoint {
   target: string;
   experimentId: string;
   condition: string;
-  monitoredPointLogs: MonitoredDecisionPointLog[];
 }
 
 /**

--- a/backend/packages/Upgrade/src/api/models/IndividualEnrollment.ts
+++ b/backend/packages/Upgrade/src/api/models/IndividualEnrollment.ts
@@ -1,11 +1,12 @@
 import { IsNotEmpty } from 'class-validator';
 import { ENROLLMENT_CODE } from 'upgrade_types';
 import { DecisionPoint } from './DecisionPoint';
-import { Entity, ManyToOne, PrimaryColumn, Column, Index } from 'typeorm';
+import { Entity, ManyToOne, PrimaryColumn, Column, Index, OneToMany } from 'typeorm';
 import { BaseModel } from './base/BaseModel';
 import { ExperimentCondition } from './ExperimentCondition';
 import { Experiment } from './Experiment';
 import { ExperimentUser } from './ExperimentUser';
+import { RepeatedEnrollment } from './RepeatedEnrollment';
 
 @Entity()
 export class IndividualEnrollment extends BaseModel {
@@ -43,4 +44,7 @@ export class IndividualEnrollment extends BaseModel {
 
   @Column({ name: 'conditionId', nullable: true })
   public conditionId?: string;
+
+  @OneToMany(() => RepeatedEnrollment, (repeatedEnrollment) => repeatedEnrollment.individualEnrollment)
+  public repeatedEnrollments?: RepeatedEnrollment[];
 }

--- a/backend/packages/Upgrade/src/api/models/RepeatedEnrollment.ts
+++ b/backend/packages/Upgrade/src/api/models/RepeatedEnrollment.ts
@@ -1,0 +1,29 @@
+import { Column, Entity, Index, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { BaseModel } from './base/BaseModel';
+import { IndividualEnrollment } from '../models/IndividualEnrollment';
+import { ExperimentCondition } from '../models/ExperimentCondition';
+
+@Entity()
+export class RepeatedEnrollment extends BaseModel {
+  @PrimaryGeneratedColumn()
+  public id: string;
+
+  @Index()
+  @ManyToOne(() => ExperimentCondition, { onDelete: 'CASCADE' })
+  public condition: ExperimentCondition;
+
+  @Column({ name: 'conditionId', nullable: true })
+  public conditionId?: string;
+
+  @Column({
+    nullable: true,
+  })
+  public uniquifier: string | null;
+
+  @Index()
+  @ManyToOne(() => IndividualEnrollment, { onDelete: 'CASCADE' })
+  public individualEnrollment: IndividualEnrollment;
+
+  @Column({ name: 'individualEnrollmentId', nullable: true })
+  public individualEnrollmentId?: string;
+}

--- a/backend/packages/Upgrade/src/api/repositories/AnalyticsRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/AnalyticsRepository.ts
@@ -1,4 +1,3 @@
-import { MonitoredDecisionPoint } from './../models/MonitoredDecisionPoint';
 import { Experiment } from '../models/Experiment';
 import { IndividualExclusionRepository } from './IndividualExclusionRepository';
 import { IndividualEnrollmentRepository } from './IndividualEnrollmentRepository';
@@ -15,11 +14,11 @@ import { GroupEnrollmentRepository } from './GroupEnrollmentRepository';
 import { GroupEnrollment } from '../models/GroupEnrollment';
 import { GroupExclusionRepository } from './GroupExclusionRepository';
 import { DecisionPoint } from '../models/DecisionPoint';
-import { MonitoredDecisionPointLog } from '../models/MonitoredDecisionPointLog';
 import { ExperimentCondition } from '../models/ExperimentCondition';
 import { UserStratificationFactorRepository } from './UserStratificationRepository';
 import _ from 'lodash';
 import { Repository } from 'typeorm';
+import { RepeatedEnrollment } from '../models/RepeatedEnrollment';
 
 export interface IEnrollmentByCondition {
   conditions_id: string;
@@ -222,13 +221,8 @@ export class AnalyticsRepository extends Repository<AnalyticsRepository> {
             '"expCond"."id" as "conditionId"',
             'COUNT(DISTINCT("individualEnrollment"."userId"))::int as count',
           ])
-          .leftJoin(MonitoredDecisionPoint, 'mdp', 'individualEnrollment.userId = mdp.userId')
-          .leftJoin(DecisionPoint, 'dp', 'dp.id = individualEnrollment.partitionId')
-          .where('"mdp"."site" = "dp"."site"')
-          .andWhere('"mdp"."target" = "dp"."target"')
-          .andWhere('"individualEnrollment"."experimentId" = :experimentId', { experimentId })
-          .leftJoin(MonitoredDecisionPointLog, 'mdpl', 'mdp.id = mdpl.monitoredDecisionPointId')
-          .leftJoin(ExperimentCondition, 'expCond', 'expCond.conditionCode = mdpl.condition')
+          .leftJoin(RepeatedEnrollment, 'repeated', 'individualEnrollment.id = repeated.individualEnrollmentId')
+          .leftJoin(ExperimentCondition, 'expCond', 'expCond.id = repeated.conditionId')
           .groupBy('"individualEnrollment"."experimentId"')
           .addGroupBy('expCond.id')
           .execute(),
@@ -240,13 +234,10 @@ export class AnalyticsRepository extends Repository<AnalyticsRepository> {
             '"expCond"."id" as "conditionId"',
             'COUNT(DISTINCT("individualEnrollment"."userId"))::int as count',
           ])
-          .leftJoin(MonitoredDecisionPoint, 'mdp', 'individualEnrollment.userId = mdp.userId')
           .leftJoin(DecisionPoint, 'dp', 'dp.id = individualEnrollment.partitionId')
-          .where('mdp.site = dp.site')
-          .andWhere('mdp.target = dp.target')
-          .andWhere('"individualEnrollment"."experimentId" = :experimentId', { experimentId })
-          .leftJoin(MonitoredDecisionPointLog, 'mdpl', 'mdp.id = mdpl.monitoredDecisionPointId')
-          .leftJoin(ExperimentCondition, 'expCond', 'expCond.conditionCode = mdpl.condition')
+          .where('"individualEnrollment"."experimentId" = :experimentId', { experimentId })
+          .leftJoin(RepeatedEnrollment, 'repeated', 'individualEnrollment.id = repeated.individualEnrollmentId')
+          .leftJoin(ExperimentCondition, 'expCond', 'expCond.id = repeated.conditionId')
           .groupBy('"dp"."id"')
           .addGroupBy('"expCond"."id"')
           .addGroupBy('"individualEnrollment"."experimentId"')
@@ -547,32 +538,31 @@ export class AnalyticsRepository extends Repository<AnalyticsRepository> {
         'experiment.context as "context"',
         'experiment.assignmentUnit as "assignmentUnit"',
         'experiment.group as "group"',
-        'monitored.site as "site"',
-        'monitored.target as "target"',
+        '"decisionPoint".site as "site"',
+        '"decisionPoint".target as "target"',
         '"individualEnrollment"."userId" as "userId"',
         '"individualEnrollment"."partitionId" as "decisionPointId"',
         '"individualEnrollment"."groupId" as "groupId"',
-        '"monitoredPointLogs"."condition" as "conditionName"',
-        'MIN("monitoredPointLogs"."createdAt") as "firstDecisionPointReachedOn"',
-        'CAST(COUNT("monitoredPointLogs"."id") as int) as "decisionPointReachedCount"',
+        '"condition"."conditionCode" as "conditionName"',
+        'MIN("repeatedEnrollment"."createdAt") as "firstDecisionPointReachedOn"',
+        'CAST(COUNT("repeatedEnrollment"."id") as int) as "decisionPointReachedCount"',
       ])
-      .leftJoin('individualEnrollment.condition', 'condition')
       .innerJoin(Experiment, 'experiment', 'experiment.id = "individualEnrollment"."experimentId"')
       .leftJoin('individualEnrollment.partition', 'decisionPoint')
       .innerJoin(
-        MonitoredDecisionPoint,
-        'monitored',
-        'monitored.userId = individualEnrollment.userId AND monitored.site = decisionPoint.site AND monitored.target = decisionPoint.target'
+        RepeatedEnrollment,
+        'repeatedEnrollment',
+        '"repeatedEnrollment"."individualEnrollmentId" = "individualEnrollment".id'
       )
-      .leftJoin('monitored.monitoredPointLogs', 'monitoredPointLogs')
+      .leftJoin(ExperimentCondition, 'condition', '"condition"."id" = "repeatedEnrollment"."conditionId"')
       .groupBy('experiment.id')
       .addGroupBy('experiment.name')
-      .addGroupBy('"monitored"."site"')
-      .addGroupBy('"monitored"."target"')
+      .addGroupBy('"decisionPoint"."site"')
+      .addGroupBy('"decisionPoint"."target"')
       .addGroupBy('"individualEnrollment"."userId"')
       .addGroupBy('"individualEnrollment"."partitionId"')
       .addGroupBy('"individualEnrollment"."groupId"')
-      .addGroupBy('"monitoredPointLogs"."condition"')
+      .addGroupBy('"condition"."conditionCode"')
       .orderBy('"individualEnrollment"."userId"', 'ASC')
       .where('"individualEnrollment"."experimentId" = :experimentId::uuid', { experimentId })
       .execute();
@@ -605,18 +595,15 @@ export class AnalyticsRepository extends Repository<AnalyticsRepository> {
           '"individualEnrollment"."partitionId"',
           individualSelectRange,
         ])
-        .leftJoin(MonitoredDecisionPoint, 'mdp', 'individualEnrollment.userId = mdp.userId')
         .leftJoin(DecisionPoint, 'dp', 'dp.id = individualEnrollment.partitionId')
-        .where('mdp.site = dp.site')
-        .andWhere('mdp.target = dp.target')
-        .andWhere('"individualEnrollment"."experimentId" = :id', { id: experimentId })
+        .where('"individualEnrollment"."experimentId" = :id', { id: experimentId })
         .andWhere(individualWhereDate)
         .andWhere((qb) => {
           const subQuery = qb.subQuery().select('user.id').from(PreviewUser, 'user').getQuery();
           return '"individualEnrollment"."userId" NOT IN ' + subQuery;
         })
-        .leftJoin(MonitoredDecisionPointLog, 'mdpl', 'mdp.id = mdpl.monitoredDecisionPointId')
-        .leftJoin(ExperimentCondition, 'expCond', 'expCond.conditionCode = mdpl.condition')
+        .leftJoin(RepeatedEnrollment, 'repeated', 'individualEnrollment.id = repeated.individualEnrollmentId')
+        .leftJoin(ExperimentCondition, 'expCond', 'expCond.id = repeated.conditionId')
         .groupBy('"expCond"."id"')
         .addGroupBy('"individualEnrollment"."partitionId"')
         .addGroupBy(groupByRange)

--- a/backend/packages/Upgrade/src/api/repositories/RepeatedEnrollmentRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/RepeatedEnrollmentRepository.ts
@@ -1,0 +1,39 @@
+import { RepeatedEnrollment } from '../models/RepeatedEnrollment';
+import { Repository } from 'typeorm';
+import { EntityRepository } from '../../typeorm-typedi-extensions';
+import { UpgradeLogger } from 'src/lib/logger/UpgradeLogger';
+import repositoryError from './utils/repositoryError';
+
+export interface RepeatedEnrollmentDataCount {
+  userId: string;
+  decisionPointId: string;
+  count: number;
+}
+@EntityRepository(RepeatedEnrollment)
+export class RepeatedEnrollmentRepository extends Repository<RepeatedEnrollment> {
+  public async getRepeatedEnrollmentCount(
+    userId: string,
+    decisionPointsIds: string[],
+    logger: UpgradeLogger
+  ): Promise<RepeatedEnrollmentDataCount[]> {
+    const result = await this.createQueryBuilder('repeatedEnrollment')
+      .select(['ie.userId as userId', 'ie.partitionId as decisionPointId'])
+      .addSelect('COUNT(*) as count')
+      .leftJoin('repeatedEnrollment.individualEnrollment', 'ie')
+      .where('ie.userId = :userId', { userId })
+      .andWhere('ie.partitionId IN (:...decisionPointsIds)', { decisionPointsIds })
+      .groupBy('ie.userId , ie.partitionId , ie.id')
+      .getRawMany()
+      .catch((errorMsg: any) => {
+        const errorMsgString = repositoryError(
+          'RepeatedEnrollmentRepository',
+          'getRepeatedEnrollmentCount',
+          {},
+          errorMsg
+        );
+        logger.error(errorMsg);
+        throw errorMsgString;
+      });
+    return result;
+  }
+}

--- a/backend/packages/Upgrade/src/api/repositories/RepeatedEnrollmentRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/RepeatedEnrollmentRepository.ts
@@ -1,7 +1,7 @@
 import { RepeatedEnrollment } from '../models/RepeatedEnrollment';
 import { Repository } from 'typeorm';
 import { EntityRepository } from '../../typeorm-typedi-extensions';
-import { UpgradeLogger } from 'src/lib/logger/UpgradeLogger';
+import { UpgradeLogger } from '../../lib/logger/UpgradeLogger';
 import repositoryError from './utils/repositoryError';
 
 export interface RepeatedEnrollmentDataCount {

--- a/backend/packages/Upgrade/src/api/repositories/RepeatedEnrollmentRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/RepeatedEnrollmentRepository.ts
@@ -17,7 +17,7 @@ export class RepeatedEnrollmentRepository extends Repository<RepeatedEnrollment>
     logger: UpgradeLogger
   ): Promise<RepeatedEnrollmentDataCount[]> {
     const result = await this.createQueryBuilder('repeatedEnrollment')
-      .select(['ie.userId as userId', 'ie.partitionId as decisionPointId'])
+      .select(['ie.userId as "userId"', 'ie.partitionId as "decisionPointId"'])
       .addSelect('COUNT(*) as count')
       .leftJoin('repeatedEnrollment.individualEnrollment', 'ie')
       .where('ie.userId = :userId', { userId })

--- a/backend/packages/Upgrade/src/database/migrations/1751031471008-repeatedEnrollments.ts
+++ b/backend/packages/Upgrade/src/database/migrations/1751031471008-repeatedEnrollments.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RepeatedEnrollments1751031471008 implements MigrationInterface {
+  name = 'RepeatedEnrollments1751031471008';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "repeated_enrollment" ("createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "versionNumber" integer NOT NULL, "id" SERIAL NOT NULL, "conditionId" uuid, "uniquifier" character varying, "individualEnrollmentId" character varying, CONSTRAINT "PK_c74f7a75a16cda34e12fe4bf23e" PRIMARY KEY ("id"))`
+    );
+    await queryRunner.query(`CREATE INDEX "IDX_6e16370d9a50b778e6e35f2256" ON "repeated_enrollment" ("conditionId") `);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_0672ed69d7d0f18dfe8856fb94" ON "repeated_enrollment" ("individualEnrollmentId") `
+    );
+    await queryRunner.query(
+      `ALTER TABLE "repeated_enrollment" ADD CONSTRAINT "FK_6e16370d9a50b778e6e35f22562" FOREIGN KEY ("conditionId") REFERENCES "experiment_condition"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "repeated_enrollment" ADD CONSTRAINT "FK_0672ed69d7d0f18dfe8856fb945" FOREIGN KEY ("individualEnrollmentId") REFERENCES "individual_enrollment"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "repeated_enrollment" DROP CONSTRAINT "FK_0672ed69d7d0f18dfe8856fb945"`);
+    await queryRunner.query(`ALTER TABLE "repeated_enrollment" DROP CONSTRAINT "FK_6e16370d9a50b778e6e35f22562"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_0672ed69d7d0f18dfe8856fb94"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_6e16370d9a50b778e6e35f2256"`);
+    await queryRunner.query(`DROP TABLE "repeated_enrollment"`);
+  }
+}

--- a/backend/packages/Upgrade/test/integration/ExperimentStats/WithinSubjectEnrollment.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentStats/WithinSubjectEnrollment.ts
@@ -2,12 +2,17 @@ import { Container } from 'typedi';
 import { ExperimentService } from '../../../src/api/services/ExperimentService';
 import { UserService } from '../../../src/api/services/UserService';
 import { systemUser } from '../mockData/user/index';
-import { checkExperimentAssignedIsNull, getAllExperimentCondition, markExperimentPoint, updateExcludeIfReachedFlag } from '../utils';
+import {
+  checkExperimentAssignedIsNull,
+  getAllExperimentCondition,
+  markExperimentPoint,
+  updateExcludeIfReachedFlag,
+} from '../utils';
 import { experimentUsers } from '../mockData/experimentUsers/index';
 import { AnalyticsService } from '../../../src/api/services/AnalyticsService';
 import { withinSubjectExperiment } from '../mockData/experiment/index';
 import { checkMarkExperimentPointForUser, checkExperimentAssignedIsNotDefault } from '../utils/index';
-import { EXPERIMENT_STATE } from 'upgrade_types';
+import { CONDITION_ORDER, EXPERIMENT_STATE } from 'upgrade_types';
 import { PreviewUserService } from '../../../src/api/services/PreviewUserService';
 import { previewUsers } from '../mockData/previewUsers/index';
 import { UpgradeLogger } from '../../../src/lib/logger/UpgradeLogger';
@@ -28,7 +33,11 @@ export default async function testCase(): Promise<void> {
   experimentObject.partitions = updateExcludeIfReachedFlag(experimentObject.partitions);
 
   // create experiment
-  await experimentService.create(experimentObject, user, new UpgradeLogger());
+  await experimentService.create(
+    { ...experimentObject, conditionOrder: CONDITION_ORDER.ORDERED_ROUND_ROBIN },
+    user,
+    new UpgradeLogger()
+  );
   const experiments = await experimentService.find(new UpgradeLogger());
   expect(experiments).toEqual(
     expect.arrayContaining([
@@ -59,22 +68,6 @@ export default async function testCase(): Promise<void> {
 
   // mark experiment point
   let markedExperimentPoint = await markExperimentPoint(
-    experimentUsers[0].id,
-    experimentName1,
-    experimentPoint1,
-    condition1,
-    experimentId,
-    new UpgradeLogger()
-  );
-  checkMarkExperimentPointForUser(markedExperimentPoint, experimentUsers[0].id, experimentName1, experimentPoint1);
-
-  // user 1 logs in experiment
-  // get all experiment condition for user 1
-  experimentConditionAssignments = await getAllExperimentCondition(experimentUsers[0].id, new UpgradeLogger());
-  expect(experimentConditionAssignments).toHaveLength(0);
-
-  // mark experiment point
-  markedExperimentPoint = await markExperimentPoint(
     experimentUsers[0].id,
     experimentName1,
     experimentPoint1,
@@ -117,6 +110,12 @@ export default async function testCase(): Promise<void> {
 
   experimentConditionAssignments = await getAllExperimentCondition(experimentUsers[0].id, new UpgradeLogger());
   expect(experimentConditionAssignments).toHaveLength(experimentObject.partitions.length);
+  // Make sure the condition list has not yet rotated
+  expect(
+    experimentConditionAssignments.find((decsionPoint) => decsionPoint.target === experimentName1).assignedCondition[0]
+      .conditionCode
+  ).toEqual(condition1);
+
   // mark experiment point
   markedExperimentPoint = await markExperimentPoint(
     experimentUsers[0].id,

--- a/backend/packages/Upgrade/test/integration/ExperimentStats/WithinSubjectEnrollment.ts
+++ b/backend/packages/Upgrade/test/integration/ExperimentStats/WithinSubjectEnrollment.ts
@@ -112,7 +112,7 @@ export default async function testCase(): Promise<void> {
   expect(experimentConditionAssignments).toHaveLength(experimentObject.partitions.length);
   // Make sure the condition list has not yet rotated
   expect(
-    experimentConditionAssignments.find((decsionPoint) => decsionPoint.target === experimentName1).assignedCondition[0]
+    experimentConditionAssignments.find((decisionPoint) => decisionPoint.target === experimentName1).assignedCondition[0]
       .conditionCode
   ).toEqual(condition1);
 

--- a/backend/packages/Upgrade/test/integration/utils/index.ts
+++ b/backend/packages/Upgrade/test/integration/utils/index.ts
@@ -78,12 +78,6 @@ export function checkMarkExperimentPointForUser(
         }),
       ])
     );
-
-    const monitorDocument = markedDecisionPoint.find((markedPoint) => {
-      return markedPoint.site === site && markedPoint.target === target && markedPoint.user.id === userId;
-    });
-
-    expect(monitorDocument.monitoredPointLogs.length).toEqual(markExperimentPointLogLength);
   }
 }
 

--- a/backend/packages/Upgrade/test/unit/services/ExperimentAssignmentService.test.ts
+++ b/backend/packages/Upgrade/test/unit/services/ExperimentAssignmentService.test.ts
@@ -9,7 +9,7 @@ import { IndividualEnrollmentRepository } from '../../../src/api/repositories/In
 import { IndividualExclusionRepository } from '../../../src/api/repositories/IndividualExclusionRepository';
 import { LogRepository } from '../../../src/api/repositories/LogRepository';
 import { MetricRepository } from '../../../src/api/repositories/MetricRepository';
-import { MonitoredDecisionPointLogRepository } from '../../../src/api/repositories/MonitoredDecisionPointLogRepository';
+import { RepeatedEnrollmentRepository } from '../../../src/api/repositories/RepeatedEnrollmentRepository';
 import { MonitoredDecisionPointRepository } from '../../../src/api/repositories/MonitoredDecisionPointRepository';
 import { StateTimeLogsRepository } from '../../../src/api/repositories/StateTimeLogsRepository';
 import { ErrorService } from '../../../src/api/services/ErrorService';
@@ -54,7 +54,7 @@ describe('Experiment Assignment Service Test', () => {
   let conditionPayloadRepositoryMock = sinon.createStubInstance(ConditionPayloadRepository);
   let factorRepositoryMock = sinon.createStubInstance(FactorRepository);
   const experimentRepositoryMock = sinon.createStubInstance(ExperimentRepository);
-  const monitoredDecisionPointLogRepositoryMock = sinon.createStubInstance(MonitoredDecisionPointLogRepository);
+  const repeatedEnrollmentRepositoryMock = sinon.createStubInstance(RepeatedEnrollmentRepository);
   const monitoredDecisionPointRepositoryMock = sinon.createStubInstance(MonitoredDecisionPointRepository);
   const errorRepositoryMock = sinon.createStubInstance(ErrorRepository);
   const logRepositoryMock = sinon.createStubInstance(LogRepository);
@@ -106,7 +106,7 @@ describe('Experiment Assignment Service Test', () => {
       groupExclusionRepositoryMock,
       groupEnrollmentRepositoryMock,
       individualEnrollmentRepositoryMock,
-      monitoredDecisionPointLogRepositoryMock,
+      repeatedEnrollmentRepositoryMock,
       monitoredDecisionPointRepositoryMock,
       errorRepositoryMock,
       logRepositoryMock,
@@ -265,14 +265,14 @@ describe('Experiment Assignment Service Test', () => {
     const exp = simpleWithinSubjectOrderedRoundRobinExperiment;
 
     const experimentUserServiceMock = { getOriginalUserDoc: sandbox.stub().resolves(userDoc) };
-    const monitoredDecisionPointLogRepositoryMock = {
+    const repeatedEnrollmentRepositoryMock = {
       find: sandbox.stub().resolves(0),
-      getAllMonitoredDecisionPointLog: sandbox.stub().resolves([]),
+      getRepeatedEnrollmentCount: sandbox.stub().resolves([]),
     };
 
     testedModule.experimentService.getCachedValidExperiments = sandbox.stub().resolves([exp]);
     testedModule.experimentUserService = experimentUserServiceMock;
-    testedModule.monitoredDecisionPointLogRepository = monitoredDecisionPointLogRepositoryMock;
+    testedModule.repeatedEnrollmentRepositoryMock = repeatedEnrollmentRepositoryMock;
 
     const result = await testedModule.getAllExperimentConditions(userDoc, context, loggerMock);
     const cond = [


### PR DESCRIPTION
- adds new 'repeated_enrollment' table, with migration
- moves storage of repeated enrollments in within-subject experiments from 'monitored_decision_point' and 'monitored_decision_point_log' tables to 'repeated_enrollment'
- alters all db queries for enrollment and metrics in within-subject experiments to reflect the above simplification
- removes creation of new records in 'monitored_decision_point_log' on /mark