### PR TITLE
restore condition payload formatting on pagination response

### DIFF
--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -207,7 +207,17 @@ export class ExperimentService {
     } else {
       queryBuilderToReturn = queryBuilderToReturn.addOrderBy('experiment.updatedAt', 'DESC');
     }
-    return await Promise.all([queryBuilderToReturn.getMany(), countQuery ? countQuery.getCount() : countQuery]);
+    const [experiments, count] = await Promise.all([
+      queryBuilderToReturn.getMany(),
+      countQuery ? countQuery.getCount() : countQuery,
+    ]);
+
+    return [
+      experiments.map((experiment) => {
+        return this.reducedConditionPayload(this.formattingPayload(this.formattingConditionPayload(experiment)));
+      }),
+      count || 0,
+    ];
   }
 
   public async getSingleExperiment(id: string, logger?: UpgradeLogger): Promise<ExperimentDTO | undefined> {


### PR DESCRIPTION
The change to the experiment pagination query left out the formatting for condition payloads. This was causing the details page for factorial experiments to error when the `conditionPayloads[]` array was not found in the return structure.