### PR TITLE
filter out _REWARD metrics that do not belong to experiment

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.ts
@@ -117,10 +117,16 @@ export class MonitoredMetricsComponent implements OnInit, OnChanges, OnDestroy {
     // Filter out reward metric keys from other experiments
     this.options = this.options.filter((option) => {
       if (option.key.endsWith('_REWARD')) {
-        const result =
-          this.experimentInfo?.name &&
-          option.key === this.experimentService.getRewardMetricKey(this.experimentInfo.name);
-        return result;
+        const isAddMode = !this.experimentInfo?.name;
+        if (isAddMode) {
+          // Exclude all reward keys if in add mode
+          return false;
+        } else {
+          // Else, exclude all reward keys except the current experiment's reward key
+          const isCurrentExperimentRewardKey =
+            option.key === this.experimentService.getRewardMetricKey(this.experimentInfo.name);
+          return isCurrentExperimentRewardKey;
+        }
       } else {
         return true;
       }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.ts
@@ -134,9 +134,7 @@ export class MonitoredMetricsComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   ngOnInit() {
-    console.log('>>> Monitored Metrics Component Initialized');
-    // TODO: Invalid
-    // ate the global metric rows whenever the unit of assignment updates to Within-subjects
+    // TODO: Invalidate the global metric rows whenever the unit of assignment updates to Within-subjects
     this.experimentDesignStepperService.currentAssignmentUnit$.subscribe((unit) => {
       if (unit === ASSIGNMENT_UNIT.WITHIN_SUBJECTS) {
         // console.log('this.queries:', this.queries);

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.ts
@@ -109,21 +109,28 @@ export class MonitoredMetricsComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   /**
-   * If the metric key ends with '_REWARD', it should only show the reward metric for the current experiment.
+   * No *_REWARD metric keys should be shown on Add Experiment flow.
+   * Only the current experiment's reward metric key should be shown on Edit Experiment flow.
    * This function will work regardless of whether mooclet is enabled or not.
    */
   filterOutRewardMetricKeysFromOtherExperiments() {
     // Filter out reward metric keys from other experiments
     this.options = this.options.filter((option) => {
       if (option.key.endsWith('_REWARD')) {
-        return option.key === this.experimentService.getRewardMetricKey(this.experimentInfo.name);
+        const result =
+          this.experimentInfo?.name &&
+          option.key === this.experimentService.getRewardMetricKey(this.experimentInfo.name);
+        return result;
+      } else {
+        return true;
       }
-      return true;
     });
   }
 
   ngOnInit() {
-    // TODO: Invalidate the global metric rows whenever the unit of assignment updates to Within-subjects
+    console.log('>>> Monitored Metrics Component Initialized');
+    // TODO: Invalid
+    // ate the global metric rows whenever the unit of assignment updates to Within-subjects
     this.experimentDesignStepperService.currentAssignmentUnit$.subscribe((unit) => {
       if (unit === ASSIGNMENT_UNIT.WITHIN_SUBJECTS) {
         // console.log('this.queries:', this.queries);

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.ts
@@ -104,6 +104,21 @@ export class MonitoredMetricsComponent implements OnInit, OnChanges, OnDestroy {
           : this.allMetrics.filter((metric) =>
               metric.context?.includes(this.currentContext || this.experimentInfo?.context)
             );
+      this.filterOutRewardMetricKeysFromOtherExperiments();
+    });
+  }
+
+  /**
+   * If the metric key ends with '_REWARD', it should only show the reward metric for the current experiment.
+   * This function will work regardless of whether mooclet is enabled or not.
+   */
+  filterOutRewardMetricKeysFromOtherExperiments() {
+    // Filter out reward metric keys from other experiments
+    this.options = this.options.filter((option) => {
+      if (option.key.endsWith('_REWARD')) {
+        return option.key === this.experimentService.getRewardMetricKey(this.experimentInfo.name);
+      }
+      return true;
     });
   }
 


### PR DESCRIPTION
This fixes issue #2576.