### PR TITLE
Change mooclet error throwing

### DIFF
--- a/backend/packages/Upgrade/src/api/services/MoocletDataService.ts
+++ b/backend/packages/Upgrade/src/api/services/MoocletDataService.ts
@@ -352,6 +352,7 @@ export class MoocletDataService {
         }
       } catch (err) {
         logger.error({ message: `Error fetching data from Mooclets API: ${err}` });
+        throw new Error(`Error fetching data from Mooclets API: ${err}`);
       }
     }
   }

--- a/backend/packages/Upgrade/test/unit/services/MoocletDataService.test.ts
+++ b/backend/packages/Upgrade/test/unit/services/MoocletDataService.test.ts
@@ -441,7 +441,7 @@ describe('#MoocletDataService', () => {
       expect(response).toEqual({ error: mockErrorResponse });
     });
 
-    it('should log an error and return undefined when the request throws an error', async () => {
+    it('should handle and log errors when the request fails', async () => {
       const mockRequestParams: MoocletProxyRequestParams = {
         method: 'POST',
         url: 'https://api.example.com/mooclet',
@@ -454,9 +454,10 @@ describe('#MoocletDataService', () => {
 
       (axios.request as jest.Mock).mockRejectedValue(mockError);
       logger.error = jest.fn().mockReturnValue(mockErrorMessage);
+      await expect(moocletDataService.fetchExternalMoocletsData(mockRequestParams, logger)).rejects.toThrow(
+        mockErrorMessage.message
+      );
 
-      const response = await moocletDataService.fetchExternalMoocletsData(mockRequestParams, logger);
-      expect(response).toBeUndefined();
       expect(logger.error).toHaveBeenCalledWith(mockErrorMessage);
     });
   });

--- a/backend/packages/Upgrade/test/unit/services/MoocletExperimentService.test.ts
+++ b/backend/packages/Upgrade/test/unit/services/MoocletExperimentService.test.ts
@@ -509,9 +509,7 @@ describe('#MoocletExperimentService', () => {
       jest.spyOn(moocletDataService, 'deletePolicyParameters').mockResolvedValue(undefined);
       jest.spyOn(moocletDataService, 'deleteVariable').mockResolvedValue(undefined);
 
-      await expect(
-        moocletExperimentService.orchestrateDeleteMoocletResources(mockMoocletExperimentRef, logger)
-      ).rejects.toThrow();
+      await moocletExperimentService.orchestrateDeleteMoocletResources(mockMoocletExperimentRef, logger);
 
       expect(moocletDataService.deleteMooclet).toHaveBeenCalledWith(mockMoocletExperimentRef.moocletId, logger);
       expect(moocletDataService.deletePolicyParameters).not.toHaveBeenCalled();


### PR DESCRIPTION
- throw errors from axios requests so that experiments cannot be created or deleted with mooclet queries failing silently
- change error message to to be consistent in cases where experiments are successfully deleted but not all mooclet resources are