### PR TITLE
fix data exports for within-subject experiments

### DIFF
--- a/backend/packages/Upgrade/src/api/repositories/ExperimentRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/ExperimentRepository.ts
@@ -486,9 +486,10 @@ export class ExperimentRepository extends Repository<Experiment> {
         'experiment.assignmentAlgorithm as "algorithmType"',
         'experiment.stratificationFactorStratificationFactorName as "stratification"',
         'experiment.postExperimentRule as "postRule"',
+        'experiment.conditionOrder as "conditionOrder"',
         'experimentRevertCondition.conditionCode as "revertTo"',
-        '"enrollingStateTimeLog"."timeLog" as "enrollmentStartDate"',
-        '"enrollmentCompleteStateTimeLog"."timeLog" as "enrollmentCompleteDate"',
+        'MIN("enrollingStateTimeLog"."timeLog") as "enrollmentStartDate"',
+        'MIN("enrollmentCompleteStateTimeLog"."timeLog") as "enrollmentCompleteDate"',
         '"conditionPayloadMain"."payloadValue" as "payload"',
         '"decisionPointData"."excludeIfReached" as "excludeIfReached"',
         '"decisionPointData"."id" as "expDecisionPointId"',
@@ -518,8 +519,6 @@ export class ExperimentRepository extends Repository<Experiment> {
       .addGroupBy('experimentRevertCondition.conditionCode')
       .addGroupBy('decisionPointData.id')
       .addGroupBy('conditionPayloadMain.payloadValue')
-      .addGroupBy('enrollingStateTimeLog.timeLog')
-      .addGroupBy('enrollmentCompleteStateTimeLog.timeLog')
       .where('experiment.id = :experimentId', { experimentId })
       .getRawMany();
 

--- a/backend/packages/Upgrade/src/api/repositories/LogRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/LogRepository.ts
@@ -134,6 +134,7 @@ export class LogRepository extends Repository<Log> {
       updatedAt: string;
       key: string;
       type: IMetricMetaData;
+      uniquifier: string;
     }>
   > {
     const experimentRepo = Container.getCustomRepository(ExperimentRepository, 'export');
@@ -146,6 +147,7 @@ export class LogRepository extends Repository<Log> {
         'queries."repeatedMeasure" as "repeatedMeasure"',
         'logs."userId" as "userId"',
         'logs."updatedAt" as "updatedAt"',
+        'logs."uniquifier" as "uniquifier"',
         'metric.key as key',
         'metric.type as type',
       ])

--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -753,12 +753,14 @@ export class ExperimentService {
         try {
           experimentDoc = await transactionalEntityManager.getRepository(Experiment).save(expDoc);
           // Store state time log for the experiment
-          const stateTimeLogDoc = await this.prepareStateTimeLogDoc(
-            experimentDoc,
-            oldExperiment.state,
-            experimentDoc.state
-          );
-          await transactionalEntityManager.getRepository(StateTimeLog).save(stateTimeLogDoc);
+          if (oldExperiment.state !== experimentDoc.state) {
+            const stateTimeLogDoc = await this.prepareStateTimeLogDoc(
+              experimentDoc,
+              oldExperiment.state,
+              experimentDoc.state
+            );
+            await transactionalEntityManager.getRepository(StateTimeLog).save(stateTimeLogDoc);
+          }
         } catch (err) {
           const error = err as ErrorWithType;
           error.details = `Error in updating experiment document "updateExperimentInDB"`;


### PR DESCRIPTION
- closes #2557 
- removes redundant record creation in state-time-log table when state is not changed on experiment edits
- updates export format to get closer to [the current spec](https://docs.google.com/spreadsheets/d/1qAy7SNklPBWTtJed0Bqc8IppZn5DsQ4nBRsjtP-wtm0/edit?gid=1887655424#gid=1887655424)