### PR TITLE
Resolve segment options not showing in experiment participants include table

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-participants/experiment-participants.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-participants/experiment-participants.component.ts
@@ -177,9 +177,6 @@ export class ExperimentParticipantsComponent implements OnInit {
     this.updateView1();
     this.updateView2();
 
-    // Bind predefined values of experiment participants from backend
-    this.bindParticipantsData();
-
     this.participantsForm.get('members1').valueChanges.subscribe((newValues) => {
       this.checkSegmentValidity(newValues, 1);
     });
@@ -202,7 +199,6 @@ export class ExperimentParticipantsComponent implements OnInit {
     this.allSegmentsSub = this.segmentsService.selectListSegmentOptionsByContext(context).subscribe((allSegments) => {
       this.allSegmentListOptions = allSegments;
       this.updateSegmentData();
-      // Rebind participants data after segment options are updated to refresh autocomplete
       this.bindParticipantsData();
     });
   }


### PR DESCRIPTION
## Problem
Fixes issue #2608 where segment options were not displayed in the autocomplete dropdown for the "ID/Name" field when creating experiments and selecting "Segment" as the type in the participants include table, even when segments with matching app context existed.

## Root Cause
The issue occurred due to a timing problem between when segment data was loaded and when form control autocomplete observables were initialized. Specifically:

1. Segment options were only loaded once during `ngOnInit()` 
2. When the app context changed, segment data wasn't refreshed for the new context
3. Autocomplete observables were set up before segment data was available
4. No mechanism existed to refresh autocomplete when new segment data arrived

## Solution
Implemented a comprehensive fix to ensure segment autocomplete works reliably:

## Key Changes:
1. **Context-aware segment loading**: Added `setSegmentOptions()` call in `ngOnChanges()` to reload segments when context changes
2. **Centralized segment data management**: Created `updateSegmentData()` method to handle segment array updates consistently
3. **Enhanced subscription handling**: Added proper cleanup and refresh logic in `setSegmentOptions()` 
4. **Autocomplete refresh mechanism**: Ensured `bindParticipantsData()` is called after segment data loads to refresh autocomplete observables
5. **Defensive programming**: Added null checks to prevent errors during async loading
6. **Fixed indexing bug**: Corrected array index in `addMember1()` for proper autocomplete setup

## Technical Details:
- **`ngOnChanges()`**: Now calls `setSegmentOptions()` when context changes
- **`setSegmentOptions()`**: Enhanced with subscription cleanup, data updates, and autocomplete refresh
- **`updateSegmentData()`**: New centralized method for updating segment arrays and maps
- **`bindParticipantsData()`** & **`manageSegmentIdsControl()`**: Added defensive checks for form existence
- **`addMember1()`**: Fixed index calculation for newly added members
- **`ngOnDestroy()`**: Added safe unsubscription logic

Closes #2608
