### PR TITLE
move jaxb.ws.rs to Jakarta and bump Jersey to 3

### DIFF
--- a/clientlibs/java/pom.xml
+++ b/clientlibs/java/pom.xml
@@ -9,7 +9,7 @@
 		at the same time that happen to rev to the same new version will be caught 
 		by a merge conflict. -->
 
-	<version>6.1.2</version> <!-- 6.1.2: add context to client object-->  
+	<version>7.0.0</version> <!-- 7.0.0 move Jaxb -> jakarta and update to Jersey 3-->
 	<build>
 		<plugins>
 			<plugin>
@@ -40,7 +40,12 @@
 		<dependency>
 			<groupId>org.glassfish.jersey.core</groupId>
 			<artifactId>jersey-client</artifactId>
-			<version>2.30.1</version>
+			<version>3.1.0</version>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.ws.rs</groupId>
+			<artifactId>jakarta.ws.rs-api</artifactId>
+			<version>3.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.media</groupId>

--- a/clientlibs/java/src/main/java/org/upgradeplatform/client/ExperimentClient.java
+++ b/clientlibs/java/src/main/java/org/upgradeplatform/client/ExperimentClient.java
@@ -22,12 +22,12 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.function.UnaryOperator;
 
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.client.AsyncInvoker;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.InvocationCallback;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.client.AsyncInvoker;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.InvocationCallback;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.upgradeplatform.interfaces.ResponseCallback;
@@ -71,7 +71,7 @@ public class ExperimentClient implements AutoCloseable {
 	 *                   Properties to permit users to control how the underlying
 	 *                   JAX-RS
 	 *                   client behaves. These are passed through to
-	 *                   {@link javax.ws.rs.core.Configurable#property(String, Object)}.
+	 *                   {@link jakarta.ws.rs.core.Configurable#property(String, Object)}.
 	 */
 	public ExperimentClient(String userId, String context, String authToken, String baseUrl,
 			Map<String, Object> properties) {
@@ -83,7 +83,7 @@ public class ExperimentClient implements AutoCloseable {
 	 *                   Properties to permit users to control how the underlying
 	 *                   JAX-RS
 	 *                   client behaves. These are passed through to
-	 *                   {@link javax.ws.rs.core.Configurable#property(String, Object)}.
+	 *                   {@link jakarta.ws.rs.core.Configurable#property(String, Object)}.
 	 */
 	public ExperimentClient(String userId, String context, String authToken, String sessionId, String baseUrl,
 			Map<String, Object> properties) {

--- a/clientlibs/java/src/main/java/org/upgradeplatform/utils/APIService.java
+++ b/clientlibs/java/src/main/java/org/upgradeplatform/utils/APIService.java
@@ -5,10 +5,10 @@ import static org.upgradeplatform.utils.Utils.*;
 
 import java.util.Map;
 
-import javax.ws.rs.client.AsyncInvoker;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.client.AsyncInvoker;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.MediaType;
 
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.HttpUrlConnectorProvider;

--- a/clientlibs/java/src/main/java/org/upgradeplatform/utils/PublishingRetryCallback.java
+++ b/clientlibs/java/src/main/java/org/upgradeplatform/utils/PublishingRetryCallback.java
@@ -1,13 +1,13 @@
 package org.upgradeplatform.utils;
 import static org.upgradeplatform.utils.Utils.*;
 
-import javax.ws.rs.client.AsyncInvoker;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.InvocationCallback;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.client.AsyncInvoker;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.InvocationCallback;
+import jakarta.ws.rs.core.Response;
 
-import static javax.ws.rs.core.Response.Status.Family.SUCCESSFUL;
-import static javax.ws.rs.core.Response.Status.Family.CLIENT_ERROR;
+import static jakarta.ws.rs.core.Response.Status.Family.SUCCESSFUL;
+import static jakarta.ws.rs.core.Response.Status.Family.CLIENT_ERROR;
 
 public class PublishingRetryCallback<T> implements InvocationCallback<Response> {
 


### PR DESCRIPTION
This is needed in order to continue work on moving CTP to Jakarta. Since this dependency is used there, this also needs updated. 