### PR TITLE
Add Docker build support for the demo app

### DIFF
--- a/demo.singleContainerApp-docker-compose.yml
+++ b/demo.singleContainerApp-docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - ./backend/packages/Upgrade/.env.docker.local
     environment:
       - NODE_ENV=production
+      - CONTEXT=upgrade
     command: >
       sh -c "
       npm --prefix ./frontend run build:demo &&

--- a/demo.singleContainerApp-docker-compose.yml
+++ b/demo.singleContainerApp-docker-compose.yml
@@ -1,0 +1,51 @@
+services:
+  upgrade-app:
+    build:
+      context: .
+      dockerfile: ./demo.singleContainerApp.Dockerfile
+    image: upgrade-app:latest
+    user: "node"
+    env_file:
+      - ./backend/packages/Upgrade/.env.docker.local
+    environment:
+      - NODE_ENV=production
+    command: >
+      sh -c "
+      npm --prefix ./frontend run build:demo &&
+      npm --prefix ./backend run build:upgrade &&
+      concurrently
+      \"npm --prefix ./frontend run server:demo\"
+      \"npm --prefix ./backend run production:upgrade\"
+      "
+    volumes:
+      - ./frontend:/usr/src/app/frontend
+      - ./backend:/usr/src/app/backend
+      - frontend-node_modules:/usr/src/app/frontend/node_modules
+    networks:
+      - localdev
+    ports:
+      - "4200:4200"
+      - "3030:3030"
+    depends_on:
+      - "postgres"
+
+  postgres:
+    image: postgres:alpine
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    networks:
+      - localdev
+    ports:
+      - "5432:5432"
+    volumes:
+      - upgradedbdata:/var/lib/postgresql/data
+
+volumes:
+  upgradedbdata:
+  frontend-node_modules:
+
+networks:
+  localdev:
+    driver: "bridge"

--- a/demo.singleContainerApp.Dockerfile
+++ b/demo.singleContainerApp.Dockerfile
@@ -1,0 +1,33 @@
+# Use an official Node runtime as a parent image
+FROM node:22.14-bullseye
+
+# Install xdg-utils
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends xdg-utils \
+ && rm -rf /var/lib/apt/lists/*
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Copy frontend and backend and upgrade types source
+COPY ./frontend ./frontend
+COPY ./backend/packages/Upgrade ./backend/packages/Upgrade
+COPY ./backend/tsconfig.json ./backend
+COPY ./types ./types
+
+ENV NEW_RELIC_NO_CONFIG_FILE=true
+ENV NR_NATIVE_METRICS_NO_BUILD=true
+
+# Install concurrently globally
+RUN npm install -g concurrently
+
+# Install frontend dependencies
+RUN cd frontend && npm ci
+# Install backend dependencies
+RUN cd backend/packages/Upgrade && npm ci
+
+# Expose any ports the frontend and backend use
+EXPOSE 4200 3030
+
+# Run frontend and backend with concurrently
+CMD ["concurrently", "\"npm --prefix ./frontend run docker:local\"", "\"npm --prefix ./backend/packages/Upgrade run dev\""]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
     "ng": "ng",
     "start": "ng serve --open --configuration=local",
     "docker:local": "ng serve --open --host 0.0.0.0 --configuration=local",
+    "docker:demo": "ng serve --open --host 0.0.0.0 --configuration=demo",
     "cl:build": "npm run build:prod && npm run cl:copy-package-json",
     "cl:copy-package-json": "cp projects/upgrade/package.json dist/upgrade/",
     "start:prod": "npm run build:prod && npm run server",

--- a/frontend/projects/server/demo-server.js
+++ b/frontend/projects/server/demo-server.js
@@ -8,6 +8,6 @@ const PORT = process.env.PORT || 4200;
 const app = express();
 
 app.use(compression());
-app.use(CONTEXT, express.static(path.resolve(__dirname, '../../dist')));
-app.use('*', express.static(path.resolve(__dirname, '../../dist/upgrade')));
+app.use(CONTEXT, express.static(path.resolve(__dirname, '../../dist/upgrade/browser')));
+app.use('*', express.static(path.resolve(__dirname, '../../dist/upgrade/browser')));
 app.listen(PORT, () => console.log(`App running on http://localhost:${PORT}${CONTEXT}`));

--- a/frontend/projects/upgrade/src/assets/js/demo-app.js
+++ b/frontend/projects/upgrade/src/assets/js/demo-app.js
@@ -5,88 +5,80 @@ if (window.self !== window.top) {
   const getElementById = (id) => {
     switch (id) {
       // Home
-      case 'upgrade-logo-link':
-        return document.querySelector('div.logo a.logo-link');
+      case 'login-with-google-button':
+        return document.querySelector('div.login-container button.google-sign-in-btn');
       case 'experiments-tab':
         return document.querySelectorAll('div.list-item-container a.nav-item')[0];
       case 'signout-button':
-        return document.querySelector('mat-list.user-list a.logout-link');
+        return document.querySelector('span.mat-list-item-content a.logout-link');
       case 'add-experiment-button':
-        return document.querySelectorAll('mat-card.mat-mdc-card button.mat-mdc-unelevated-button')[1];
+        return document.querySelectorAll('mat-card.mat-card button.mat-flat-button')[1];
 
       // Experiment Stepper - Overview Step
       case 'experiment-stepper-overview-name':
-        return document.querySelectorAll('form.experiment-overview input.mat-mdc-input-element')[0];
+        return document.querySelectorAll('form.experiment-overview input.mat-input-element')[0];
       case 'experiment-stepper-overview-description':
-        return document.querySelectorAll('form.experiment-overview input.mat-mdc-input-element')[1];
+        return document.querySelectorAll('form.experiment-overview input.mat-input-element')[1];
       case 'experiment-stepper-overview-app-context':
-        return document.querySelectorAll('form.experiment-overview div.mat-mdc-select-value')[0];
+        return document.querySelectorAll('form.experiment-overview div.mat-select-value')[0];
       case 'experiment-stepper-overview-unit-of-assignment':
-        return document.querySelectorAll('form.experiment-overview div.mat-mdc-select-value')[1];
+        return document.querySelectorAll('form.experiment-overview div.mat-select-value')[1];
       case 'experiment-stepper-overview-consistency-rule':
-        return document.querySelectorAll('form.experiment-overview div.mat-mdc-select-value')[2];
+        return document.querySelectorAll('form.experiment-overview div.mat-select-value')[2];
       case 'experiment-stepper-overview-next-button':
-        return document.querySelectorAll('div.new-experiment-modal button.mat-mdc-raised-button')[1];
+        return document.querySelectorAll('div.new-experiment-modal button.mat-raised-button')[1];
 
       // Experiment Stepper - Design Step
       case 'experiment-stepper-design-add-decision-point-button':
-        return document.querySelector('form.experiment-design button.add-decision-point');
+        return document.querySelector('form.experiment-design button.add-partition');
       case 'experiment-stepper-design-decision-points-row1-site':
-        return document.querySelectorAll('mat-table.decision-point-table input.mat-mdc-input-element')[0];
+        return document.querySelectorAll('mat-table.partition-table input.mat-input-element')[0];
       case 'experiment-stepper-design-decision-points-row1-target':
-        return document.querySelectorAll('mat-table.decision-point-table input.mat-mdc-input-element')[1];
+        return document.querySelectorAll('mat-table.partition-table input.mat-input-element')[1];
       case 'experiment-stepper-design-decision-points-row1-exclude-if-reached':
-        return document.querySelector('mat-table.decision-point-table input.mdc-checkbox__native-control');
-      case 'experiment-stepper-design-decision-points-row1-confirm-button':
-        return document.querySelectorAll('mat-table.decision-point-table button.row-action-btn')[0];
+        return document.querySelector('mat-table.partition-table input.mat-checkbox-input');
       case 'experiment-stepper-design-add-condition-button':
         return document.querySelector('form.experiment-design button.add-condition');
       case 'experiment-stepper-design-conditions-row1-condition':
-        return document.querySelectorAll('mat-table.condition-table input.mat-mdc-input-element')[0];
-      case 'experiment-stepper-design-conditions-row1-confirm':
-        return document.querySelectorAll('mat-table.condition-table button.row-action-btn')[0];
+        return document.querySelectorAll('mat-table.condition-table input.mat-input-element')[0];
       case 'experiment-stepper-design-conditions-row2-condition':
-        return document.querySelectorAll('mat-table.condition-table input.mat-mdc-input-element')[0];
-      case 'experiment-stepper-design-conditions-row2-confirm':
-        return document.querySelectorAll('mat-table.condition-table button.row-action-btn')[2];
+        return document.querySelectorAll('mat-table.condition-table input.mat-input-element')[3];
       case 'experiment-stepper-design-next-button':
-        return document.querySelectorAll('div.new-experiment-modal button.mat-mdc-raised-button')[4];
+        return document.querySelectorAll('div.new-experiment-modal button.mat-raised-button')[4];
 
       // Experiment Stepper - Participants Step
-      case 'experiment-stepper-participants-add-member-button':
-        return document.querySelector('form.experiment-participants button.add-member');
-      case 'experiment-stepper-participants-include-row1-type':
-        return document.querySelectorAll('mat-table.member-table div.mat-mdc-select-value')[0];
+      case 'experiment-stepper-participants-inclusion-criteria':
+        return document.querySelector('form.experiment-participants div.mat-select-value');
       case 'experiment-stepper-participants-next-button':
-        return document.querySelectorAll('div.new-experiment-modal button.mat-mdc-raised-button')[7];
+        return document.querySelectorAll('div.new-experiment-modal button.mat-raised-button')[7];
 
       // Experiment Stepper - Metrics Step
       case 'experiment-stepper-metrics-add-metric-button':
         return document.querySelector('form.metric-design button.add-metric');
       case 'experiment-stepper-metrics-metrics-row1-metric':
-        return document.querySelectorAll('mat-table.metric-table input.mat-mdc-input-element')[0];
+        return document.querySelectorAll('mat-table.metric-table input.mat-input-element')[0];
       case 'experiment-stepper-metrics-metrics-row1-statistic':
-        return document.querySelectorAll('mat-table.metric-table div.mat-mdc-select-value')[0];
+        return document.querySelectorAll('mat-table.metric-table div.mat-select-value')[0];
       case 'experiment-stepper-metrics-metrics-row1-display-name':
-        return document.querySelectorAll('mat-table.metric-table input.mat-mdc-input-element')[1];
+        return document.querySelectorAll('mat-table.metric-table input.mat-input-element')[1];
       case 'experiment-stepper-metrics-metrics-row2-metric':
-        return document.querySelectorAll('mat-table.metric-table input.mat-mdc-input-element')[2];
+        return document.querySelectorAll('mat-table.metric-table input.mat-input-element')[2];
       case 'experiment-stepper-metrics-metrics-row2-statistic':
-        return document.querySelectorAll('mat-table.metric-table div.mat-mdc-select-value')[1];
+        return document.querySelectorAll('mat-table.metric-table div.mat-select-value')[1];
       case 'experiment-stepper-metrics-metrics-row2-display-name':
-        return document.querySelectorAll('mat-table.metric-table input.mat-mdc-input-element')[3];
+        return document.querySelectorAll('mat-table.metric-table input.mat-input-element')[3];
       case 'experiment-stepper-metrics-next-button':
-        return document.querySelectorAll('div.new-experiment-modal button.mat-mdc-raised-button')[10];
+        return document.querySelectorAll('div.new-experiment-modal button.mat-raised-button')[10];
 
       // Experiment Stepper - Schedule Step
       case 'experiment-stepper-schedule-next-button':
-        return document.querySelectorAll('div.new-experiment-modal button.mat-mdc-raised-button')[13];
+        return document.querySelectorAll('div.new-experiment-modal button.mat-raised-button')[13];
 
       // Experiment Stepper - Post Rule Step
       case 'experiment-stepper-post-rule-post-rule':
-        return document.querySelectorAll('form.post-experiment-rule-form div.mat-mdc-select-value')[0];
+        return document.querySelectorAll('form.post-experiment-rule-form div.mat-select-value')[0];
       case 'experiment-stepper-post-rule-create-button':
-        return document.querySelectorAll('div.new-experiment-modal button.mat-mdc-raised-button')[16];
+        return document.querySelectorAll('div.new-experiment-modal button.mat-raised-button')[16];
 
       // Experiment Details - Overview Tab
       case 'experiment-details-overview-status':
@@ -94,13 +86,13 @@ if (window.self !== window.top) {
 
       // Experiment Details - Data Tab
       case 'experiment-details-data-tab':
-        return document.querySelectorAll('div.mat-mdc-tab-list div.mat-mdc-tab')[4];
+        return document.querySelectorAll('div.mat-tab-list div.mat-tab-label')[4];
 
       // Change Experiment Status Modal
       case 'change-experiment-status-modal-new-status':
-        return document.querySelectorAll('form.experiment-status-form div.mat-mdc-select-value')[1];
+        return document.querySelectorAll('form.experiment-status-form div.mat-select-value')[1];
       case 'change-experiment-status-modal-save-button':
-        return document.querySelectorAll('div.button-container button.mat-mdc-raised-button')[1];
+        return document.querySelectorAll('div.button-container button.mat-raised-button')[1];
     }
     console.error(`Error: The element ID "${id}" is not valid.`);
     return null;
@@ -118,7 +110,7 @@ if (window.self !== window.top) {
       activeWindowEvent.target.removeEventListener(activeWindowEvent.type, activeWindowEvent.callback, true);
       activeWindowEvent = null;
     }
-  };
+  }
 
   const addWindowEvent = (target, type, callback) => {
     removeActiveWindowEvent();
@@ -130,50 +122,46 @@ if (window.self !== window.top) {
     activeWindowEvent = {
       target,
       type,
-      callback,
+      callback
     };
-  };
+  }
 
   const closeOpenedModals = () => {
-    const modalButtonsSelector = 'div.cdk-overlay-pane button.mat-mdc-raised-button';
-    const modalCloseButton = Array.from(document.querySelectorAll(modalButtonsSelector)).find(
-      (elem) => elem.innerText.toLowerCase() === 'close'
-    );
+    const modalButtonsSelector = 'div.cdk-overlay-pane button.mat-raised-button';
+    const modalCloseButton = Array.from(document.querySelectorAll(modalButtonsSelector)).find((elem) => elem.innerText.toLowerCase() === 'close');
     if (modalCloseButton) {
       modalCloseButton.click();
-      const confirmCloseButton = Array.from(document.querySelectorAll(modalButtonsSelector)).find(
-        (elem) => elem.innerText.toLowerCase() === 'yes'
-      );
+      const confirmCloseButton = Array.from(document.querySelectorAll(modalButtonsSelector)).find((elem) => elem.innerText.toLowerCase() === 'yes');
       if (confirmCloseButton) {
         confirmCloseButton.click();
       }
     }
-  };
+  }
 
   // A set of functions that do more than triggering an event
   const initCallFunction = {
     'set-zoom-level': (args) => {
       document.body.style.zoom = args[0];
     },
-    logout: () => {
+    'logout': () => {
       closeOpenedModals();
       const signOutButton = getElementById('signout-button');
       if (signOutButton) {
         signOutButton.click();
+      } else if (gapi.auth2.getAuthInstance().isSignedIn.get()) {
+        gapi.auth2.getAuthInstance().signOut();
       }
     },
     'on-upgrade-tab-click': () => {
-      if (!getElementById('upgrade-logo-link')) {
+      if (!gapi.auth2.getAuthInstance().isSignedIn.get()) {
         return closeOpenedModals();
       }
       const experimentsTab = getElementById('experiments-tab');
-      if (experimentsTab) {
-        experimentsTab.click();
-      }
+      experimentsTab.click();
     },
     'remove-active-window-event': () => {
       removeActiveWindowEvent();
-    },
+    }
   };
 
   // Used to call a function or trigger event on element
@@ -205,16 +193,14 @@ if (window.self !== window.top) {
     'on-experiment-click': (args, onNextCall) => {
       const experimentName = args[0];
       const onWindowClick = (event) => {
-        const elem = Array.from(
-          document.querySelectorAll('div.experiment-list-table-container a.experiment-name')
-        ).find((elem) => elem.innerText === experimentName);
+        const elem = Array.from(document.querySelectorAll('div.experiment-list-table-container a.experiment-name')).find((elem) => elem.innerText === experimentName);
         if (elem && elem.contains(event.target)) {
           removeActiveWindowEvent();
           onNextCall();
         }
       };
       addWindowEvent(window, 'click', onWindowClick);
-    },
+    }
   };
 
   // Used to detect event on element

--- a/frontend/projects/upgrade/src/assets/js/demo-app.js
+++ b/frontend/projects/upgrade/src/assets/js/demo-app.js
@@ -5,80 +5,88 @@ if (window.self !== window.top) {
   const getElementById = (id) => {
     switch (id) {
       // Home
-      case 'login-with-google-button':
-        return document.querySelector('div.login-container button.google-sign-in-btn');
+      case 'upgrade-logo-link':
+        return document.querySelector('div.logo a.logo-link');
       case 'experiments-tab':
         return document.querySelectorAll('div.list-item-container a.nav-item')[0];
       case 'signout-button':
-        return document.querySelector('span.mat-list-item-content a.logout-link');
+        return document.querySelector('mat-list.user-list a.logout-link');
       case 'add-experiment-button':
-        return document.querySelectorAll('mat-card.mat-card button.mat-flat-button')[1];
+        return document.querySelectorAll('mat-card.mat-mdc-card button.mat-mdc-unelevated-button')[1];
 
       // Experiment Stepper - Overview Step
       case 'experiment-stepper-overview-name':
-        return document.querySelectorAll('form.experiment-overview input.mat-input-element')[0];
+        return document.querySelectorAll('form.experiment-overview input.mat-mdc-input-element')[0];
       case 'experiment-stepper-overview-description':
-        return document.querySelectorAll('form.experiment-overview input.mat-input-element')[1];
+        return document.querySelectorAll('form.experiment-overview input.mat-mdc-input-element')[1];
       case 'experiment-stepper-overview-app-context':
-        return document.querySelectorAll('form.experiment-overview div.mat-select-value')[0];
+        return document.querySelectorAll('form.experiment-overview div.mat-mdc-select-value')[0];
       case 'experiment-stepper-overview-unit-of-assignment':
-        return document.querySelectorAll('form.experiment-overview div.mat-select-value')[1];
+        return document.querySelectorAll('form.experiment-overview div.mat-mdc-select-value')[1];
       case 'experiment-stepper-overview-consistency-rule':
-        return document.querySelectorAll('form.experiment-overview div.mat-select-value')[2];
+        return document.querySelectorAll('form.experiment-overview div.mat-mdc-select-value')[2];
       case 'experiment-stepper-overview-next-button':
-        return document.querySelectorAll('div.new-experiment-modal button.mat-raised-button')[1];
+        return document.querySelectorAll('div.new-experiment-modal button.mat-mdc-raised-button')[1];
 
       // Experiment Stepper - Design Step
       case 'experiment-stepper-design-add-decision-point-button':
-        return document.querySelector('form.experiment-design button.add-partition');
+        return document.querySelector('form.experiment-design button.add-decision-point');
       case 'experiment-stepper-design-decision-points-row1-site':
-        return document.querySelectorAll('mat-table.partition-table input.mat-input-element')[0];
+        return document.querySelectorAll('mat-table.decision-point-table input.mat-mdc-input-element')[0];
       case 'experiment-stepper-design-decision-points-row1-target':
-        return document.querySelectorAll('mat-table.partition-table input.mat-input-element')[1];
+        return document.querySelectorAll('mat-table.decision-point-table input.mat-mdc-input-element')[1];
       case 'experiment-stepper-design-decision-points-row1-exclude-if-reached':
-        return document.querySelector('mat-table.partition-table input.mat-checkbox-input');
+        return document.querySelector('mat-table.decision-point-table input.mdc-checkbox__native-control');
+      case 'experiment-stepper-design-decision-points-row1-confirm-button':
+        return document.querySelectorAll('mat-table.decision-point-table button.row-action-btn')[0];
       case 'experiment-stepper-design-add-condition-button':
         return document.querySelector('form.experiment-design button.add-condition');
       case 'experiment-stepper-design-conditions-row1-condition':
-        return document.querySelectorAll('mat-table.condition-table input.mat-input-element')[0];
+        return document.querySelectorAll('mat-table.condition-table input.mat-mdc-input-element')[0];
+      case 'experiment-stepper-design-conditions-row1-confirm':
+        return document.querySelectorAll('mat-table.condition-table button.row-action-btn')[0];
       case 'experiment-stepper-design-conditions-row2-condition':
-        return document.querySelectorAll('mat-table.condition-table input.mat-input-element')[3];
+        return document.querySelectorAll('mat-table.condition-table input.mat-mdc-input-element')[0];
+      case 'experiment-stepper-design-conditions-row2-confirm':
+        return document.querySelectorAll('mat-table.condition-table button.row-action-btn')[2];
       case 'experiment-stepper-design-next-button':
-        return document.querySelectorAll('div.new-experiment-modal button.mat-raised-button')[4];
+        return document.querySelectorAll('div.new-experiment-modal button.mat-mdc-raised-button')[4];
 
       // Experiment Stepper - Participants Step
-      case 'experiment-stepper-participants-inclusion-criteria':
-        return document.querySelector('form.experiment-participants div.mat-select-value');
+      case 'experiment-stepper-participants-add-member-button':
+        return document.querySelector('form.experiment-participants button.add-member');
+      case 'experiment-stepper-participants-include-row1-type':
+        return document.querySelectorAll('mat-table.member-table div.mat-mdc-select-value')[0];
       case 'experiment-stepper-participants-next-button':
-        return document.querySelectorAll('div.new-experiment-modal button.mat-raised-button')[7];
+        return document.querySelectorAll('div.new-experiment-modal button.mat-mdc-raised-button')[7];
 
       // Experiment Stepper - Metrics Step
       case 'experiment-stepper-metrics-add-metric-button':
         return document.querySelector('form.metric-design button.add-metric');
       case 'experiment-stepper-metrics-metrics-row1-metric':
-        return document.querySelectorAll('mat-table.metric-table input.mat-input-element')[0];
+        return document.querySelectorAll('mat-table.metric-table input.mat-mdc-input-element')[0];
       case 'experiment-stepper-metrics-metrics-row1-statistic':
-        return document.querySelectorAll('mat-table.metric-table div.mat-select-value')[0];
+        return document.querySelectorAll('mat-table.metric-table div.mat-mdc-select-value')[0];
       case 'experiment-stepper-metrics-metrics-row1-display-name':
-        return document.querySelectorAll('mat-table.metric-table input.mat-input-element')[1];
+        return document.querySelectorAll('mat-table.metric-table input.mat-mdc-input-element')[1];
       case 'experiment-stepper-metrics-metrics-row2-metric':
-        return document.querySelectorAll('mat-table.metric-table input.mat-input-element')[2];
+        return document.querySelectorAll('mat-table.metric-table input.mat-mdc-input-element')[2];
       case 'experiment-stepper-metrics-metrics-row2-statistic':
-        return document.querySelectorAll('mat-table.metric-table div.mat-select-value')[1];
+        return document.querySelectorAll('mat-table.metric-table div.mat-mdc-select-value')[1];
       case 'experiment-stepper-metrics-metrics-row2-display-name':
-        return document.querySelectorAll('mat-table.metric-table input.mat-input-element')[3];
+        return document.querySelectorAll('mat-table.metric-table input.mat-mdc-input-element')[3];
       case 'experiment-stepper-metrics-next-button':
-        return document.querySelectorAll('div.new-experiment-modal button.mat-raised-button')[10];
+        return document.querySelectorAll('div.new-experiment-modal button.mat-mdc-raised-button')[10];
 
       // Experiment Stepper - Schedule Step
       case 'experiment-stepper-schedule-next-button':
-        return document.querySelectorAll('div.new-experiment-modal button.mat-raised-button')[13];
+        return document.querySelectorAll('div.new-experiment-modal button.mat-mdc-raised-button')[13];
 
       // Experiment Stepper - Post Rule Step
       case 'experiment-stepper-post-rule-post-rule':
-        return document.querySelectorAll('form.post-experiment-rule-form div.mat-select-value')[0];
+        return document.querySelectorAll('form.post-experiment-rule-form div.mat-mdc-select-value')[0];
       case 'experiment-stepper-post-rule-create-button':
-        return document.querySelectorAll('div.new-experiment-modal button.mat-raised-button')[16];
+        return document.querySelectorAll('div.new-experiment-modal button.mat-mdc-raised-button')[16];
 
       // Experiment Details - Overview Tab
       case 'experiment-details-overview-status':
@@ -86,13 +94,13 @@ if (window.self !== window.top) {
 
       // Experiment Details - Data Tab
       case 'experiment-details-data-tab':
-        return document.querySelectorAll('div.mat-tab-list div.mat-tab-label')[4];
+        return document.querySelectorAll('div.mat-mdc-tab-list div.mat-mdc-tab')[4];
 
       // Change Experiment Status Modal
       case 'change-experiment-status-modal-new-status':
-        return document.querySelectorAll('form.experiment-status-form div.mat-select-value')[1];
+        return document.querySelectorAll('form.experiment-status-form div.mat-mdc-select-value')[1];
       case 'change-experiment-status-modal-save-button':
-        return document.querySelectorAll('div.button-container button.mat-raised-button')[1];
+        return document.querySelectorAll('div.button-container button.mat-mdc-raised-button')[1];
     }
     console.error(`Error: The element ID "${id}" is not valid.`);
     return null;
@@ -110,7 +118,7 @@ if (window.self !== window.top) {
       activeWindowEvent.target.removeEventListener(activeWindowEvent.type, activeWindowEvent.callback, true);
       activeWindowEvent = null;
     }
-  }
+  };
 
   const addWindowEvent = (target, type, callback) => {
     removeActiveWindowEvent();
@@ -122,46 +130,50 @@ if (window.self !== window.top) {
     activeWindowEvent = {
       target,
       type,
-      callback
+      callback,
     };
-  }
+  };
 
   const closeOpenedModals = () => {
-    const modalButtonsSelector = 'div.cdk-overlay-pane button.mat-raised-button';
-    const modalCloseButton = Array.from(document.querySelectorAll(modalButtonsSelector)).find((elem) => elem.innerText.toLowerCase() === 'close');
+    const modalButtonsSelector = 'div.cdk-overlay-pane button.mat-mdc-raised-button';
+    const modalCloseButton = Array.from(document.querySelectorAll(modalButtonsSelector)).find(
+      (elem) => elem.innerText.toLowerCase() === 'close'
+    );
     if (modalCloseButton) {
       modalCloseButton.click();
-      const confirmCloseButton = Array.from(document.querySelectorAll(modalButtonsSelector)).find((elem) => elem.innerText.toLowerCase() === 'yes');
+      const confirmCloseButton = Array.from(document.querySelectorAll(modalButtonsSelector)).find(
+        (elem) => elem.innerText.toLowerCase() === 'yes'
+      );
       if (confirmCloseButton) {
         confirmCloseButton.click();
       }
     }
-  }
+  };
 
   // A set of functions that do more than triggering an event
   const initCallFunction = {
     'set-zoom-level': (args) => {
       document.body.style.zoom = args[0];
     },
-    'logout': () => {
+    logout: () => {
       closeOpenedModals();
       const signOutButton = getElementById('signout-button');
       if (signOutButton) {
         signOutButton.click();
-      } else if (gapi.auth2.getAuthInstance().isSignedIn.get()) {
-        gapi.auth2.getAuthInstance().signOut();
       }
     },
     'on-upgrade-tab-click': () => {
-      if (!gapi.auth2.getAuthInstance().isSignedIn.get()) {
+      if (!getElementById('upgrade-logo-link')) {
         return closeOpenedModals();
       }
       const experimentsTab = getElementById('experiments-tab');
-      experimentsTab.click();
+      if (experimentsTab) {
+        experimentsTab.click();
+      }
     },
     'remove-active-window-event': () => {
       removeActiveWindowEvent();
-    }
+    },
   };
 
   // Used to call a function or trigger event on element
@@ -193,14 +205,16 @@ if (window.self !== window.top) {
     'on-experiment-click': (args, onNextCall) => {
       const experimentName = args[0];
       const onWindowClick = (event) => {
-        const elem = Array.from(document.querySelectorAll('div.experiment-list-table-container a.experiment-name')).find((elem) => elem.innerText === experimentName);
+        const elem = Array.from(
+          document.querySelectorAll('div.experiment-list-table-container a.experiment-name')
+        ).find((elem) => elem.innerText === experimentName);
         if (elem && elem.contains(event.target)) {
           removeActiveWindowEvent();
           onNextCall();
         }
       };
       addWindowEvent(window, 'click', onWindowClick);
-    }
+    },
   };
 
   // Used to detect event on element

--- a/frontend/projects/upgrade/src/environments/environment.demo.prod.ts
+++ b/frontend/projects/upgrade/src/environments/environment.demo.prod.ts
@@ -13,10 +13,10 @@ export const environment: Environment = {
   pollingEnabled: true,
   pollingInterval: 10 * 1000,
   pollingLimit: 600,
-  segmentsRefreshToggle: false,
+  segmentsRefreshToggle: true,
   withinSubjectExperimentSupportToggle: false,
   errorLogsToggle: false,
-  metricAnalyticsExperimentDisplayToggle: false,
+  metricAnalyticsExperimentDisplayToggle: true,
   moocletToggle: false,
   api: {
     getAllExperiments: '/experiments/paginated',


### PR DESCRIPTION
This PR adds support for running the demo app with Docker using `docker-compose -f demo.singleContainerApp-docker-compose.yml up -d` (tested on the EC2 instance).

For reference, I created a separate `demo.singleContainerApp.Dockerfile` because the frontend crashed with a `Segmentation fault (core dumped)` error when using `node:22.14-alpine`. Updating this to `node:22.14-bullseye` fixed the issue (suggested by ChatGPT).