### PR TITLE
add warning icon, some refactoring to improve shared logic between components / selectors

### DIFF
--- a/frontend/projects/upgrade/src/app/core/experiments/condition-helper.service.spec.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/condition-helper.service.spec.ts
@@ -1,0 +1,468 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  ConditionHelperService,
+  WEIGHT_CONFIG,
+  determineWeightingMethod,
+  distributeWeightsEqually,
+  isWeightSumValid,
+} from './condition-helper.service';
+import { ExperimentService } from './experiments.service';
+import { ExperimentCondition, WEIGHTING_METHOD } from './store/experiments.model';
+
+describe('ConditionHelperService', () => {
+  let service: ConditionHelperService;
+  let mockExperimentService: any;
+
+  beforeEach(() => {
+    mockExperimentService = {
+      updateExperimentConditions: jest.fn(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [ConditionHelperService, { provide: ExperimentService, useValue: mockExperimentService }],
+    });
+
+    service = TestBed.inject(ConditionHelperService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('WEIGHT_CONFIG', () => {
+    it('should have correct configuration values', () => {
+      expect(WEIGHT_CONFIG.TOTAL_WEIGHT).toBe(100);
+      expect(WEIGHT_CONFIG.DECIMAL_PLACES).toBe(2);
+      expect(WEIGHT_CONFIG.VALIDATION_TOLERANCE).toBe(0.1);
+    });
+  });
+
+  describe('determineWeightingMethod (pure function)', () => {
+    it('should return EQUAL for empty conditions array', () => {
+      const result = determineWeightingMethod([]);
+      expect(result).toBe(WEIGHTING_METHOD.EQUAL);
+    });
+
+    it('should return EQUAL for null/undefined conditions', () => {
+      expect(determineWeightingMethod(null)).toBe(WEIGHTING_METHOD.EQUAL);
+      expect(determineWeightingMethod(undefined)).toBe(WEIGHTING_METHOD.EQUAL);
+    });
+
+    it('should return EQUAL for single condition with 100% weight', () => {
+      const conditions: ExperimentCondition[] = [createCondition('Control', 100)];
+      const result = determineWeightingMethod(conditions);
+      expect(result).toBe(WEIGHTING_METHOD.EQUAL);
+    });
+
+    it('should return EQUAL for 2 conditions with 50/50 split', () => {
+      const conditions: ExperimentCondition[] = [createCondition('Control', 50), createCondition('Treatment', 50)];
+      const result = determineWeightingMethod(conditions);
+      expect(result).toBe(WEIGHTING_METHOD.EQUAL);
+    });
+
+    it('should return EQUAL for 3 conditions with 33.33 each (total 99.99)', () => {
+      const conditions: ExperimentCondition[] = [
+        createCondition('A', 33.33),
+        createCondition('B', 33.33),
+        createCondition('C', 33.33),
+      ];
+      const result = determineWeightingMethod(conditions);
+      expect(result).toBe(WEIGHTING_METHOD.EQUAL);
+    });
+
+    it('should return EQUAL for 4 conditions with 25 each', () => {
+      const conditions: ExperimentCondition[] = [
+        createCondition('A', 25),
+        createCondition('B', 25),
+        createCondition('C', 25),
+        createCondition('D', 25),
+      ];
+      const result = determineWeightingMethod(conditions);
+      expect(result).toBe(WEIGHTING_METHOD.EQUAL);
+    });
+
+    it('should return CUSTOM for unequal weights', () => {
+      const conditions: ExperimentCondition[] = [createCondition('Control', 40), createCondition('Treatment', 60)];
+      const result = determineWeightingMethod(conditions);
+      expect(result).toBe(WEIGHTING_METHOD.CUSTOM);
+    });
+
+    it('should return CUSTOM for 3 conditions with custom split', () => {
+      const conditions: ExperimentCondition[] = [
+        createCondition('A', 20),
+        createCondition('B', 30),
+        createCondition('C', 50),
+      ];
+      const result = determineWeightingMethod(conditions);
+      expect(result).toBe(WEIGHTING_METHOD.CUSTOM);
+    });
+
+    it('should return EQUAL for weights within tolerance', () => {
+      // Expected weight is 33.33, actual is 33.32 (within 0.1 tolerance)
+      const conditions: ExperimentCondition[] = [
+        createCondition('A', 33.32),
+        createCondition('B', 33.33),
+        createCondition('C', 33.33),
+      ];
+      const result = determineWeightingMethod(conditions);
+      expect(result).toBe(WEIGHTING_METHOD.EQUAL);
+    });
+
+    it('should handle 7 conditions (14.29 each)', () => {
+      const conditions: ExperimentCondition[] = Array(7)
+        .fill(null)
+        .map((_, i) => createCondition(`Condition${i}`, 14.29));
+      const result = determineWeightingMethod(conditions);
+      expect(result).toBe(WEIGHTING_METHOD.EQUAL);
+    });
+  });
+
+  describe('distributeWeightsEqually (pure function)', () => {
+    it('should not modify empty array', () => {
+      const conditions: ExperimentCondition[] = [];
+      distributeWeightsEqually(conditions);
+      expect(conditions.length).toBe(0);
+    });
+
+    it('should set single condition to 100', () => {
+      const conditions: ExperimentCondition[] = [createCondition('Control', 0)];
+      distributeWeightsEqually(conditions);
+      expect(conditions[0].assignmentWeight).toBe(100);
+    });
+
+    it('should distribute 50/50 for 2 conditions', () => {
+      const conditions: ExperimentCondition[] = [createCondition('Control', 0), createCondition('Treatment', 0)];
+      distributeWeightsEqually(conditions);
+      expect(conditions[0].assignmentWeight).toBe(50);
+      expect(conditions[1].assignmentWeight).toBe(50);
+    });
+
+    it('should distribute 33.33/33.33/33.33 for 3 conditions (total 99.99)', () => {
+      const conditions: ExperimentCondition[] = [
+        createCondition('A', 0),
+        createCondition('B', 0),
+        createCondition('C', 0),
+      ];
+      distributeWeightsEqually(conditions);
+
+      // All should be 33.33 (truly equal)
+      expect(conditions[0].assignmentWeight).toBe(33.33);
+      expect(conditions[1].assignmentWeight).toBe(33.33);
+      expect(conditions[2].assignmentWeight).toBe(33.33);
+
+      // Total should be 99.99 (acceptable per requirements)
+      const total = conditions.reduce((sum, c) => sum + c.assignmentWeight, 0);
+      expect(total).toBe(99.99);
+    });
+
+    it('should distribute 25/25/25/25 for 4 conditions', () => {
+      const conditions: ExperimentCondition[] = [
+        createCondition('A', 0),
+        createCondition('B', 0),
+        createCondition('C', 0),
+        createCondition('D', 0),
+      ];
+      distributeWeightsEqually(conditions);
+
+      conditions.forEach((c) => {
+        expect(c.assignmentWeight).toBe(25);
+      });
+
+      const total = conditions.reduce((sum, c) => sum + c.assignmentWeight, 0);
+      expect(total).toBe(100);
+    });
+
+    it('should round to 2 decimal places', () => {
+      const conditions: ExperimentCondition[] = Array(7)
+        .fill(null)
+        .map((_, i) => createCondition(`C${i}`, 0));
+      distributeWeightsEqually(conditions);
+
+      // 100 / 7 = 14.285714... should round to 14.29
+      conditions.forEach((c) => {
+        expect(c.assignmentWeight).toBe(14.29);
+        // Verify exactly 2 decimal places
+        const decimals = c.assignmentWeight.toString().split('.')[1];
+        expect(decimals?.length || 0).toBeLessThanOrEqual(2);
+      });
+    });
+
+    it('should handle 9 conditions (11.11 each)', () => {
+      const conditions: ExperimentCondition[] = Array(9)
+        .fill(null)
+        .map((_, i) => createCondition(`C${i}`, 0));
+      distributeWeightsEqually(conditions);
+
+      conditions.forEach((c) => {
+        expect(c.assignmentWeight).toBe(11.11);
+      });
+
+      const total = conditions.reduce((sum, c) => sum + c.assignmentWeight, 0);
+      expect(total).toBeCloseTo(99.99, 2);
+    });
+
+    it('should overwrite existing weights', () => {
+      const conditions: ExperimentCondition[] = [
+        createCondition('A', 40),
+        createCondition('B', 60),
+        createCondition('C', 0),
+      ];
+      distributeWeightsEqually(conditions);
+
+      conditions.forEach((c) => {
+        expect(c.assignmentWeight).toBe(33.33);
+      });
+    });
+  });
+
+  describe('isWeightSumValid (pure function)', () => {
+    it('should return true for empty conditions', () => {
+      expect(isWeightSumValid([])).toBe(true);
+    });
+
+    it('should return true for null/undefined conditions', () => {
+      expect(isWeightSumValid(null)).toBe(true);
+      expect(isWeightSumValid(undefined)).toBe(true);
+    });
+
+    it('should return true for weights totaling exactly 100', () => {
+      const conditions: ExperimentCondition[] = [createCondition('Control', 50), createCondition('Treatment', 50)];
+      expect(isWeightSumValid(conditions)).toBe(true);
+    });
+
+    it('should return true for weights totaling 99.99 (within tolerance)', () => {
+      const conditions: ExperimentCondition[] = [
+        createCondition('A', 33.33),
+        createCondition('B', 33.33),
+        createCondition('C', 33.33),
+      ];
+      expect(isWeightSumValid(conditions)).toBe(true);
+    });
+
+    it('should return true for weights totaling 100.01 (within tolerance)', () => {
+      const conditions: ExperimentCondition[] = [
+        createCondition('A', 33.34),
+        createCondition('B', 33.34),
+        createCondition('C', 33.33),
+      ];
+      expect(isWeightSumValid(conditions)).toBe(true);
+    });
+
+    it('should return true for weights at lower tolerance boundary (99.9)', () => {
+      const conditions: ExperimentCondition[] = [createCondition('Control', 99.9)];
+      expect(isWeightSumValid(conditions)).toBe(true);
+    });
+
+    it('should return true for weights at upper tolerance boundary (100.1)', () => {
+      const conditions: ExperimentCondition[] = [createCondition('Control', 100.1)];
+      expect(isWeightSumValid(conditions)).toBe(true);
+    });
+
+    it('should return false for weights totaling 90', () => {
+      const conditions: ExperimentCondition[] = [
+        createCondition('A', 30),
+        createCondition('B', 30),
+        createCondition('C', 30),
+      ];
+      expect(isWeightSumValid(conditions)).toBe(false);
+    });
+
+    it('should return false for weights totaling 110', () => {
+      const conditions: ExperimentCondition[] = [
+        createCondition('A', 40),
+        createCondition('B', 40),
+        createCondition('C', 30),
+      ];
+      expect(isWeightSumValid(conditions)).toBe(false);
+    });
+
+    it('should return false for weights outside lower tolerance (99.89)', () => {
+      const conditions: ExperimentCondition[] = [createCondition('Control', 99.89)];
+      expect(isWeightSumValid(conditions)).toBe(false);
+    });
+
+    it('should return false for weights outside upper tolerance (100.11)', () => {
+      const conditions: ExperimentCondition[] = [createCondition('Control', 100.11)];
+      expect(isWeightSumValid(conditions)).toBe(false);
+    });
+
+    it('should handle conditions with 0 weight', () => {
+      const conditions: ExperimentCondition[] = [createCondition('A', 0), createCondition('B', 0)];
+      expect(isWeightSumValid(conditions)).toBe(false);
+    });
+
+    it('should handle single condition at 100%', () => {
+      const conditions: ExperimentCondition[] = [createCondition('Control', 100)];
+      expect(isWeightSumValid(conditions)).toBe(true);
+    });
+  });
+
+  describe('addCondition', () => {
+    it('should add condition with 0 weight when not equal weighting', () => {
+      const experiment = createExperiment([createCondition('A', 40), createCondition('B', 60)]);
+      const conditionData = { conditionCode: 'C', description: 'Condition C' };
+
+      service.addCondition(experiment, conditionData);
+
+      expect(mockExperimentService.updateExperimentConditions).toHaveBeenCalled();
+      const updateRequest = mockExperimentService.updateExperimentConditions.mock.lastCall[0];
+      expect(updateRequest.conditions.length).toBe(3);
+      expect(updateRequest.conditions[2].conditionCode).toBe('C');
+      expect(updateRequest.conditions[2].assignmentWeight).toBe(0);
+    });
+
+    it('should redistribute weights equally when adding to equal-weighted conditions', () => {
+      const experiment = createExperiment([createCondition('A', 50), createCondition('B', 50)]);
+      const conditionData = { conditionCode: 'C', description: 'Condition C' };
+
+      service.addCondition(experiment, conditionData);
+
+      const updateRequest = mockExperimentService.updateExperimentConditions.mock.lastCall[0];
+      expect(updateRequest.conditions.length).toBe(3);
+      // All should be 33.33
+      expect(updateRequest.conditions[0].assignmentWeight).toBe(33.33);
+      expect(updateRequest.conditions[1].assignmentWeight).toBe(33.33);
+      expect(updateRequest.conditions[2].assignmentWeight).toBe(33.33);
+    });
+
+    it('should set order correctly for new condition', () => {
+      const experiment = createExperiment([createCondition('A', 50), createCondition('B', 50)]);
+      const conditionData = { conditionCode: 'C', description: 'Condition C' };
+
+      service.addCondition(experiment, conditionData);
+
+      const updateRequest = mockExperimentService.updateExperimentConditions.mock.lastCall[0];
+      expect(updateRequest.conditions[2].order).toBe(3);
+    });
+  });
+
+  describe('updateCondition', () => {
+    it('should update condition code and description', () => {
+      const condition = createCondition('A', 33.33);
+      const experiment = createExperiment([condition, createCondition('B', 33.33), createCondition('C', 33.34)]);
+      const conditionData = { conditionCode: 'A-Updated', description: 'Updated description' };
+
+      service.updateCondition(experiment, condition, conditionData);
+
+      const updateRequest = mockExperimentService.updateExperimentConditions.mock.lastCall[0];
+      expect(updateRequest.conditions[0].conditionCode).toBe('A-Updated');
+      expect(updateRequest.conditions[0].description).toBe('Updated description');
+    });
+
+    it('should not modify weight when updating', () => {
+      const condition = createCondition('A', 40);
+      const experiment = createExperiment([condition, createCondition('B', 60)]);
+      const conditionData = { conditionCode: 'A-Updated', description: 'Updated' };
+
+      service.updateCondition(experiment, condition, conditionData);
+
+      const updateRequest = mockExperimentService.updateExperimentConditions.mock.lastCall[0];
+      expect(updateRequest.conditions[0].assignmentWeight).toBe(40);
+      expect(updateRequest.conditions[1].assignmentWeight).toBe(60);
+    });
+  });
+
+  describe('deleteCondition', () => {
+    it('should remove condition and redistribute weights if equal weighting', () => {
+      const conditionToDelete = createCondition('B', 33.33);
+      const experiment = createExperiment([
+        createCondition('A', 33.33),
+        conditionToDelete,
+        createCondition('C', 33.33),
+      ]);
+
+      service.deleteCondition(experiment, conditionToDelete);
+
+      const updateRequest = mockExperimentService.updateExperimentConditions.mock.lastCall[0];
+      expect(updateRequest.conditions.length).toBe(2);
+      expect(updateRequest.conditions[0].assignmentWeight).toBe(50);
+      expect(updateRequest.conditions[1].assignmentWeight).toBe(50);
+    });
+
+    it('should reorder remaining conditions after deletion', () => {
+      const conditionToDelete = createCondition('B', 33.33);
+      const experiment = createExperiment([
+        createCondition('A', 33.33),
+        conditionToDelete,
+        createCondition('C', 33.33),
+      ]);
+
+      service.deleteCondition(experiment, conditionToDelete);
+
+      const updateRequest = mockExperimentService.updateExperimentConditions.mock.lastCall[0];
+      expect(updateRequest.conditions[0].order).toBe(1);
+      expect(updateRequest.conditions[1].order).toBe(2);
+    });
+
+    it('should not redistribute weights if custom weighting', () => {
+      const conditionToDelete = createCondition('B', 30);
+      const experiment = createExperiment([createCondition('A', 40), conditionToDelete, createCondition('C', 30)]);
+
+      service.deleteCondition(experiment, conditionToDelete);
+
+      const updateRequest = mockExperimentService.updateExperimentConditions.mock.lastCall[0];
+      expect(updateRequest.conditions.length).toBe(2);
+      expect(updateRequest.conditions[0].assignmentWeight).toBe(40);
+      expect(updateRequest.conditions[1].assignmentWeight).toBe(30);
+    });
+
+    it('should handle deleting last condition', () => {
+      const conditionToDelete = createCondition('A', 100);
+      const experiment = createExperiment([conditionToDelete]);
+
+      service.deleteCondition(experiment, conditionToDelete);
+
+      const updateRequest = mockExperimentService.updateExperimentConditions.mock.lastCall[0];
+      expect(updateRequest.conditions.length).toBe(0);
+    });
+  });
+
+  describe('integration scenarios', () => {
+    it('should maintain total weight near 100 after multiple operations', () => {
+      // Start with 3 conditions
+      let experiment = createExperiment([
+        createCondition('A', 33.33),
+        createCondition('B', 33.33),
+        createCondition('C', 33.33),
+      ]);
+
+      // Add a condition (4 conditions at 25 each)
+      service.addCondition(experiment, { conditionCode: 'D', description: 'D' });
+      let updateRequest = mockExperimentService.updateExperimentConditions.mock.lastCall[0];
+      let total = updateRequest.conditions.reduce((sum, c) => sum + c.assignmentWeight, 0);
+      expect(total).toBeCloseTo(100, 1);
+
+      // Delete a condition (back to 3 conditions)
+      experiment = { ...experiment, conditions: updateRequest.conditions };
+      service.deleteCondition(experiment, updateRequest.conditions[1]);
+      updateRequest = mockExperimentService.updateExperimentConditions.mock.lastCall[0];
+      total = updateRequest.conditions.reduce((sum, c) => sum + c.assignmentWeight, 0);
+      expect(total).toBeCloseTo(99.99, 1);
+    });
+  });
+});
+
+// Helper functions
+function createCondition(code: string, weight: number): ExperimentCondition {
+  return {
+    id: `id-${code}`,
+    name: code,
+    description: `Description for ${code}`,
+    conditionCode: code,
+    assignmentWeight: weight,
+    twoCharacterId: code.substring(0, 2),
+    order: 1,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    versionNumber: 1,
+  };
+}
+
+function createExperiment(conditions: ExperimentCondition[]): any {
+  return {
+    id: 'exp-1',
+    name: 'Test Experiment',
+    conditions: conditions.map((c, i) => ({ ...c, order: i + 1 })),
+    conditionPayloads: [],
+  };
+}

--- a/frontend/projects/upgrade/src/app/core/experiments/condition-helper.service.spec.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/condition-helper.service.spec.ts
@@ -33,7 +33,7 @@ describe('ConditionHelperService', () => {
     it('should have correct configuration values', () => {
       expect(WEIGHT_CONFIG.TOTAL_WEIGHT).toBe(100);
       expect(WEIGHT_CONFIG.DECIMAL_PLACES).toBe(2);
-      expect(WEIGHT_CONFIG.VALIDATION_TOLERANCE).toBe(0.1);
+      expect(WEIGHT_CONFIG.VALIDATION_TOLERANCE).toBe(0.03);
     });
   });
 
@@ -98,7 +98,7 @@ describe('ConditionHelperService', () => {
     });
 
     it('should return EQUAL for weights within tolerance', () => {
-      // Expected weight is 33.33, actual is 33.32 (within 0.1 tolerance)
+      // Expected weight is 33.33, actual is 33.32 (within 0.03 tolerance)
       const conditions: ExperimentCondition[] = [
         createCondition('A', 33.32),
         createCondition('B', 33.33),
@@ -248,13 +248,13 @@ describe('ConditionHelperService', () => {
       expect(isWeightSumValid(conditions)).toBe(true);
     });
 
-    it('should return true for weights at lower tolerance boundary (99.9)', () => {
-      const conditions: ExperimentCondition[] = [createCondition('Control', 99.9)];
+    it('should return true for weights at lower tolerance boundary (99.97)', () => {
+      const conditions: ExperimentCondition[] = [createCondition('Control', 99.97)];
       expect(isWeightSumValid(conditions)).toBe(true);
     });
 
-    it('should return true for weights at upper tolerance boundary (100.1)', () => {
-      const conditions: ExperimentCondition[] = [createCondition('Control', 100.1)];
+    it('should return true for weights at upper tolerance boundary (100.03)', () => {
+      const conditions: ExperimentCondition[] = [createCondition('Control', 100.03)];
       expect(isWeightSumValid(conditions)).toBe(true);
     });
 
@@ -276,13 +276,13 @@ describe('ConditionHelperService', () => {
       expect(isWeightSumValid(conditions)).toBe(false);
     });
 
-    it('should return false for weights outside lower tolerance (99.89)', () => {
-      const conditions: ExperimentCondition[] = [createCondition('Control', 99.89)];
+    it('should return false for weights outside lower tolerance (99.96)', () => {
+      const conditions: ExperimentCondition[] = [createCondition('Control', 99.96)];
       expect(isWeightSumValid(conditions)).toBe(false);
     });
 
-    it('should return false for weights outside upper tolerance (100.11)', () => {
-      const conditions: ExperimentCondition[] = [createCondition('Control', 100.11)];
+    it('should return false for weights outside upper tolerance (100.04)', () => {
+      const conditions: ExperimentCondition[] = [createCondition('Control', 100.04)];
       expect(isWeightSumValid(conditions)).toBe(false);
     });
 

--- a/frontend/projects/upgrade/src/app/core/experiments/condition-helper.service.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/condition-helper.service.ts
@@ -7,7 +7,83 @@ import {
   ExperimentCondition,
   UpdateExperimentConditionsRequest,
   ConditionFormData,
+  WeightingMethod,
+  WEIGHTING_METHOD,
 } from './store/experiments.model';
+import { ConditionWeightUpdate } from '../../features/dashboard/experiments/modals/edit-condition-weights-modal/edit-condition-weights-modal.component';
+
+export const WEIGHT_CONFIG = {
+  TOTAL_WEIGHT: 100,
+  DECIMAL_PLACES: 2,
+  VALIDATION_TOLERANCE: 0.1, // Allow rounding errors from equal distribution (e.g., 3 × 33.33 = 99.99)
+} as const;
+
+// ============================================================================
+// Pure Functions (exported for use in selectors and other pure contexts)
+// ============================================================================
+
+/**
+ * Round to configured decimal places (2 decimals)
+ */
+function roundToDecimalPlaces(value: number): number {
+  const multiplier = Math.pow(10, WEIGHT_CONFIG.DECIMAL_PLACES);
+  return Math.round(value * multiplier) / multiplier;
+}
+
+/**
+ * Check if two weights are equal within tolerance
+ */
+function isWeightEqual(actual: number, expected: number): boolean {
+  return Math.abs(actual - expected) < WEIGHT_CONFIG.VALIDATION_TOLERANCE;
+}
+
+/**
+ * Determine the weighting method for a set of conditions.
+ * Returns 'equal' if all weights are the same, 'custom' otherwise.
+ */
+export function determineWeightingMethod(conditions: ExperimentCondition[]): WeightingMethod {
+  if (!conditions || conditions.length === 0) {
+    return WEIGHTING_METHOD.EQUAL; // Default to equal weighting for new experiments
+  }
+
+  const expectedWeight = roundToDecimalPlaces(WEIGHT_CONFIG.TOTAL_WEIGHT / conditions.length);
+  const isEqual = conditions.every((condition) => isWeightEqual(condition.assignmentWeight, expectedWeight));
+
+  return isEqual ? WEIGHTING_METHOD.EQUAL : WEIGHTING_METHOD.CUSTOM;
+}
+
+/**
+ * Distributes weights equally across all conditions.
+ * All conditions get the exact same weight rounded to 2 decimals.
+ * Total may be 99.99% or 100.01% due to rounding - this is acceptable.
+ */
+export function distributeWeightsEqually(conditions: ExperimentCondition[] | ConditionWeightUpdate[]): void {
+  if (!conditions || conditions.length === 0) return;
+
+  const equalWeight = roundToDecimalPlaces(WEIGHT_CONFIG.TOTAL_WEIGHT / conditions.length);
+
+  conditions.forEach((condition) => {
+    condition.assignmentWeight = equalWeight;
+  });
+}
+
+/**
+ * Check if total weights sum to 100 within tolerance.
+ * Used for validation warnings.
+ */
+export function isWeightSumValid(conditions: ExperimentCondition[]): boolean {
+  if (!conditions || conditions.length === 0) {
+    return true;
+  }
+
+  const totalWeight = conditions.reduce((sum, condition) => sum + (condition.assignmentWeight || 0), 0);
+
+  return Math.abs(totalWeight - WEIGHT_CONFIG.TOTAL_WEIGHT) < WEIGHT_CONFIG.VALIDATION_TOLERANCE;
+}
+
+// ============================================================================
+// Service Class (for stateful operations that need dependency injection)
+// ============================================================================
 
 @Injectable({
   providedIn: 'root',
@@ -29,6 +105,12 @@ export class ConditionHelperService {
     };
 
     const updatedConditions = [...currentConditions, newCondition] as ExperimentCondition[];
+
+    // Check if weights should be distributed equally
+    const weightingMethod = determineWeightingMethod(currentConditions);
+    if (weightingMethod === WEIGHTING_METHOD.EQUAL) {
+      distributeWeightsEqually(updatedConditions);
+    }
 
     this.updateExperimentConditions(experiment, updatedConditions);
   }
@@ -71,6 +153,14 @@ export class ConditionHelperService {
       ...c,
       order: index + 1,
     }));
+
+    // Check if weights should be redistributed equally
+    const weightingMethod = determineWeightingMethod(currentConditions);
+
+    if (weightingMethod === WEIGHTING_METHOD.EQUAL && reorderedConditions.length > 0) {
+      distributeWeightsEqually(reorderedConditions);
+    }
+
     this.updateExperimentConditions(updatedExperiment, reorderedConditions);
   }
 

--- a/frontend/projects/upgrade/src/app/core/experiments/condition-helper.service.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/condition-helper.service.ts
@@ -15,7 +15,7 @@ import { ConditionWeightUpdate } from '../../features/dashboard/experiments/moda
 export const WEIGHT_CONFIG = {
   TOTAL_WEIGHT: 100,
   DECIMAL_PLACES: 2,
-  VALIDATION_TOLERANCE: 0.1, // Allow rounding errors from equal distribution (e.g., 3 × 33.33 = 99.99)
+  VALIDATION_TOLERANCE: 0.03, // Allow rounding errors from equal distribution (e.g., 3 × 33.33 = 99.99)
 } as const;
 
 // ============================================================================
@@ -77,8 +77,9 @@ export function isWeightSumValid(conditions: ExperimentCondition[]): boolean {
   }
 
   const totalWeight = conditions.reduce((sum, condition) => sum + (condition.assignmentWeight || 0), 0);
+  const difference = roundToDecimalPlaces(Math.abs(totalWeight - WEIGHT_CONFIG.TOTAL_WEIGHT));
 
-  return Math.abs(totalWeight - WEIGHT_CONFIG.TOTAL_WEIGHT) < WEIGHT_CONFIG.VALIDATION_TOLERANCE;
+  return difference <= WEIGHT_CONFIG.VALIDATION_TOLERANCE;
 }
 
 // ============================================================================

--- a/frontend/projects/upgrade/src/app/core/experiments/store/experiments.model.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/store/experiments.model.ts
@@ -303,8 +303,16 @@ export interface IExperimentGraphInfo {
 }
 
 export interface ExperimentVM extends Experiment {
-  stat: IExperimentEnrollmentDetailStats;
+  stat?: IExperimentEnrollmentDetailStats;
+  weightingMethod?: WeightingMethod;
 }
+
+export type WeightingMethod = 'equal' | 'custom';
+
+export const WEIGHTING_METHOD = {
+  EQUAL: 'equal' as WeightingMethod,
+  CUSTOM: 'custom' as WeightingMethod,
+} as const;
 
 export enum UPSERT_EXPERIMENT_ACTION {
   ADD = 'add',
@@ -531,7 +539,7 @@ export const EXPERIMENT_TRANSLATION_KEYS = {
 
 export const EXPERIMENT_ROOT_DISPLAYED_COLUMNS = Object.values(EXPERIMENT_ROOT_COLUMN_NAMES);
 
-export interface ExperimentState extends EntityState<Experiment> {
+export interface ExperimentState extends EntityState<ExperimentVM> {
   isLoadingExperiment: boolean;
   isLoadingExperimentDetailStats: boolean;
   isPollingExperimentDetailStats: boolean;

--- a/frontend/projects/upgrade/src/app/core/experiments/store/experiments.reducer.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/store/experiments.reducer.ts
@@ -4,12 +4,13 @@ import {
   EXPERIMENT_SEARCH_KEY,
   SORT_AS_DIRECTION,
   EXPERIMENT_SORT_KEY,
+  ExperimentVM,
 } from './experiments.model';
 import { createReducer, on, Action } from '@ngrx/store';
 import * as experimentsAction from './experiments.actions';
 import { createEntityAdapter, EntityAdapter } from '@ngrx/entity';
 
-export const adapter: EntityAdapter<Experiment> = createEntityAdapter<Experiment>();
+export const adapter: EntityAdapter<ExperimentVM> = createEntityAdapter<ExperimentVM>();
 
 export const { selectIds, selectEntities, selectAll, selectTotal } = adapter.getSelectors();
 
@@ -36,6 +37,8 @@ export const initialState: ExperimentState = adapter.getInitialState({
   isLoadingContextMetaData: false,
   currentUserSelectedContext: null,
   isLoadingExperimentDelete: false,
+  stat: null,
+  weightingMethod: 'equal',
 });
 
 const reducer = createReducer(

--- a/frontend/projects/upgrade/src/app/core/experiments/store/experiments.reducer.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/store/experiments.reducer.ts
@@ -37,8 +37,6 @@ export const initialState: ExperimentState = adapter.getInitialState({
   isLoadingContextMetaData: false,
   currentUserSelectedContext: null,
   isLoadingExperimentDelete: false,
-  stat: null,
-  weightingMethod: 'equal',
 });
 
 const reducer = createReducer(

--- a/frontend/projects/upgrade/src/app/core/experiments/store/experiments.selector.spec.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/store/experiments.selector.spec.ts
@@ -206,6 +206,8 @@ describe('Experiments Selectors', () => {
         ],
         type: EXPERIMENT_TYPE.SIMPLE,
         assignmentAlgorithm: ASSIGNMENT_ALGORITHM.RANDOM,
+        stat: null,
+        weightingMethod: 'equal',
       },
     },
     isLoadingExperiment: false,

--- a/frontend/projects/upgrade/src/app/core/experiments/store/experiments.selectors.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/store/experiments.selectors.ts
@@ -33,7 +33,7 @@ export const selectIsLoadingExperimentDetailStats = createSelector(
 export const selectSelectedExperiment = createSelector(
   selectRouterState,
   selectExperimentState,
-  (routerState, experimentState): ExperimentVM => {
+  (routerState, experimentState): ExperimentVM | undefined => {
     // be very defensive here to make sure routerState is correct
     const experimentId = routerState?.state?.params?.experimentId;
     if (experimentId && experimentState?.entities) {

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/modals/edit-condition-weights-modal/edit-condition-weights-modal.component.spec.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/modals/edit-condition-weights-modal/edit-condition-weights-modal.component.spec.ts
@@ -245,7 +245,7 @@ describe('EditConditionWeightsModalComponent', () => {
       };
 
       const { component } = await setupComponent(threeConditionsData);
-      component.distributeWeightsEqually();
+      component.distributeWeightsEquallyInFormControls();
 
       const total = component.getCurrentTotal();
       expect(total).toBe(100);

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-conditions-section-card/experiment-conditions-section-card.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-conditions-section-card/experiment-conditions-section-card.component.html
@@ -5,6 +5,7 @@
     [title]="'experiments.details.conditions.card.title.text' | translate"
     [subtitle]="'experiments.details.conditions.card.subtitle.text' | translate"
     [tableRowCount]="experiment.conditions?.length || 0"
+    [warningMessage]="weightWarningText$ | async"
   ></app-common-section-card-title-header>
 
   <!-- header-right -->

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-conditions-section-card/experiment-conditions-section-card.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-conditions-section-card/experiment-conditions-section-card.component.ts
@@ -6,13 +6,11 @@ import {
 } from '../../../../../../../shared-standalone-component-lib/components';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
-import { IMenuButtonItem } from 'upgrade_types';
 import { ExperimentConditionsTableComponent } from './experiment-conditions-table/experiment-conditions-table.component';
 import { ExperimentService } from '../../../../../../../core/experiments/experiments.service';
-import { Observable, map, take } from 'rxjs';
+import { Observable, combineLatest, map, take } from 'rxjs';
 import {
   Experiment,
-  EXPERIMENT_BUTTON_ACTION,
   EXPERIMENT_ROW_ACTION,
   ExperimentCondition,
   ExperimentConditionRowActionEvent,
@@ -46,8 +44,11 @@ export class ExperimentConditionsSectionCardComponent implements OnInit {
   permissions$: Observable<UserPermission>;
   selectedExperiment$ = this.experimentService.selectedExperiment$;
   conditionWeightsValid$ = this.store.select(selectConditionWeightsValid);
-  weightWarningText$ = this.conditionWeightsValid$.pipe(
-    map((valid) => (!valid ? 'experiments.edit-condition-weights-modal.weights-sum-validation.text' : undefined))
+  isLoadingExperiment$ = this.experimentService.isLoadingExperiment$;
+  weightWarningText$ = combineLatest([this.conditionWeightsValid$, this.isLoadingExperiment$]).pipe(
+    map(([valid, isLoading]) =>
+      !valid && !isLoading ? 'experiments.edit-condition-weights-modal.weights-sum-validation.text' : undefined
+    )
   );
 
   constructor(

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-conditions-section-card/experiment-conditions-table/experiment-conditions-table.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-conditions-section-card/experiment-conditions-table/experiment-conditions-table.component.html
@@ -3,12 +3,7 @@
   <mat-progress-bar class="spinner" mode="indeterminate" *ngIf="isLoading$ | async"></mat-progress-bar>
 
   <!-- Table -->
-  <table
-    mat-table
-    [dataSource]="conditions"
-    [ngClass]="{ 'no-data': !conditions?.length }"
-    class="conditions-table"
-  >
+  <table mat-table [dataSource]="conditions" [ngClass]="{ 'no-data': !conditions?.length }" class="conditions-table">
     <!-- Condition Column -->
     <ng-container matColumnDef="condition">
       <th mat-header-cell *matHeaderCellDef class="condition-column ft-14-600">
@@ -24,19 +19,13 @@
       <th mat-header-cell *matHeaderCellDef class="weight-column ft-14-600">
         {{ CONDITION_TRANSLATION_KEYS.WEIGHT | translate }}
       </th>
-      <td mat-cell *matCellDef="let condition" class="weight-column ft-14-400">
-        {{ condition.assignmentWeight }}%
-      </td>
+      <td mat-cell *matCellDef="let condition" class="weight-column ft-14-400">{{ condition.assignmentWeight }}%</td>
     </ng-container>
 
     <!-- Weight Edit Column -->
     <ng-container matColumnDef="weightEdit">
       <th mat-header-cell *matHeaderCellDef class="weight-edit-column ft-14-600 dense-2">
-        <button
-          mat-icon-button
-          class="weight-edit-button"
-          [disabled]="actionsDisabled || conditions.length < 2"
-          (click)="onEditWeightsClick()">
+        <button mat-icon-button class="weight-edit-button" (click)="onEditWeightsClick()">
           <mat-icon>edit</mat-icon>
         </button>
       </th>
@@ -66,7 +55,8 @@
             mat-icon-button
             class="action-button"
             [disabled]="actionsDisabled"
-            (click)="onEditButtonClick(condition)">
+            (click)="onEditButtonClick(condition)"
+          >
             <mat-icon>edit</mat-icon>
           </button>
         </div>
@@ -75,7 +65,8 @@
             mat-icon-button
             class="action-button"
             [disabled]="actionsDisabled"
-            (click)="onDeleteButtonClick(condition)">
+            (click)="onDeleteButtonClick(condition)"
+          >
             <mat-icon>delete_outline</mat-icon>
           </button>
         </div>
@@ -84,7 +75,7 @@
 
     <!-- Header and Row Definitions -->
     <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
-    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
 
     <!-- No Data Row -->
     <tr *matNoDataRow>

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-overview-details-section-card/feature-flag-overview-details-section-card.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-overview-details-section-card/feature-flag-overview-details-section-card.component.html
@@ -5,9 +5,10 @@
     [title]="flag.name"
     [createdAt]="flag.createdAt"
     [updatedAt]="flag.updatedAt"
-    [versionNumber]="flag.versionNumber"
     [chipClass]="flag.status"
-    [showWarning]="shouldShowWarning$ | async"
+    [warningMessage]="
+      (shouldShowWarning$ | async) ? ('feature-flags.global-status-warning-tooltip.text' | translate) : ''
+    "
   ></app-common-section-card-title-header>
 
   <!-- header-right -->

--- a/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-content/segment-overview-details-section-card/segment-overview-details-section-card.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-details-page/segment-details-page-content/segment-overview-details-section-card/segment-overview-details-section-card.component.html
@@ -5,7 +5,6 @@
     [title]="segment.name"
     [createdAt]="segment.createdAt"
     [updatedAt]="segment.updatedAt"
-    [versionNumber]="segment.versionNumber"
     [chipClass]="segment.status.toLowerCase()"
   ></app-common-section-card-title-header>
   <!-- TODO: Update the SEGMENT_STATUS enum to lowercase and remove toLowerCase() once the legacy Segments code is removed -->

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-title-header/common-section-card-title-header.component.html
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-title-header/common-section-card-title-header.component.html
@@ -1,13 +1,17 @@
 <div class="title-header">
   <h5 class="title ft-18-700">
     {{ title | translate }} &nbsp;<span *ngIf="tableRowCount > 0"> ({{ tableRowCount }}) </span>
-    <ng-container *ngIf="chipClass">
-      <app-common-status-indicator-chip
-        [chipClass]="chipClass"
-        [showWarning]="showWarning"
-        class="status-chip"
-      ></app-common-status-indicator-chip>
-    </ng-container>
+    <app-common-status-indicator-chip
+      *ngIf="chipClass"
+      [chipClass]="chipClass"
+      [warningMessage]="warningMessage | translate"
+      class="status-chip"
+    ></app-common-status-indicator-chip>
+    <app-common-warning-icon
+      *ngIf="!chipClass && warningMessage"
+      [warningMessage]="warningMessage | translate"
+      class="warning-icon"
+    ></app-common-warning-icon>
   </h5>
   <p class="subtitle">
     <ng-container *ngIf="subtitle">
@@ -17,10 +21,14 @@
     </ng-container>
     <ng-container *ngIf="createdAt && updatedAt">
       <span class="ft-14-400">
-        {{ ('feature-flags.details-created-on.text' | translate) + (createdAt | date : 'MMM d, y') + ' | ' }}
+        {{ ('common-section-card-title-header.created-on.text' | translate) + (createdAt | date : 'MMM d, y') + ' | ' }}
       </span>
       <span class="ft-14-400">
-        {{ ('feature-flags.details-updated-at.text' | translate) + (updatedAt | date : 'MMM d, y, h:mm a') + '.' }}
+        {{
+          ('common-section-card-title-header.details-updated-at.text' | translate) +
+            (updatedAt | date : 'MMM d, y, h:mm a') +
+            '.'
+        }}
       </span>
     </ng-container>
   </p>

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-title-header/common-section-card-title-header.component.scss
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-title-header/common-section-card-title-header.component.scss
@@ -12,6 +12,11 @@
     .status-chip {
       margin-left: 8px;
     }
+
+    .warning-icon {
+      margin-top: 6px;
+      margin-left: 8px;
+    }
   }
 
   .subtitle {

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-title-header/common-section-card-title-header.component.ts
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-title-header/common-section-card-title-header.component.ts
@@ -1,27 +1,74 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { CommonStatusIndicatorChipComponent } from '../common-status-indicator-chip/common-status-indicator-chip.component';
 import { STATUS_INDICATOR_CHIP_TYPE } from 'upgrade_types';
 import { SharedModule } from '../../../shared/shared.module';
+import { CommonWarningIconComponent } from '../common-warning-icon/common-warning-icon.component';
 
 /**
- * The `app-common-section-card-search-header` component provides a common header with title and subtitle for a section card.
+ * The `app-common-section-card-title-header` component provides a common header with title and subtitle for a section card.
  * It includes the following properties:
  * - `title`: The title of the section card.
- * - `tableRowCount`: The count of rows in the table. If it's falsy, nothing will be displayed. If it's greater than 1, the count will be displayed in parentheses.
+ * - `tableRowCount`: The count of rows in the table. If it's falsy, nothing will be displayed. If it's 1 or more, the count will be displayed in parentheses.
  * - `subtitle`: The subtitle of the section card.
- * - `chipClass`: The class for the status chip. For example, `STATUS_INDICATOR_CHIP_TYPE.ENROLLMENT_COMPLETE`.
+ * - `createdAt`: The creationAt timestamp of any db entity
+ * - `updatedAt`: The updatedAt timestamp of any db entity
+ * - `chipClass`: An optional class for the status chip. For example, `STATUS_INDICATOR_CHIP_TYPE.ENROLLMENT_COMPLETE`.
+ * - `warningMessage`: An optional warning message to be displayed with a warning icon.
  *
- * Example usage:
+ * Example usage to show basic details:
  *
  * ```html
  * <app-common-section-card-title-header
  *   [title]="title"
  *   [tableRowCount]="tableRowCount"
  *   [subtitle]="subtitle"
+ *   [createdAt]="createdAt"
+ *   [updatedAt]="updatedAt"
+ * ></app-common-section-card-title-header>
+ * ```
+ *
+ * Example usage to show a warning icon next to the title with message in tooltip:
+ * Use "warningMessage"
+ *
+ * ```html
+ * <app-common-section-card-title-header
+ *   [title]="title"
+ *   [tableRowCount]="tableRowCount"
+ *   [subtitle]="subtitle"
+ *   [createdAt]="createdAt"
+ *   [updatedAt]="updatedAt"
+ *   [warningMessage]="warningMessage"
+ * ></app-common-section-card-title-header>
+ * ```
+ *
+ *  Example usage to show a status chip next to the title
+ *  Use "chipClass"
+ *
+ * ```html
+ * <app-common-section-card-title-header
+ *   [title]="title"
+ *   [tableRowCount]="tableRowCount"
+ *   [subtitle]="subtitle"
+ *   [createdAt]="createdAt"
+ *   [updatedAt]="updatedAt"
  *   [chipClass]="STATUS_INDICATOR_CHIP_TYPE.ENROLLMENT_COMPLETE"
- *   [showWarning]="false"
+ * ></app-common-section-card-title-header>
+ * ```
+ *
+ *  Example usage to show a status with warning icon
+ *  Use chipClass + warningMessage
+ *
+ * ```html
+ * <app-common-section-card-title-header
+ *   [title]="title"
+ *   [tableRowCount]="tableRowCount"
+ *   [subtitle]="subtitle"
+ *   [createdAt]="createdAt"
+ *   [updatedAt]="updatedAt"
+ *   [chipClass]="STATUS_INDICATOR_CHIP_TYPE.ENROLLMENT_COMPLETE"
+ *   [warningMessage]="warningMessage"
  * ></app-common-section-card-title-header>
  * ```
  */
@@ -30,7 +77,13 @@ import { SharedModule } from '../../../shared/shared.module';
   selector: 'app-common-section-card-title-header',
   templateUrl: './common-section-card-title-header.component.html',
   styleUrls: ['./common-section-card-title-header.component.scss'],
-  imports: [CommonModule, TranslateModule, CommonStatusIndicatorChipComponent, SharedModule],
+  imports: [
+    CommonModule,
+    TranslateModule,
+    CommonStatusIndicatorChipComponent,
+    SharedModule,
+    CommonWarningIconComponent,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CommonSectionCardTitleHeaderComponent {
@@ -39,7 +92,6 @@ export class CommonSectionCardTitleHeaderComponent {
   @Input() subtitle?: string;
   @Input() createdAt?: string;
   @Input() updatedAt?: string;
-  @Input() versionNumber?: number;
+  @Input() warningMessage?: string;
   @Input() chipClass?: STATUS_INDICATOR_CHIP_TYPE;
-  @Input() showWarning?: boolean;
 }

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-status-indicator-chip/common-status-indicator-chip.component.html
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-status-indicator-chip/common-status-indicator-chip.component.html
@@ -1,13 +1,12 @@
-<div
-  [matTooltip]="'feature-flags.global-status-warning-tooltip.text' | translate"
-  [matTooltipDisabled]="!showWarning"
-  matTooltipPosition="above"
-  class="chip-container dense-2"
->
+<div class="chip-container dense-2">
   <mat-chip class="status-indicator" [ngClass]="chipClass">
     <span class="chip-label">
       {{ chipText }}
     </span>
   </mat-chip>
-  <mat-icon *ngIf="showWarning" class="warning-icon">warning_amber</mat-icon>
+  <app-common-warning-icon
+    *ngIf="warningMessage"
+    [warningMessage]="warningMessage"
+    class="warning-icon"
+  ></app-common-warning-icon>
 </div>

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-status-indicator-chip/common-status-indicator-chip.component.scss
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-status-indicator-chip/common-status-indicator-chip.component.scss
@@ -89,10 +89,7 @@
   }
 
   .warning-icon {
+    margin-top: 6px;
     margin-left: 6px;
-    font-size: 20px;
-    width: 20px;
-    height: 20px;
-    color: var(--status-disabled);
   }
 }

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-status-indicator-chip/common-status-indicator-chip.component.ts
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-status-indicator-chip/common-status-indicator-chip.component.ts
@@ -1,20 +1,29 @@
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Input, SimpleChanges } from '@angular/core';
 import { MatChipsModule } from '@angular/material/chips';
-import { MatIcon } from '@angular/material/icon';
-import { MatTooltipModule } from '@angular/material/tooltip';
 import { TranslateModule } from '@ngx-translate/core';
 import { STATUS_INDICATOR_CHIP_TYPE } from 'upgrade_types';
+import { CommonWarningIconComponent } from '../common-warning-icon/common-warning-icon.component';
 
 /**
  * The `app-common-status-indicator-chip` component provides a common component for status indicator inside mat-chip.
- * It contains a chipText which will be used to choose chip's border and font color as well.
+ *
+ *
  * Example usage:
  *
- * ```
+ * ```html
  * <app-common-status-indicator-chip
  *  [chipClass]="STATUS_INDICATOR_CHIP_TYPE.ENROLLMENT_COMPLETE"
- *  [showWarning]="false"
+ * ></app-common-status-indicator-chip>
+ * ```
+ *
+ * Providing warning message will make a warning icon next to the chip.
+ * The message will be shown as a tooltip when hovered over the icon.
+ *
+ * ```html
+ * <app-common-status-indicator-chip
+ *  [chipClass]="STATUS_INDICATOR_CHIP_TYPE.ENROLLMENT_COMPLETE"
+ *  [warningMessage]="'feature-flags.global-status-warning-tooltip.text' | translate"
  * ></app-common-status-indicator-chip>
  * ```
  */
@@ -23,12 +32,12 @@ import { STATUS_INDICATOR_CHIP_TYPE } from 'upgrade_types';
   selector: 'app-common-status-indicator-chip',
   templateUrl: './common-status-indicator-chip.component.html',
   styleUrls: ['./common-status-indicator-chip.component.scss'],
-  imports: [CommonModule, TranslateModule, MatChipsModule, MatIcon, MatTooltipModule],
+  imports: [CommonModule, TranslateModule, MatChipsModule, CommonWarningIconComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CommonStatusIndicatorChipComponent {
   @Input() chipClass!: STATUS_INDICATOR_CHIP_TYPE;
-  @Input() showWarning!: boolean;
+  @Input() warningMessage?: string;
   chipText = '';
 
   ngOnInit() {

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-warning-icon/common-warning-icon.component.html
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-warning-icon/common-warning-icon.component.html
@@ -1,0 +1,8 @@
+<mat-icon
+  class="warning-icon"
+  [matTooltip]="warningMessage"
+  [matTooltipDisabled]="!warningMessage"
+  matTooltipPosition="above"
+>
+  warning_amber
+</mat-icon>

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-warning-icon/common-warning-icon.component.scss
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-warning-icon/common-warning-icon.component.scss
@@ -1,0 +1,6 @@
+.warning-icon {
+  color: var(--status-disabled);
+  font-size: 20px;
+  width: 20px;
+  height: 20px;
+}

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-warning-icon/common-warning-icon.component.ts
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-warning-icon/common-warning-icon.component.ts
@@ -1,0 +1,28 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { MatIcon } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+
+/**
+ * The `app-common-warning-icon` component provides a common warning icon with a tooltip if provided with a message.
+ * It displays a warning_amber Material icon with a tooltip when hovered.
+ *
+ * Example usage:
+ *
+ * ```html
+ * <app-common-warning-icon
+ *   [warningMessage]="'This is a warning message'"
+ * ></app-common-warning-icon>
+ * ```
+ */
+
+@Component({
+  selector: 'app-common-warning-icon',
+  templateUrl: './common-warning-icon.component.html',
+  styleUrls: ['./common-warning-icon.component.scss'],
+  imports: [CommonModule, MatIcon, MatTooltipModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CommonWarningIconComponent {
+  @Input() warningMessage?: string = '';
+}

--- a/frontend/projects/upgrade/src/app/shared/services/common-dialog.service.ts
+++ b/frontend/projects/upgrade/src/app/shared/services/common-dialog.service.ts
@@ -43,8 +43,7 @@ import {
   ExperimentDecisionPoint,
   ExperimentCondition,
   ExperimentConditionPayload,
-  Experiment,
-  ExperimentVM,
+  WeightingMethod,
 } from '../../core/experiments/store/experiments.model';
 import {
   ConditionWeightUpdate,
@@ -503,7 +502,10 @@ export class DialogService {
     return this.openUpsertPrivateSegmentListModal(commonModalConfig);
   }
 
-  openEditConditionWeightsModal(conditions: ExperimentCondition[]): Observable<ConditionWeightUpdate[]> {
+  openEditConditionWeightsModal(
+    conditions: ExperimentCondition[],
+    weightingMethod: WeightingMethod
+  ): Observable<ConditionWeightUpdate[]> {
     const dialogRef = this.dialog.open(EditConditionWeightsModalComponent, {
       panelClass: ['experiment-modal', 'modal-shadow'],
       hasBackdrop: true,
@@ -522,6 +524,7 @@ export class DialogService {
             conditionCode: condition.conditionCode,
             assignmentWeight: condition.assignmentWeight || 0,
           })),
+          weightingMethod,
         },
       },
     });

--- a/frontend/projects/upgrade/src/assets/i18n/en.json
+++ b/frontend/projects/upgrade/src/assets/i18n/en.json
@@ -471,8 +471,6 @@
   "experiments.edit-condition-weights-modal.equal-assignment-weights.description.text": "Equally distribute weight percentages across all conditions.",
   "experiments.edit-condition-weights-modal.custom-percentages.label.text": "Custom Percentages",
   "experiments.edit-condition-weights-modal.custom-percentages.description.text": "Define a custom weight percentage for each condition.",
-  "feature-flags.details-created-on.text": "Created on: ",
-  "feature-flags.details-updated-at.text": "Updated at: ",
   "feature-flags.global-name.text": "Name",
   "feature-flags.global-status.text": "Status",
   "feature-flags.global-status-warning-tooltip.text": "No include lists enabled",
@@ -713,5 +711,7 @@
   "monitor.metric-most-recent.text": "Most recent",
   "monitor.metric-repeated-measure.text": "Repeated measure treatment",
   "monitor.monitored-metrics.text": "Monitored Metrics",
-  "common-import-modal.incompatible-import-warning.text": "*Incompatible files will not be imported"
+  "common-import-modal.incompatible-import-warning.text": "*Incompatible files will not be imported",
+  "common-section-card-title-header.created-on.text": "Created on: ",
+  "common-section-card-title-header.details-updated-at.text": "Updated at: "
 }


### PR DESCRIPTION
- Makes equal weight the default when adding in new experiment
- Creates a common warning icon with tooltip
- Adds standalone Warning Icon capability to common section card title header component
- Refactors common chip status to use the common warning icon within it
- Adds functionality to pop that warning up when custom weights are indicated weights don't equal 100 (within 0.1)
- Refactors to build on the condition-helper service to share common weighting utilities between components and selectors
- Utilized Claude to create a bunch of unit tests for the condition-helper service