### PR TITLE
NO-TICKET tech/upgrade_client_lib: Add custom exports to support default entrypoint

### DIFF
--- a/clientlibs/js/package-lock.json
+++ b/clientlibs/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "upgrade_client_lib",
-  "version": "6.1.2",
+  "version": "6.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "upgrade_client_lib",
-      "version": "6.1.2",
+      "version": "6.2.1",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.4.0",

--- a/clientlibs/js/package.json
+++ b/clientlibs/js/package.json
@@ -1,13 +1,39 @@
 {
   "name": "upgrade_client_lib",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "Client library to communicate with the Upgrade server",
   "files": [
     "dist/*"
   ],
+  "exports": {
+    ".": {
+      "browser": "./dist/browser/index.js",
+      "browser-lite": "./dist/browser-lite/index.js",
+      "node": "./dist/node/index.js",
+      "node-lite": "./dist/node-lite/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./dist/browser": {
+      "default": "./dist/browser/index.js",
+      "types": "./dist/browser/index.d.ts"
+    },
+    "./dist/browser-lite": {
+      "default": "./dist/browser-lite/index.js",
+      "types": "./dist/browser-lite/index.d.ts"
+    },
+    "./dist/node": {
+      "default": "./dist/node/index.js",
+      "types": "./dist/node/index.d.ts"
+    },
+    "./dist/node-lite": {
+      "default": "./dist/node-lite/index.js",
+      "types": "./dist/node-lite/index.d.ts"
+    }
+  },
   "scripts": {
     "build:bundler": "webpack",
     "build:types": "concurrently \"npm:build:types-*\"",
+    "build:types-default": "./node_modules/.bin/dts-bundle-generator -o dist/index.d.ts src/index.ts",
     "build:types-browser": "./node_modules/.bin/dts-bundle-generator -o dist/browser/index.d.ts src/index.ts",
     "build:types-node": "./node_modules/.bin/dts-bundle-generator -o dist/node/index.d.ts src/index.ts",
     "build:types-browser-lite": "./node_modules/.bin/dts-bundle-generator -o dist/browser-lite/index.d.ts src/index.ts",


### PR DESCRIPTION
- Added `./dist/<platform>`-like entrypoints for backward compatibility
- Also added platform-based paths to the default entrypoint
