### PR TITLE
Prevent crash when req.logger is undefined in error handler

### DIFF
--- a/backend/packages/Upgrade/src/api/middlewares/ErrorHandlerMiddleware.ts
+++ b/backend/packages/Upgrade/src/api/middlewares/ErrorHandlerMiddleware.ts
@@ -5,7 +5,7 @@ import { env } from '../../env';
 import { ErrorService } from '../services/ErrorService';
 import { ExperimentError } from '../models/ExperimentError';
 import { SERVER_ERROR } from 'upgrade_types';
-import { UpgradeLogger } from 'src/lib/logger/UpgradeLogger';
+import { UpgradeLogger } from '../../lib/logger/UpgradeLogger';
 
 interface ErrorWithRequest extends ExperimentError {
   request?: {

--- a/backend/packages/Upgrade/src/api/middlewares/ErrorHandlerMiddleware.ts
+++ b/backend/packages/Upgrade/src/api/middlewares/ErrorHandlerMiddleware.ts
@@ -5,6 +5,7 @@ import { env } from '../../env';
 import { ErrorService } from '../services/ErrorService';
 import { ExperimentError } from '../models/ExperimentError';
 import { SERVER_ERROR } from 'upgrade_types';
+import { UpgradeLogger } from 'src/lib/logger/UpgradeLogger';
 
 interface ErrorWithRequest extends ExperimentError {
   request?: {
@@ -120,6 +121,13 @@ export class ErrorHandlerMiddleware implements ExpressErrorMiddlewareInterface {
 
     if (req.logger) {
       req.logger.error(experimentError);
+    } else {
+      const fallbackLogger = new UpgradeLogger();
+      fallbackLogger.error({
+        ...experimentError,
+        warning:
+          'req.logger was undefined so custom logger used - error occurred before LogMiddleware loaded, likely a CORS issue',
+      });
     }
 
     // #1040

--- a/backend/packages/Upgrade/src/api/middlewares/ErrorHandlerMiddleware.ts
+++ b/backend/packages/Upgrade/src/api/middlewares/ErrorHandlerMiddleware.ts
@@ -18,12 +18,7 @@ export class ErrorHandlerMiddleware implements ExpressErrorMiddlewareInterface {
 
   constructor(public errorService: ErrorService) {}
 
-  public async error(
-    error: any,
-    req: express.Request,
-    res: express.Response,
-    next: express.NextFunction
-  ): Promise<void> {
+  public error(error: any, req: express.Request, res: express.Response, next: express.NextFunction): void {
     // It seems like some decorators handle setting the response (i.e. class-validators)
     let message: string;
     let type: SERVER_ERROR;
@@ -123,7 +118,9 @@ export class ErrorHandlerMiddleware implements ExpressErrorMiddlewareInterface {
     // #1042 send request in logging output, don't need to put into database
     experimentError.request = req.body;
 
-    req.logger.error(experimentError);
+    if (req.logger) {
+      req.logger.error(experimentError);
+    }
 
     // #1040
     // experimentError.type ? await this.errorService.create(experimentError, req.logger) : await Promise.resolve(error);

--- a/backend/packages/Upgrade/test/unit/middlewares/ErrorHandlerMiddleware.test.ts
+++ b/backend/packages/Upgrade/test/unit/middlewares/ErrorHandlerMiddleware.test.ts
@@ -36,174 +36,197 @@ describe('ErrorHandler Middleware tests', () => {
     };
   });
 
-  test('Incorrect param error test', async () => {
+  test('Incorrect param error test', () => {
     const error = {
       type: SERVER_ERROR.INCORRECT_PARAM_FORMAT,
       message: 'Incorrect Parameters',
       httpCode: 500,
     };
 
-    await errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
+    errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
     expect(mockResponse.statusCode).toBe(error.httpCode);
     expect(mockResponse.body).toBe(error.message);
   });
 
-  test('Missing param error test', async () => {
+  test('Missing param error test', () => {
     const error = {
       type: SERVER_ERROR.MISSING_PARAMS,
       message: 'Missing Parameters',
       httpCode: 500,
     };
 
-    await errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
+    errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
     expect(mockResponse.statusCode).toBe(error.httpCode);
     expect(mockResponse.body).toBe(error.message);
   });
 
-  test('Query failed error test', async () => {
+  test('Query failed error test', () => {
     const error = {
       type: SERVER_ERROR.QUERY_FAILED,
       message: 'Query failed',
       httpCode: 500,
     };
 
-    await errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
+    errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
     expect(mockResponse.statusCode).toBe(error.httpCode);
     expect(mockResponse.body).toBe(error.message);
   });
 
-  test('Experiment user not defined error test', async () => {
+  test('Experiment user not defined error test', () => {
     const error = {
       type: SERVER_ERROR.EXPERIMENT_USER_NOT_DEFINED,
       message: 'Experiment user not defined',
       httpCode: 404,
     };
 
-    await errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
+    errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
     expect(mockResponse.statusCode).toBe(error.httpCode);
     expect(mockResponse.body).toBe(error.message);
   });
 
-  test('Experiment user group not defined error test', async () => {
+  test('Experiment user group not defined error test', () => {
     const error = {
       type: SERVER_ERROR.EXPERIMENT_USER_GROUP_NOT_DEFINED,
       message: 'Experiment user group not defined',
       httpCode: 404,
     };
 
-    await errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
+    errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
     expect(mockResponse.statusCode).toBe(error.httpCode);
     expect(mockResponse.body).toBe(error.message);
   });
 
-  test('Assignment error test', async () => {
+  test('Assignment error test', () => {
     const error = {
       type: SERVER_ERROR.ASSIGNMENT_ERROR,
       message: 'Assignment error',
       httpCode: 500,
     };
 
-    await errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
+    errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
     expect(mockResponse.statusCode).toBe(error.httpCode);
     expect(mockResponse.body).toBe(error.message);
   });
 
-  test('Working group not subset of group error test', async () => {
+  test('Working group not subset of group error test', () => {
     const error = {
       type: SERVER_ERROR.WORKING_GROUP_NOT_SUBSET_OF_GROUP,
       message: 'Working group not subset of group error',
       httpCode: 500,
     };
 
-    await errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
+    errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
     expect(mockResponse.statusCode).toBe(error.httpCode);
     expect(mockResponse.body).toBe(error.message);
   });
 
-  test('Invalid token error test', async () => {
+  test('Invalid token error test', () => {
     const error = {
       type: SERVER_ERROR.INVALID_TOKEN,
       message: 'Invalid token error',
       httpCode: 500,
     };
 
-    await errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
+    errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
     expect(mockResponse.statusCode).toBe(error.httpCode);
     expect(mockResponse.body).toBe(error.message);
   });
 
-  test('Token not present error test', async () => {
+  test('Token not present error test', () => {
     const error = {
       type: SERVER_ERROR.TOKEN_NOT_PRESENT,
       message: 'Token not present error',
       httpCode: 500,
     };
 
-    await errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
+    errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
     expect(mockResponse.statusCode).toBe(error.httpCode);
     expect(mockResponse.body).toBe(error.message);
   });
 
-  test('Condition not found error test', async () => {
+  test('Condition not found error test', () => {
     const error = {
       type: SERVER_ERROR.CONDITION_NOT_FOUND,
       message: 'Condition not found error',
       httpCode: 500,
     };
 
-    await errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
+    errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
     expect(mockResponse.statusCode).toBe(error.httpCode);
     expect(mockResponse.body).toBe(error.message);
   });
 
-  test('Email send error test', async () => {
+  test('Email send error test', () => {
     const error = {
       type: SERVER_ERROR.EMAIL_SEND_ERROR,
       message: 'Email send error',
       httpCode: 500,
     };
 
-    await errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
+    errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
     expect(mockResponse.statusCode).toBe(error.httpCode);
     expect(mockResponse.body).toBe(error.message);
   });
 
-  test('Incorrect param format error test', async () => {
+  test('Incorrect param format error test', () => {
     const error = {
       message: 'Incorrect param format error',
       httpCode: 400,
     };
-    await errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
+    errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
     expect(mockResponse.statusCode).toBe(error.httpCode);
     expect(mockResponse.body).toBe(error.message);
   });
 
-  test('User not found error test', async () => {
+  test('User not found error test', () => {
     const error = {
       message: 'User not found errors',
       httpCode: 401,
     };
 
-    await errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
+    errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
     expect(mockResponse.statusCode).toBe(error.httpCode);
     expect(mockResponse.body).toBe(error.message);
   });
 
-  test('Query failed error test', async () => {
+  test('Query failed error test', () => {
     const error = {
       message: 'Query failed error',
       httpCode: 404,
     };
 
-    await errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
+    errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
     expect(mockResponse.statusCode).toBe(error.httpCode);
     expect(mockResponse.body).toBe(error.message);
   });
 
-  test('Default error test', async () => {
+  test('Default error test', () => {
     const error = {};
 
-    await errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
+    errorhandler.error(error, mockRequest, mockResponse as Response, nextFunction);
     expect(mockResponse.statusCode).toBe(500);
+  });
+
+  test('Error handler should not crash when logger is undefined', () => {
+    const mockRequestWithoutLogger: any = {
+      header: jest.fn(),
+      body: { test: 'data' },
+      originalUrl: '/test/endpoint',
+    };
+
+    const error = {
+      type: SERVER_ERROR.QUERY_FAILED,
+      message: 'Query failed',
+      httpCode: 500,
+      name: 'TestError',
+    };
+
+    // This should not throw an error even though logger is undefined
+    expect(() => {
+      errorhandler.error(error, mockRequestWithoutLogger, mockResponse as Response, nextFunction);
+    }).not.toThrow();
+
+    expect(mockResponse.statusCode).toBe(error.httpCode);
+    expect(mockResponse.body).toBe(error.message);
   });
 });


### PR DESCRIPTION
## Problem
The UpGrade instance used by the demo app was crashing with the following error:

```
uncaughtException: Cannot read properties of undefined (reading 'error')
at ErrorHandlerMiddleware.ts:126:16
```

This occurred when the `ErrorHandlerMiddleware` tried to call `req.logger.error()` without checking if `req.logger` exists. In certain scenarios (e.g., errors occurring before the `LogMiddleware` runs or during early request processing), `req.logger` may be undefined.

## Solution
1. **Added null check before accessing req.logger**: Prevents the crash by checking if `req.logger` exists before calling `req.logger.error(experimentError)`
2. **Fixed TypeScript warning**: Removed `async` keyword and changed return type from `Promise<void>` to `void` to properly implement the `ExpressErrorMiddlewareInterface` contract (no `await` calls exist in the method)

## Changes
- Added defensive null check: `if (req.logger) { req.logger.error(experimentError); }`
- Changed method signature from `async error(...): Promise<void>` to `error(...): void`

