### PR TITLE
Bugfix/remove reward metric key

### DIFF
--- a/backend/packages/Upgrade/src/api/DTO/ExperimentDTO.ts
+++ b/backend/packages/Upgrade/src/api/DTO/ExperimentDTO.ts
@@ -524,10 +524,6 @@ export class ExperimentDTO extends BaseExperimentWithoutPayload {
     keepDiscriminatorProperty: true,
   })
   public moocletPolicyParameters?: MoocletPolicyParametersDTO;
-
-  @ValidateIf(isMoocletAssignmentAlgorithm)
-  @IsDefined()
-  public rewardMetricKey?: string;
 }
 
 export class OldExperimentDTO extends BaseExperimentWithoutPayload {

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v6.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v6.ts
@@ -865,22 +865,22 @@ export class ExperimentClientController {
    *                 description: The binary reward value indicating success or failure of the assigned condition
    *               experimentId:
    *                 type: string
-   *                 example: exp_adaptive_123
+   *                 example: uuid-of-adaptive-experiment
    *                 description: The ID of the adaptive experiment. Required if context and decisionPoint are not provided.
    *               context:
    *                 type: string
-   *                 example: learning-module
+   *                 example: upgrade-internal
    *                 description: The context for the decision point. Required with decisionPoint if experimentId is not provided.
    *               decisionPoint:
    *                 type: object
    *                 properties:
    *                   site:
    *                     type: string
-   *                     example: math-course
+   *                     example: fakesite
    *                     description: The site of the decision point
    *                   target:
    *                     type: string
-   *                     example: problem-set-1
+   *                     example: faketarget
    *                     description: The target of the decision point
    *                 description: The decision point information. Required with context if experimentId is not provided.
    *           description: Reward data for the adaptive experiment
@@ -890,16 +890,16 @@ export class ExperimentClientController {
    *               description: Send reward using the experiment ID directly
    *               value:
    *                 rewardValue: SUCCESS
-   *                 experimentId: exp_adaptive_123
+   *                 experimentId: uuid-of-adaptive-experiment
    *             decision_point_lookup:
    *               summary: Decision Point Lookup - Using context and decisionPoint
    *               description: Send reward by identifying the experiment through decision point
    *               value:
    *                 rewardValue: FAILURE
-   *                 context: learning-module
+   *                 context: upgrade-internal
    *                 decisionPoint:
-   *                   site: math-course
-   *                   target: problem-set-1
+   *                   site: fakesite
+   *                   target: faketarget
    *       tags:
    *         - Client Side SDK
    *       produces:
@@ -939,10 +939,8 @@ export class ExperimentClientController {
    *            description: BadRequestError - Invalid parameters (e.g., missing required fields, invalid rewardValue)
    *          '401':
    *            description: AuthorizationRequiredError
-   *          '404':
-   *            description: Experiment User not defined or experiment not found
    *          '409':
-   *            description: Conflict - Data conflict (e.g., user not enrolled in experiment, experiment not in correct state)
+   *            description: Conflict - Data conflict (e.g., site or target not found, enrollment data not found, etc)
    *          '500':
    *            description: Internal Server Error
    */

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v6.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentClientController.v6.ts
@@ -8,6 +8,7 @@ import {
   Delete,
   Patch,
   Authorized,
+  BadRequestError,
 } from 'routing-controllers';
 import { ExperimentService } from '../services/ExperimentService';
 import { ExperimentAssignmentService } from '../services/ExperimentAssignmentService';
@@ -27,6 +28,9 @@ import { MarkExperimentValidatorv6 } from './validators/MarkExperimentValidator.
 import { Log } from '../models/Log';
 import { ExperimentUserValidatorv6 } from './validators/ExperimentUserValidator';
 import { UserCheckMiddleware } from '../middlewares/UserCheckMiddleware';
+import { RewardValidator } from './validators/RewardValidator';
+import { IRewardResponse, MoocletRewardsService } from '../services/MoocletRewardsService';
+import { env } from '../../env';
 
 interface IMonitoredDecisionPoint {
   id: string;
@@ -93,7 +97,8 @@ export class ExperimentClientController {
     public experimentAssignmentService: ExperimentAssignmentService,
     public experimentUserService: ExperimentUserService,
     public featureFlagService: FeatureFlagService,
-    public metricService: MetricService
+    public metricService: MetricService,
+    public moocletRewardsService: MoocletRewardsService
   ) {}
 
   /**
@@ -815,6 +820,146 @@ export class ExperimentClientController {
   ): Promise<IUserAliases> {
     const experimentUserDoc = request.userDoc;
     return this.experimentUserService.setAliasesForUser(experimentUserDoc, user.aliases, request.logger);
+  }
+
+  /**
+   * @swagger
+   * /v6/reward:
+   *    post:
+   *       description: |
+   *         Send a reward signal for an adaptive experiment (Mooclet).
+   *
+   *         This endpoint allows sending binary reward feedback (SUCCESS or FAILURE) for adaptive experiments.
+   *         The reward is used by the adaptive algorithm to update its learning model and improve future assignments.
+   *
+   *         **Lookup Methods:**
+   *
+   *         The endpoint supports two methods to identify the experiment:
+   *
+   *         1. **Direct Lookup** - Provide the `experimentId` directly
+   *         2. **Decision Point Lookup** - Provide `context` and `decisionPoint` (site and target) to look up the experiment
+   *
+   *         At least one of these methods must be provided.
+   *       consumes:
+   *         - application/json
+   *       parameters:
+   *         - in: header
+   *           name: User-Id
+   *           required: true
+   *           schema:
+   *             type: string
+   *           example: user123
+   *           description: The unique identifier for the user
+   *         - in: body
+   *           name: rewardData
+   *           required: true
+   *           schema:
+   *             type: object
+   *             required:
+   *               - rewardValue
+   *             properties:
+   *               rewardValue:
+   *                 type: string
+   *                 enum: [SUCCESS, FAILURE]
+   *                 example: SUCCESS
+   *                 description: The binary reward value indicating success or failure of the assigned condition
+   *               experimentId:
+   *                 type: string
+   *                 example: exp_adaptive_123
+   *                 description: The ID of the adaptive experiment. Required if context and decisionPoint are not provided.
+   *               context:
+   *                 type: string
+   *                 example: learning-module
+   *                 description: The context for the decision point. Required with decisionPoint if experimentId is not provided.
+   *               decisionPoint:
+   *                 type: object
+   *                 properties:
+   *                   site:
+   *                     type: string
+   *                     example: math-course
+   *                     description: The site of the decision point
+   *                   target:
+   *                     type: string
+   *                     example: problem-set-1
+   *                     description: The target of the decision point
+   *                 description: The decision point information. Required with context if experimentId is not provided.
+   *           description: Reward data for the adaptive experiment
+   *           examples:
+   *             direct_lookup:
+   *               summary: Direct Lookup - Using experimentId
+   *               description: Send reward using the experiment ID directly
+   *               value:
+   *                 rewardValue: SUCCESS
+   *                 experimentId: exp_adaptive_123
+   *             decision_point_lookup:
+   *               summary: Decision Point Lookup - Using context and decisionPoint
+   *               description: Send reward by identifying the experiment through decision point
+   *               value:
+   *                 rewardValue: FAILURE
+   *                 context: learning-module
+   *                 decisionPoint:
+   *                   site: math-course
+   *                   target: problem-set-1
+   *       tags:
+   *         - Client Side SDK
+   *       produces:
+   *         - application/json
+   *       responses:
+   *          '200':
+   *            description: Reward successfully sent to the adaptive experiment
+   *            schema:
+   *              type: object
+   *              properties:
+   *                message:
+   *                  type: string
+   *                  example: Reward sent successfully
+   *                  description: Success message
+   *                request:
+   *                  type: object
+   *                  description: Echo of the original request data
+   *                  properties:
+   *                    rewardValue:
+   *                      type: string
+   *                      enum: [SUCCESS, FAILURE]
+   *                    experimentId:
+   *                      type: string
+   *                    context:
+   *                      type: string
+   *                    decisionPoint:
+   *                      type: object
+   *                      properties:
+   *                        site:
+   *                          type: string
+   *                        target:
+   *                          type: string
+   *                reward:
+   *                  type: object
+   *                  description: The reward data that was sent to the Mooclet API
+   *          '400':
+   *            description: BadRequestError - Invalid parameters (e.g., missing required fields, invalid rewardValue)
+   *          '401':
+   *            description: AuthorizationRequiredError
+   *          '404':
+   *            description: Experiment User not defined or experiment not found
+   *          '409':
+   *            description: Conflict - Data conflict (e.g., user not enrolled in experiment, experiment not in correct state)
+   *          '500':
+   *            description: Internal Server Error
+   */
+  @Post('reward')
+  public async sendReward(
+    @Req()
+    request: AppRequest,
+    @Body({ validate: true })
+    rewardData: RewardValidator
+  ): Promise<IRewardResponse> {
+    request.logger.info({ message: 'Starting the sendReward call for user' });
+    if (!env.mooclets?.enabled) {
+      throw new BadRequestError('Failed to send reward: mooclet is not currently enabled on backend.');
+    }
+
+    const experimentUserDoc = request.userDoc;
+    return this.moocletRewardsService.sendReward(experimentUserDoc, rewardData, request.logger);
   }
 
   /**

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
@@ -30,6 +30,7 @@ import { env } from '../../env';
 import { NotFoundException } from '@nestjs/common/exceptions';
 import { ExperimentIdValidator } from '../DTO/ExperimentDTO';
 import { ImportExportService } from '../services/ImportExportService';
+import { SUPPORTED_MOOCLET_ALGORITHMS } from 'types/src';
 
 interface ExperimentPaginationInfo extends PaginationResponse {
   filtered: number;
@@ -836,7 +837,17 @@ export class ExperimentController {
     @Params({ validate: true }) { id }: ExperimentIdValidator,
     @Req() request: AppRequest
   ): Promise<ExperimentDTO> {
-    const experiment = await this.experimentService.getSingleExperiment(id, request.logger);
+    let experiment = await this.experimentService.getSingleExperiment(id, request.logger);
+
+    if (SUPPORTED_MOOCLET_ALGORITHMS.includes(experiment?.assignmentAlgorithm)) {
+      if (!env.mooclets?.enabled) {
+        throw new BadRequestError(
+          'MoocletPolicyParameters are present in the experiment but Mooclet is not enabled in the environment'
+        );
+      } else {
+        experiment = await this.moocletExperimentService.attachPolicyParamsToExperimentDTO(experiment, request.logger);
+      }
+    }
 
     return experiment;
   }

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
@@ -30,7 +30,7 @@ import { env } from '../../env';
 import { NotFoundException } from '@nestjs/common/exceptions';
 import { ExperimentIdValidator } from '../DTO/ExperimentDTO';
 import { ImportExportService } from '../services/ImportExportService';
-import { SUPPORTED_MOOCLET_ALGORITHMS } from 'types/src';
+import { SUPPORTED_MOOCLET_ALGORITHMS } from 'upgrade_types';
 
 interface ExperimentPaginationInfo extends PaginationResponse {
   filtered: number;

--- a/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
@@ -29,7 +29,6 @@ import { MoocletExperimentService } from '../services/MoocletExperimentService';
 import { env } from '../../env';
 import { NotFoundException } from '@nestjs/common/exceptions';
 import { ExperimentIdValidator } from '../DTO/ExperimentDTO';
-import { SUPPORTED_MOOCLET_ALGORITHMS } from 'upgrade_types';
 import { ImportExportService } from '../services/ImportExportService';
 
 interface ExperimentPaginationInfo extends PaginationResponse {
@@ -837,20 +836,8 @@ export class ExperimentController {
     @Params({ validate: true }) { id }: ExperimentIdValidator,
     @Req() request: AppRequest
   ): Promise<ExperimentDTO> {
-    let experiment = await this.experimentService.getSingleExperiment(id, request.logger);
+    const experiment = await this.experimentService.getSingleExperiment(id, request.logger);
 
-    if (SUPPORTED_MOOCLET_ALGORITHMS.includes(experiment?.assignmentAlgorithm)) {
-      if (!env.mooclets?.enabled) {
-        throw new BadRequestError(
-          'MoocletPolicyParameters are present in the experiment but Mooclet is not enabled in the environment'
-        );
-      } else {
-        experiment = await this.moocletExperimentService.attachRewardKeyAndPolicyParamsToExperimentDTO(
-          experiment,
-          request.logger
-        );
-      }
-    }
     return experiment;
   }
 

--- a/backend/packages/Upgrade/src/api/controllers/validators/RewardValidator.ts
+++ b/backend/packages/Upgrade/src/api/controllers/validators/RewardValidator.ts
@@ -1,0 +1,40 @@
+import { IsNotEmpty, IsIn, registerDecorator, ValidationOptions, ValidationArguments } from 'class-validator';
+import { BinaryRewardAllowedValue } from 'upgrade_types';
+
+// Custom validator specific to AdaptiveExperimentRewardValidator
+function RequireDecisionPointOrExperimentId(validationOptions?: ValidationOptions) {
+  return function (target: RewardValidator, propertyName: string) {
+    registerDecorator({
+      target: target.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      validator: {
+        validate(_: any, args: ValidationArguments) {
+          const request = args.object as RewardValidator;
+          const hasSecondaryLookupDetails = request.decisionPoint && request.context;
+          return !!(request.experimentId || hasSecondaryLookupDetails);
+        },
+        defaultMessage() {
+          return 'experimentId or secondary lookup details (context and decisionPoint) must be provided.';
+        },
+      },
+    });
+  };
+}
+
+export class RewardValidator {
+  @IsNotEmpty()
+  @IsIn([BinaryRewardAllowedValue.SUCCESS, BinaryRewardAllowedValue.FAILURE])
+  public rewardValue: BinaryRewardAllowedValue;
+
+  // this decorator will check for existence of either experimentId or (context and decisionPoint)
+  @RequireDecisionPointOrExperimentId()
+  public experimentId: string;
+
+  public context: string;
+
+  public decisionPoint: {
+    site: string;
+    target: string;
+  };
+}

--- a/backend/packages/Upgrade/src/api/controllers/validators/RewardValidator.ts
+++ b/backend/packages/Upgrade/src/api/controllers/validators/RewardValidator.ts
@@ -1,7 +1,7 @@
 import { IsNotEmpty, IsIn, registerDecorator, ValidationOptions, ValidationArguments } from 'class-validator';
 import { BinaryRewardAllowedValue } from 'upgrade_types';
 
-// Custom validator specific to AdaptiveExperimentRewardValidator
+// Custom validator specific to RewardValidator
 function RequireDecisionPointOrExperimentId(validationOptions?: ValidationOptions) {
   return function (target: RewardValidator, propertyName: string) {
     registerDecorator({

--- a/backend/packages/Upgrade/src/api/middlewares/ErrorHandlerMiddleware.ts
+++ b/backend/packages/Upgrade/src/api/middlewares/ErrorHandlerMiddleware.ts
@@ -83,6 +83,10 @@ export class ErrorHandlerMiddleware implements ExpressErrorMiddlewareInterface {
         type = SERVER_ERROR.EMAIL_SEND_ERROR;
         message = errorMessage;
         break;
+      case SERVER_ERROR.MOOCLET_REWARD_ERROR:
+        type = SERVER_ERROR.MOOCLET_REWARD_ERROR;
+        message = errorMessage;
+        break;
       default:
         switch (error.httpCode) {
           case 400:

--- a/backend/packages/Upgrade/src/api/models/MoocletExperimentRef.ts
+++ b/backend/packages/Upgrade/src/api/models/MoocletExperimentRef.ts
@@ -33,8 +33,5 @@ export class MoocletExperimentRef {
   variableId?: number;
 
   @Column({ nullable: true })
-  rewardMetricKey?: string;
-
-  @Column({ nullable: true })
   outcomeVariableName?: string;
 }

--- a/backend/packages/Upgrade/src/api/repositories/ExperimentRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/ExperimentRepository.ts
@@ -234,6 +234,24 @@ export class ExperimentRepository extends Repository<Experiment> {
     return experiment;
   }
 
+  public async getEnrollingExperimentsForContextAndDecisionPoint(
+    context: string,
+    site: string,
+    target: string
+  ): Promise<Experiment[]> {
+    const whereExperimentsClause =
+      'experiment.state = :enrolling AND :context ILIKE ANY (ARRAY[experiment.context]) AND partitions.site = :site AND partitions.target = :target';
+    const whereClauseParams = {
+      enrolling: 'enrolling',
+      assign: 'assign',
+      context,
+      site,
+      target,
+    };
+    const experiment = await this.createBaseQueryBuilder().where(whereExperimentsClause, whereClauseParams).getMany();
+    return experiment;
+  }
+
   public async getValidExperimentsWithPreview(context: string): Promise<Experiment[]> {
     const whereExperimentsClause =
       '(experiment.state = :enrolling OR experiment.state = :enrollmentComplete OR experiment.state = :preview) AND NOT (experiment.state = :enrollmentComplete AND experiment.postExperimentRule = :assign AND experiment.revertTo IS NULL) AND :context ILIKE ANY (ARRAY[experiment.context])';

--- a/backend/packages/Upgrade/src/api/repositories/MoocletExperimentRefRepository.ts
+++ b/backend/packages/Upgrade/src/api/repositories/MoocletExperimentRefRepository.ts
@@ -12,4 +12,20 @@ export class MoocletExperimentRefRepository extends Repository<MoocletExperiment
       .where('experiment.state = :status', { status: EXPERIMENT_STATE.ENROLLING })
       .getMany();
   }
+
+  public async findActivelyEnrollingMoocletExperimentsByContextSiteTarget(
+    context: string,
+    site: string,
+    target: string
+  ): Promise<MoocletExperimentRef[]> {
+    return this.createQueryBuilder('moocletExperimentRef')
+      .leftJoinAndSelect('moocletExperimentRef.versionConditionMaps', 'versionConditionMaps')
+      .leftJoinAndSelect('moocletExperimentRef.experiment', 'experiment')
+      .leftJoinAndSelect('experiment.partitions', 'decisionPoint')
+      .where('experiment.state = :status', { status: EXPERIMENT_STATE.ENROLLING })
+      .andWhere(':context = ANY(experiment.context)', { context })
+      .andWhere('decisionPoint.site = :site', { site })
+      .andWhere('decisionPoint.target = :target', { target })
+      .getMany();
+  }
 }

--- a/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentAssignmentService.ts
@@ -73,7 +73,6 @@ import { RequestedExperimentUser } from '../controllers/validators/ExperimentUse
 import { In } from 'typeorm';
 import { env } from '../../env';
 import { MoocletExperimentService } from './MoocletExperimentService';
-import { MoocletRewardsService } from './MoocletRewardsService';
 
 export interface FactorialConditionResult {
   factorialCondition: Omit<ExperimentCondition, 'levelCombinationElements' | 'conditionPayloads'>;
@@ -125,8 +124,7 @@ export class ExperimentAssignmentService {
     public segmentService: SegmentService,
     public experimentService: ExperimentService,
     public cacheService: CacheService,
-    public moocletExperimentService: MoocletExperimentService,
-    public moocletRewardsService: MoocletRewardsService
+    public moocletExperimentService: MoocletExperimentService
   ) {}
 
   private async getCachedExperiments(site: string, target: string): Promise<[DecisionPoint[], Experiment[]]> {
@@ -1145,10 +1143,6 @@ export class ExperimentAssignmentService {
     const userId = userDoc.id;
     logger.info({ message: `Add data log userId ${userId}`, details: jsonLog });
     const keyUniqueArray: { key: string; uniquifier: string }[] = [];
-
-    if (env.mooclets.enabled) {
-      this.moocletRewardsService.parseLogsAndSendPotentialRewards(userDoc, jsonLog, logger);
-    }
 
     // extract the array value
     const promise = jsonLog.map(async (individualMetrics) => {

--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -88,7 +88,6 @@ import { StratificationFactorRepository } from '../repositories/StratificationFa
 import { ExperimentDetailsForCSVData } from '../repositories/AnalyticsRepository';
 import { compare } from 'compare-versions';
 import { MetricService } from './MetricService';
-import { MoocletRewardsService } from './MoocletRewardsService';
 import { MoocletExperimentRefRepository } from '../repositories/MoocletExperimentRefRepository';
 
 const errorRemovePart = 'instance of ExperimentDTO has failed the validation:\n - ';
@@ -131,8 +130,7 @@ export class ExperimentService {
     protected errorService: ErrorService,
     protected cacheService: CacheService,
     protected queryService: QueryService,
-    protected metricService: MetricService,
-    protected moocletRewardsService: MoocletRewardsService
+    protected metricService: MetricService
   ) {}
 
   public async find(logger?: UpgradeLogger): Promise<ExperimentDTO[]> {

--- a/backend/packages/Upgrade/src/api/services/ImportExportService.ts
+++ b/backend/packages/Upgrade/src/api/services/ImportExportService.ts
@@ -111,10 +111,10 @@ export class ImportExportService {
           this.experimentService.formattingPayload(this.experimentService.formattingConditionPayload(experiment))
         );
 
-        // If it's a mooclet experiment, attach reward key and policy parameters
+        // If it's a mooclet experiment, policy parameters
         if (SUPPORTED_MOOCLET_ALGORITHMS.includes(experiment.assignmentAlgorithm)) {
           try {
-            experimentRecord = await this.moocletExperimentService.attachRewardKeyAndPolicyParamsToExperimentDTO(
+            experimentRecord = await this.moocletExperimentService.attachPolicyParamsToExperimentDTO(
               experimentRecord,
               logger
             );

--- a/backend/packages/Upgrade/src/api/services/MoocletExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/MoocletExperimentService.ts
@@ -1209,11 +1209,11 @@ export class MoocletExperimentService extends ExperimentService {
   ): Promise<ExperimentDTO> {
     try {
       const moocletExperimentRef = await this.getMoocletExperimentRefByUpgradeExperimentId(experiment.id);
-      const policyParamters = await this.moocletDataService.getPolicyParameters(
+      const policyParameters = await this.moocletDataService.getPolicyParameters(
         moocletExperimentRef.policyParametersId,
         logger
       );
-      experiment.moocletPolicyParameters = policyParamters.parameters;
+      experiment.moocletPolicyParameters = policyParameters.parameters;
 
       return experiment;
     } catch (err) {

--- a/backend/packages/Upgrade/src/api/services/MoocletExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/MoocletExperimentService.ts
@@ -54,8 +54,6 @@ import {
 } from 'upgrade_types';
 import { ExperimentCondition } from '../models/ExperimentCondition';
 import { MetricService } from './MetricService';
-import { Metric } from '../models/Metric';
-import { MoocletRewardsService } from './MoocletRewardsService';
 import { env } from '../../env';
 import { ExperimentSchedulerService } from './ExperimentSchedulerService';
 
@@ -128,8 +126,7 @@ export class MoocletExperimentService extends ExperimentService {
     errorService: ErrorService,
     cacheService: CacheService,
     queryService: QueryService,
-    metricService: MetricService,
-    moocletRewardsService: MoocletRewardsService
+    metricService: MetricService
   ) {
     super(
       experimentRepository,
@@ -159,8 +156,7 @@ export class MoocletExperimentService extends ExperimentService {
       errorService,
       cacheService,
       queryService,
-      metricService,
-      moocletRewardsService
+      metricService
     );
   }
 
@@ -179,12 +175,9 @@ export class MoocletExperimentService extends ExperimentService {
   /**
    * handleCreateMoocletTransaction
    *
-   * 1. Create and save an experiment-specific reward metric for the experiment
-   * 2. Attach a percent-success reward metric query to the experimentDTO before saving
-   * 3. Save the upgrade experiment
-   * 4. Create and save the Mooclet experiment resources (outputs MoocletExperimentRef)
-   * 5. Assign the rewardMetricKey to the MoocletExperimentRef
-   * 6. Save the MoocletExperimentRef and VersionConditionMaps
+   * 1. Save the upgrade experiment
+   * 2. Create and save the Mooclet experiment resources (outputs MoocletExperimentRef)
+   * 3. Save the MoocletExperimentRef and VersionConditionMaps
    *
    * On any error, rollback the Mooclet resources and abort the transaction
    */
@@ -194,25 +187,7 @@ export class MoocletExperimentService extends ExperimentService {
     params: SyncCreateParams
   ): Promise<ExperimentDTO> {
     const logger = params.logger;
-    const { moocletPolicyParameters, queries, rewardMetricKey, context } = params.experimentDTO;
-
-    // create reward metric
-    try {
-      await this.moocletRewardsService.createAndSaveRewardMetric(rewardMetricKey, context[0], logger);
-    } catch (error) {
-      logger.error({
-        message: 'Failed to create reward metric',
-        error,
-        rewardMetricKey,
-      });
-      throw error;
-    }
-    if (!queries.some((query) => query?.metric?.key === rewardMetricKey)) {
-      // if it's not already present, append default reward metric query to existing experimentDTO queries before saving
-      const defaultRewardMetricQuery = this.moocletRewardsService.getRewardMetricQuery(rewardMetricKey);
-
-      queries.push(defaultRewardMetricQuery);
-    }
+    const { moocletPolicyParameters } = params.experimentDTO;
 
     // create Upgrade Experiment. If this fails, then mooclet resources will not be created, and the UpGrade experiment transaction will abort
     const experimentResponse = await this.createExperiment(manager, params);
@@ -223,8 +198,6 @@ export class MoocletExperimentService extends ExperimentService {
       moocletPolicyParameters,
       logger
     );
-
-    moocletExperimentRefResponse.rewardMetricKey = rewardMetricKey;
 
     logger.info({
       message: 'Mooclet experiment created successfully:',
@@ -1024,10 +997,6 @@ export class MoocletExperimentService extends ExperimentService {
         existingEntityManager: manager,
       });
 
-      if (moocletExperimentRef.rewardMetricKey) {
-        await manager.getRepository(Metric).delete(moocletExperimentRef.rewardMetricKey);
-      }
-
       // delete the mooclet resources. If this fails, the transaction will abort and the upgrade experiment will not be deleted,
       // but the Mooclet resources may not be deleted either
       const removedResources = await this.orchestrateDeleteMoocletResources(moocletExperimentRef, logger);
@@ -1234,7 +1203,7 @@ export class MoocletExperimentService extends ExperimentService {
     }
   }
 
-  public async attachRewardKeyAndPolicyParamsToExperimentDTO(
+  public async attachPolicyParamsToExperimentDTO(
     experiment: ExperimentDTO,
     logger: UpgradeLogger
   ): Promise<ExperimentDTO> {
@@ -1244,7 +1213,6 @@ export class MoocletExperimentService extends ExperimentService {
         moocletExperimentRef.policyParametersId,
         logger
       );
-      experiment.rewardMetricKey = moocletExperimentRef.rewardMetricKey;
       experiment.moocletPolicyParameters = policyParamters.parameters;
 
       return experiment;

--- a/backend/packages/Upgrade/src/api/services/MoocletRewardsService.ts
+++ b/backend/packages/Upgrade/src/api/services/MoocletRewardsService.ts
@@ -107,7 +107,7 @@ export class MoocletRewardsService {
       // NOTE: in the future we may want to batch these, the mooclet API technically supports it by adding "/create_many" to an endpoint but it's not documented
       this.moocletDataService.postNewReward(reward, logger);
 
-      return { message: `Reward sent to mooclet successfuly.`, request: this.request, reward };
+      return { message: `Reward sent to mooclet successfully.`, request: this.request, reward };
     } catch (error) {
       if (error instanceof HttpError) {
         throw error;
@@ -186,7 +186,7 @@ export class MoocletRewardsService {
       (map) => enrollment.conditionId === map.experimentConditionId
     );
     if (!map) {
-      this.throwConflictError(`Version-condtiion mapping not found, no reward sent.`);
+      this.throwConflictError(`Version-condition mapping not found, no reward sent.`);
     }
     return map.moocletVersionId;
   }
@@ -197,9 +197,8 @@ export class MoocletRewardsService {
   private throwConflictError(message: string): never {
     this.logger.error({ message, request: this.request });
 
-    const error = new Error(message);
+    const error = new HttpError(409, message);
     (error as any).type = SERVER_ERROR.MOOCLET_REWARD_ERROR;
-    (error as any).httpCode = 409;
     throw error;
   }
 }

--- a/backend/packages/Upgrade/src/api/services/MoocletRewardsService.ts
+++ b/backend/packages/Upgrade/src/api/services/MoocletRewardsService.ts
@@ -167,6 +167,8 @@ export class MoocletRewardsService {
       );
     }
 
+    // TODO: this is a spot where we want to use shared-decision-point pooling logic,
+    // but for now if there are competing experiments, it will be required to use experimentId
     if (moocletExperimentRefs.length > 1) {
       this.throwConflictError(
         `Multiple active experiments found for decision point (context: ${context}, site: ${site}, target: ${target}), cannot determine which to send reward to.`

--- a/backend/packages/Upgrade/src/api/services/MoocletRewardsService.ts
+++ b/backend/packages/Upgrade/src/api/services/MoocletRewardsService.ts
@@ -1,227 +1,199 @@
 import { UpgradeLogger } from '../../../src/lib/logger/UpgradeLogger';
-import { REPEATED_MEASURE, IMetricMetaData, ILogInput } from 'upgrade_types';
+import { EXPERIMENT_STATE } from 'upgrade_types';
 import { RequestedExperimentUser } from '../controllers/validators/ExperimentUserValidator';
-import { Metric } from '../models/Metric';
 import { MoocletExperimentRef } from '../models/MoocletExperimentRef';
-import { v4 as uuid } from 'uuid';
-import { MetricService } from './MetricService';
 import { MoocletDataService } from './MoocletDataService';
 import { MoocletExperimentRefRepository } from '../repositories/MoocletExperimentRefRepository';
 import { IndividualEnrollment } from '../models/IndividualEnrollment';
 import { IndividualEnrollmentRepository } from '../repositories/IndividualEnrollmentRepository';
 import { Service } from 'typedi';
 import { InjectRepository } from '../../typeorm-typedi-extensions';
+import { HttpError } from 'routing-controllers';
+import { MoocletValueRequestBody } from '../../types/Mooclet';
+import { RewardValidator } from '../controllers/validators/RewardValidator';
+import { BinaryRewardValueMap } from '../../../../../../types/src/Mooclet';
 
-import { QueryValidator } from '../DTO/ExperimentDTO';
-import { BinaryRewardMetricAllowedValue, BinaryRewardMetricValueMap } from 'upgrade_types';
-
-export interface ValidRewardMetricType {
-  key: string;
-  value: BinaryRewardMetricAllowedValue;
+export interface IRewardResponse {
+  message: string;
+  request: RewardValidator;
+  reward: MoocletValueRequestBody;
 }
 
 @Service()
 export class MoocletRewardsService {
+  userId: string;
+  request: RewardValidator;
+  logger: UpgradeLogger;
+
   constructor(
     @InjectRepository()
     private moocletExperimentRefRepository: MoocletExperimentRefRepository,
     @InjectRepository()
     private individualEnrollmentRepository: IndividualEnrollmentRepository,
-    private metricService: MetricService,
     private moocletDataService: MoocletDataService
   ) {}
 
-  public getRewardMetricQuery(rewardMetricKey: string): QueryValidator {
-    return {
-      id: uuid(),
-      name: 'Success Rate',
-      query: {
-        operationType: 'percentage',
-        compareFn: '=',
-        compareValue: BinaryRewardMetricAllowedValue.SUCCESS,
-      },
-      metric: {
-        key: rewardMetricKey,
-      },
-      repeatedMeasure: REPEATED_MEASURE.mostRecent,
-    };
-  }
-
-  public async createAndSaveRewardMetric(
-    rewardMetricKey: string,
-    context: string,
-    logger: UpgradeLogger
-  ): Promise<Metric[]> {
-    const metric = {
-      id: uuid(),
-      metric: rewardMetricKey,
-      datatype: IMetricMetaData.CATEGORICAL,
-      allowedValues: [BinaryRewardMetricAllowedValue.SUCCESS, BinaryRewardMetricAllowedValue.FAILURE],
-    };
-
-    return this.metricService.saveAllMetrics([metric], [context], logger);
-  }
-
-  public async parseLogsAndSendPotentialRewards(
+  /**
+   * Attempt to send a reward to the external mooclet API.
+   * This is intended to be a "fire-and-forget" operation; we do not wait for
+   * confirmation that the reward was received successfully.
+   *
+   * Several criteria must be met to validate that a reward can be sent:
+   *
+   * 1. Mooclets feature must be currently enabled
+   *
+   * 2. The unique experiment must be ascertained before sending a reward.
+   * `experimentId` is preferred, but if not provided, `context`, `site`, and `target` can
+   * be used to identify the experiment.
+   *
+   * 3. A complete synced Mooclet experiment reference must exist.
+   *
+   * 4. The user must have marked and have a unique enrollment.
+   *
+   * 5. The condition enrolled must match a `version` in the mooclet experiment ref.
+   *
+   * - If any of these criteria are not met, a 409 data-conflict error is thrown.
+   */
+  public async sendReward(
     user: RequestedExperimentUser,
-    logs: ILogInput[],
+    request: RewardValidator,
     logger: UpgradeLogger
-  ): Promise<void> {
-    // First see if any simple metrics have valid reward values
-    const validSimpleMetricAttributes = this.gatherValidRewardMetrics(logs);
+  ): Promise<IRewardResponse> {
+    this.request = request;
+    this.logger = logger;
+    this.userId = user.id;
 
-    if (!validSimpleMetricAttributes.length) {
-      // no need to log anything here, just quit early as this is the most common case
-      return;
-    }
+    const { experimentId, context, decisionPoint, rewardValue } = request;
 
     try {
-      // If we have valid metric rewards, only then check for active mooclet experiment refs
-      const moocletExperimentRefs = await this.getAllActiveMoocletExperimentRefs(logger);
+      // Find the mooclet experiment ref by ID or decision point
+      const moocletExperimentRef = experimentId
+        ? await this.findMoocletExperimentRefById(experimentId)
+        : await this.findMoocletExperimentRefByDecisionPoint(context, decisionPoint);
 
-      if (!moocletExperimentRefs.length) {
-        logger.warn({
-          message: 'No active mooclet experiment refs found',
-          user,
-        });
-        return;
+      // Find user's enrollment
+      const enrollments = await this.individualEnrollmentRepository.findEnrollments(user.id, [
+        moocletExperimentRef.experimentId,
+      ]);
+
+      if (!enrollments.length || enrollments.length > 1) {
+        this.throwConflictError(
+          `Could not find unique user enrollment for experiment (userId: ${user.id}, enrollments: ${enrollments}), no reward sent.`
+        );
       }
 
-      // Find each experiment match by reward metric key
-      const experimentsMatchingLoggedRewardKey = this.findExperimentByRewardMetricKey(
-        moocletExperimentRefs,
-        validSimpleMetricAttributes
+      // Get version ID for the user's condition
+      const enrollment = enrollments[0];
+      const versionId = this.getVersionIdByConditionId(enrollment, moocletExperimentRef);
+
+      if (!versionId) {
+        this.throwConflictError(
+          `Could not find version id for user enrollment (userId: ${user.id}, experimentId: ${moocletExperimentRef.experimentId}, conditionId: ${enrollment.conditionId}).`
+        );
+      }
+
+      // Prepare and send reward
+      const reward: MoocletValueRequestBody = {
+        variable: moocletExperimentRef.outcomeVariableName,
+        value: BinaryRewardValueMap[rewardValue],
+        mooclet: moocletExperimentRef.moocletId,
+        version: versionId,
+        learner: user.id,
+      };
+
+      logger.info({ message: 'Sending reward to mooclet', reward, user });
+
+      // Fire-and-forget operation
+      // NOTE: in the future we may want to batch these, the mooclet API technically supports it by adding "/create_many" to an endpoint but it's not documented
+      this.moocletDataService.postNewReward(reward, logger);
+
+      return { message: `Reward sent to mooclet successfuly.`, request: this.request, reward };
+    } catch (error) {
+      if (error instanceof HttpError) {
+        throw error;
+      }
+
+      // Log and wrap unexpected errors
+      this.throwConflictError(
+        `Failed to process reward request due to unexpected error (userId: ${user.id}, experimentId: ${
+          experimentId || 'not provided'
+        }, rewardValue: ${rewardValue}).`
+      );
+    }
+  }
+
+  /**
+   * Finds mooclet experiment ref by experiment ID
+   */
+  private async findMoocletExperimentRefById(experimentId: string): Promise<MoocletExperimentRef> {
+    const moocletExperimentRef = await this.moocletExperimentRefRepository.findOne({
+      where: { experimentId },
+      relations: ['versionConditionMaps', 'versionConditionMaps.experimentCondition', 'experiment'],
+    });
+
+    if (!moocletExperimentRef) {
+      this.throwConflictError(
+        `No active mooclet experiment ref found for experiment id: ${experimentId}, could not send reward.`
+      );
+    }
+
+    if (moocletExperimentRef.experiment.state !== EXPERIMENT_STATE.ENROLLING) {
+      this.throwConflictError(
+        `Experiment with id: ${experimentId} is not actively enrolling (current state: ${moocletExperimentRef.experiment.state}), could not send reward.`
+      );
+    }
+
+    return moocletExperimentRef;
+  }
+
+  /**
+   * Finds mooclet experiment ref by decision point
+   */
+  private async findMoocletExperimentRefByDecisionPoint(
+    context: string,
+    decisionPoint: { site: string; target: string }
+  ): Promise<MoocletExperimentRef> {
+    const { site, target } = decisionPoint;
+    const moocletExperimentRefs =
+      await this.moocletExperimentRefRepository.findActivelyEnrollingMoocletExperimentsByContextSiteTarget(
+        context,
+        site,
+        target
       );
 
-      if (!experimentsMatchingLoggedRewardKey.length) {
-        logger.warn({
-          message: 'Reward metrics were logged, but no active experiments matched the rewardMetricKeys',
-          moocletExperimentRefs,
-          validSimpleMetricAttributes,
-        });
-        return;
-      }
-
-      const experimentIds = experimentsMatchingLoggedRewardKey.map((pair) => pair.moocletExperimentRef.experimentId);
-      const enrollments = await this.individualEnrollmentRepository.findEnrollments(user.id, experimentIds);
-
-      // For each match, find the user's condition, map to version id, and create reward object
-      await Promise.all(
-        experimentsMatchingLoggedRewardKey.map(async ({ moocletExperimentRef, rewardMetricValue }) => {
-          const enrollment = enrollments.find(
-            (enrollment) => enrollment.experimentId === moocletExperimentRef.experimentId
-          );
-
-          // not sure if this even possible in reality, but should be handled
-          if (!enrollment) {
-            logger.error({
-              message: 'Could not find user enrollment for experiment.',
-              user,
-              moocletExperimentRef,
-            });
-            return;
-          }
-
-          const versionId = this.getVersionIdByConditionId(enrollment, moocletExperimentRef, logger);
-
-          if (!versionId) {
-            logger.error({
-              message: 'Could not find version id for user enrollment.',
-              enrollment,
-              moocletExperimentRef,
-            });
-            return;
-          }
-
-          const reward = {
-            variable: moocletExperimentRef.outcomeVariableName,
-            value: BinaryRewardMetricValueMap[rewardMetricValue],
-            mooclet: moocletExperimentRef.moocletId,
-            version: versionId,
-            learner: user.id,
-          };
-          logger.info({
-            message: 'Sending reward to mooclet',
-            reward,
-            user,
-          });
-          // NOTE: in the future we may want to batch these, the mooclet API technically supports it by adding "/create_many" to an endpoint but it's not documented
-          await this.moocletDataService.postNewReward(reward, logger);
-        })
+    if (moocletExperimentRefs.length === 0) {
+      this.throwConflictError(
+        `No active experiment found for decision point (context: ${context}, site: ${site}, target: ${target}), could not send reward.`
       );
-    } catch (error) {
-      logger.error({
-        message: 'Failure processing and sending rewards',
-        error,
-        logs,
-      });
-    }
-  }
-
-  private async getAllActiveMoocletExperimentRefs(logger: UpgradeLogger): Promise<MoocletExperimentRef[]> {
-    // cache this? would be complex to invalidate, and our TTL is usually in the order of seconds...
-    try {
-      return this.moocletExperimentRefRepository.getRefsForActivelyEnrollingExperiments();
-    } catch (error) {
-      logger.error({ message: 'Failed to fetch active mooclet refs ', error });
-      return Promise.resolve([]);
-    }
-  }
-
-  private gatherValidRewardMetrics(logs: ILogInput[]): ValidRewardMetricType[] {
-    return logs.reduce((acc, log) => {
-      const simpleMetrics = log.metrics.attributes;
-
-      for (const key in simpleMetrics) {
-        if (this.isBinaryRewardMetricAllowedValue(simpleMetrics[key])) {
-          acc.push({ key, value: simpleMetrics[key] });
-        }
-      }
-
-      return acc;
-    }, [] as ValidRewardMetricType[]);
-  }
-
-  // type guard to allow for type checking of binary reward metric value
-  private isBinaryRewardMetricAllowedValue(value: any): value is BinaryRewardMetricAllowedValue {
-    return Object.values(BinaryRewardMetricAllowedValue).includes(value);
-  }
-
-  private findExperimentByRewardMetricKey(
-    moocletExperimentRefs: MoocletExperimentRef[],
-    rewardMetricKeys: ValidRewardMetricType[]
-  ): { moocletExperimentRef: MoocletExperimentRef; rewardMetricValue: BinaryRewardMetricAllowedValue }[] {
-    const moocletExperimentRefMatches = [];
-
-    for (const rewardMetric of rewardMetricKeys) {
-      const matchedMoocletRef = moocletExperimentRefs.find((ref) => ref.rewardMetricKey === rewardMetric.key);
-
-      if (matchedMoocletRef) {
-        moocletExperimentRefMatches.push({
-          moocletExperimentRef: matchedMoocletRef,
-          rewardMetricValue: rewardMetric.value,
-        });
-      }
     }
 
-    return moocletExperimentRefMatches;
+    if (moocletExperimentRefs.length > 1) {
+      this.throwConflictError(
+        `Multiple active experiments found for decision point (context: ${context}, site: ${site}, target: ${target}), cannot determine which to send reward to.`
+      );
+    }
+
+    return moocletExperimentRefs[0];
   }
 
   private getVersionIdByConditionId(
     enrollment: IndividualEnrollment,
-    moocletExperimentRef: MoocletExperimentRef,
-    logger: UpgradeLogger
+    moocletExperimentRef: MoocletExperimentRef
   ): number | null {
     const map = moocletExperimentRef.versionConditionMaps.find(
       (map) => enrollment.conditionId === map.experimentConditionId
     );
     if (!map) {
-      logger.error({
-        message: 'Could not find a version for the user enrollment.',
-        versionConditionMaps: moocletExperimentRef.versionConditionMaps,
-      });
-      return null;
+      this.throwConflictError(`Version-condtiion mapping not found, no reward sent.`);
     }
     return map.moocletVersionId;
+  }
+
+  /**
+   * Throws a 409 data-conflict error for most unexpected cases
+   */
+  private throwConflictError(message: string): never {
+    this.logger.error({ message, request: this.request });
+    throw new HttpError(409, message);
   }
 }

--- a/backend/packages/Upgrade/src/api/services/MoocletRewardsService.ts
+++ b/backend/packages/Upgrade/src/api/services/MoocletRewardsService.ts
@@ -1,5 +1,5 @@
 import { UpgradeLogger } from '../../../src/lib/logger/UpgradeLogger';
-import { EXPERIMENT_STATE } from 'upgrade_types';
+import { EXPERIMENT_STATE, SERVER_ERROR } from 'upgrade_types';
 import { RequestedExperimentUser } from '../controllers/validators/ExperimentUserValidator';
 import { MoocletExperimentRef } from '../models/MoocletExperimentRef';
 import { MoocletDataService } from './MoocletDataService';
@@ -194,6 +194,10 @@ export class MoocletRewardsService {
    */
   private throwConflictError(message: string): never {
     this.logger.error({ message, request: this.request });
-    throw new HttpError(409, message);
+
+    const error = new Error(message);
+    (error as any).type = SERVER_ERROR.MOOCLET_REWARD_ERROR;
+    (error as any).httpCode = 409;
+    throw error;
   }
 }

--- a/backend/packages/Upgrade/src/api/services/MoocletRewardsService.ts
+++ b/backend/packages/Upgrade/src/api/services/MoocletRewardsService.ts
@@ -1,5 +1,5 @@
 import { UpgradeLogger } from '../../../src/lib/logger/UpgradeLogger';
-import { EXPERIMENT_STATE, SERVER_ERROR } from 'upgrade_types';
+import { EXPERIMENT_STATE, SERVER_ERROR, BinaryRewardValueMap } from 'upgrade_types';
 import { RequestedExperimentUser } from '../controllers/validators/ExperimentUserValidator';
 import { MoocletExperimentRef } from '../models/MoocletExperimentRef';
 import { MoocletDataService } from './MoocletDataService';
@@ -11,7 +11,6 @@ import { InjectRepository } from '../../typeorm-typedi-extensions';
 import { HttpError } from 'routing-controllers';
 import { MoocletValueRequestBody } from '../../types/Mooclet';
 import { RewardValidator } from '../controllers/validators/RewardValidator';
-import { BinaryRewardValueMap } from '../../../../../../types/src/Mooclet';
 
 export interface IRewardResponse {
   message: string;

--- a/backend/packages/Upgrade/src/api/services/MoocletRewardsService.ts
+++ b/backend/packages/Upgrade/src/api/services/MoocletRewardsService.ts
@@ -20,10 +20,6 @@ export interface IRewardResponse {
 
 @Service()
 export class MoocletRewardsService {
-  userId: string;
-  request: RewardValidator;
-  logger: UpgradeLogger;
-
   constructor(
     @InjectRepository()
     private moocletExperimentRefRepository: MoocletExperimentRefRepository,
@@ -58,17 +54,13 @@ export class MoocletRewardsService {
     request: RewardValidator,
     logger: UpgradeLogger
   ): Promise<IRewardResponse> {
-    this.request = request;
-    this.logger = logger;
-    this.userId = user.id;
-
     const { experimentId, context, decisionPoint, rewardValue } = request;
 
     try {
       // Find the mooclet experiment ref by ID or decision point
       const moocletExperimentRef = experimentId
-        ? await this.findMoocletExperimentRefById(experimentId)
-        : await this.findMoocletExperimentRefByDecisionPoint(context, decisionPoint);
+        ? await this.findMoocletExperimentRefById(experimentId, request, logger)
+        : await this.findMoocletExperimentRefByDecisionPoint(context, decisionPoint, request, logger);
 
       // Find user's enrollment
       const enrollments = await this.individualEnrollmentRepository.findEnrollments(user.id, [
@@ -77,17 +69,21 @@ export class MoocletRewardsService {
 
       if (!enrollments.length || enrollments.length > 1) {
         this.throwConflictError(
-          `Could not find unique user enrollment for experiment (userId: ${user.id}, enrollments: ${enrollments}), no reward sent.`
+          `Could not find unique user enrollment for experiment (userId: ${user.id}, enrollments: ${enrollments}), no reward sent.`,
+          request,
+          logger
         );
       }
 
       // Get version ID for the user's condition
       const enrollment = enrollments[0];
-      const versionId = this.getVersionIdByConditionId(enrollment, moocletExperimentRef);
+      const versionId = this.getVersionIdByConditionId(enrollment, moocletExperimentRef, request, logger);
 
       if (!versionId) {
         this.throwConflictError(
-          `Could not find version id for user enrollment (userId: ${user.id}, experimentId: ${moocletExperimentRef.experimentId}, conditionId: ${enrollment.conditionId}).`
+          `Could not find version id for user enrollment (userId: ${user.id}, experimentId: ${moocletExperimentRef.experimentId}, conditionId: ${enrollment.conditionId}).`,
+          request,
+          logger
         );
       }
 
@@ -106,7 +102,7 @@ export class MoocletRewardsService {
       // NOTE: in the future we may want to batch these, the mooclet API technically supports it by adding "/create_many" to an endpoint but it's not documented
       this.moocletDataService.postNewReward(reward, logger);
 
-      return { message: `Reward sent to mooclet successfully.`, request: this.request, reward };
+      return { message: `Reward sent to mooclet successfully.`, request, reward };
     } catch (error) {
       if (error instanceof HttpError) {
         throw error;
@@ -116,7 +112,9 @@ export class MoocletRewardsService {
       this.throwConflictError(
         `Failed to process reward request due to unexpected error (userId: ${user.id}, experimentId: ${
           experimentId || 'not provided'
-        }, rewardValue: ${rewardValue}).`
+        }, rewardValue: ${rewardValue}).`,
+        request,
+        logger
       );
     }
   }
@@ -124,7 +122,11 @@ export class MoocletRewardsService {
   /**
    * Finds mooclet experiment ref by experiment ID
    */
-  private async findMoocletExperimentRefById(experimentId: string): Promise<MoocletExperimentRef> {
+  private async findMoocletExperimentRefById(
+    experimentId: string,
+    request: RewardValidator,
+    logger: UpgradeLogger
+  ): Promise<MoocletExperimentRef> {
     const moocletExperimentRef = await this.moocletExperimentRefRepository.findOne({
       where: { experimentId },
       relations: ['versionConditionMaps', 'versionConditionMaps.experimentCondition', 'experiment'],
@@ -132,13 +134,17 @@ export class MoocletRewardsService {
 
     if (!moocletExperimentRef) {
       this.throwConflictError(
-        `No active mooclet experiment ref found for experiment id: ${experimentId}, could not send reward.`
+        `No active mooclet experiment ref found for experiment id: ${experimentId}, could not send reward.`,
+        request,
+        logger
       );
     }
 
     if (moocletExperimentRef.experiment.state !== EXPERIMENT_STATE.ENROLLING) {
       this.throwConflictError(
-        `Experiment with id: ${experimentId} is not actively enrolling (current state: ${moocletExperimentRef.experiment.state}), could not send reward.`
+        `Experiment with id: ${experimentId} is not actively enrolling (current state: ${moocletExperimentRef.experiment.state}), could not send reward.`,
+        request,
+        logger
       );
     }
 
@@ -150,7 +156,9 @@ export class MoocletRewardsService {
    */
   private async findMoocletExperimentRefByDecisionPoint(
     context: string,
-    decisionPoint: { site: string; target: string }
+    decisionPoint: { site: string; target: string },
+    request: RewardValidator,
+    logger: UpgradeLogger
   ): Promise<MoocletExperimentRef> {
     const { site, target } = decisionPoint;
     const moocletExperimentRefs =
@@ -162,7 +170,9 @@ export class MoocletRewardsService {
 
     if (moocletExperimentRefs.length === 0) {
       this.throwConflictError(
-        `No active experiment found for decision point (context: ${context}, site: ${site}, target: ${target}), could not send reward.`
+        `No active experiment found for decision point (context: ${context}, site: ${site}, target: ${target}), could not send reward.`,
+        request,
+        logger
       );
     }
 
@@ -170,7 +180,9 @@ export class MoocletRewardsService {
     // but for now if there are competing experiments, it will be required to use experimentId
     if (moocletExperimentRefs.length > 1) {
       this.throwConflictError(
-        `Multiple active experiments found for decision point (context: ${context}, site: ${site}, target: ${target}), cannot determine which to send reward to.`
+        `Multiple active experiments found for decision point (context: ${context}, site: ${site}, target: ${target}), cannot determine which to send reward to.`,
+        request,
+        logger
       );
     }
 
@@ -179,13 +191,15 @@ export class MoocletRewardsService {
 
   private getVersionIdByConditionId(
     enrollment: IndividualEnrollment,
-    moocletExperimentRef: MoocletExperimentRef
+    moocletExperimentRef: MoocletExperimentRef,
+    request: RewardValidator,
+    logger: UpgradeLogger
   ): number | null {
     const map = moocletExperimentRef.versionConditionMaps.find(
       (map) => enrollment.conditionId === map.experimentConditionId
     );
     if (!map) {
-      this.throwConflictError(`Version-condition mapping not found, no reward sent.`);
+      this.throwConflictError(`Version-condition mapping not found, no reward sent.`, request, logger);
     }
     return map.moocletVersionId;
   }
@@ -193,8 +207,8 @@ export class MoocletRewardsService {
   /**
    * Throws a 409 data-conflict error for most unexpected cases
    */
-  private throwConflictError(message: string): never {
-    this.logger.error({ message, request: this.request });
+  private throwConflictError(message: string, request: RewardValidator, logger: UpgradeLogger): never {
+    logger.error({ message, request });
 
     const error = new HttpError(409, message);
     (error as any).type = SERVER_ERROR.MOOCLET_REWARD_ERROR;

--- a/backend/packages/Upgrade/test/unit/controllers/ExperimentController.test.ts
+++ b/backend/packages/Upgrade/test/unit/controllers/ExperimentController.test.ts
@@ -112,7 +112,6 @@ describe('Experiment Controller Testing', () => {
     ...experimentData,
     id: uuid(),
     moocletPolicyParameters: tsConfigurablePolicyParameters,
-    rewardMetricKey: 'TEST_REWARD',
     assignmentAlgorithm: ASSIGNMENT_ALGORITHM.MOOCLET_TS_CONFIGURABLE,
   };
 

--- a/backend/packages/Upgrade/test/unit/services/ExperimentAssignmentService.test.ts
+++ b/backend/packages/Upgrade/test/unit/services/ExperimentAssignmentService.test.ts
@@ -36,7 +36,6 @@ import { UserStratificationFactorRepository } from '../../../src/api/repositorie
 import { configureLogger } from '../../utils/logger';
 import { MoocletExperimentService } from '../../../src/api/services/MoocletExperimentService';
 import { factorialGroupExperiment, factorialIndividualExperiment } from '../mockdata/raw';
-import { MoocletRewardsService } from '../../../src/api/services/MoocletRewardsService';
 import { UpgradeLogger } from '../../../src/lib/logger/UpgradeLogger';
 import { ConditionPayloadRepository } from '../../../src/api/repositories/ConditionPayloadRepository';
 import { FactorRepository } from '../../../src/api/repositories/FactorRepository';
@@ -72,7 +71,6 @@ describe('Experiment Assignment Service Test', () => {
   const experimentServiceMock = sinon.createStubInstance(ExperimentService);
   const cacheServiceMock = sinon.createStubInstance(CacheService);
   const moocletExperimentServiceMock = sinon.createStubInstance(MoocletExperimentService);
-  const moocletRewardsServiceMock = sinon.createStubInstance(MoocletRewardsService);
   experimentServiceMock.formattingConditionPayload.restore();
   experimentServiceMock.formattingPayload.restore();
 
@@ -131,8 +129,7 @@ describe('Experiment Assignment Service Test', () => {
       segmentServiceMock,
       experimentServiceMock,
       cacheServiceMock,
-      moocletExperimentServiceMock,
-      moocletRewardsServiceMock
+      moocletExperimentServiceMock
     );
 
     testedModule.cacheService.wrap.resolves([]);

--- a/backend/packages/Upgrade/test/unit/services/MoocletExperimentService.test.ts
+++ b/backend/packages/Upgrade/test/unit/services/MoocletExperimentService.test.ts
@@ -43,7 +43,6 @@ import {
 } from 'upgrade_types';
 import { UpgradeLogger } from '../../../src/lib/logger/UpgradeLogger';
 import { MetricService } from '../../../src/api/services/MetricService';
-import { MoocletRewardsService } from '../../../src/api/services/MoocletRewardsService';
 import { ExperimentSchedulerService } from '../../../src/api/services/ExperimentSchedulerService';
 
 const mockDataSource = {
@@ -95,7 +94,6 @@ jest.mock('../../../src/api/services/ErrorService');
 jest.mock('../../../src/api/services/CacheService');
 jest.mock('../../../src/api/services/QueryService');
 jest.mock('../../../src/api/services/MetricService');
-jest.mock('../../../src/api/services/MoocletRewardsService');
 
 const mockTSConfigMoocletPolicyParameters = {
   assignmentAlgorithm: ASSIGNMENT_ALGORITHM.MOOCLET_TS_CONFIGURABLE,
@@ -232,7 +230,6 @@ describe('#MoocletExperimentService', () => {
   let cacheService: CacheService;
   let queryService: QueryService;
   let metricService: MetricService;
-  let moocletRewardsService: MoocletRewardsService;
 
   beforeEach(() => {
     moocletDataService = {
@@ -245,11 +242,6 @@ describe('#MoocletExperimentService', () => {
       saveAllMetrics: jest.fn(),
       delete: jest.fn(),
     } as unknown as MetricService;
-
-    moocletRewardsService = {
-      createAndSaveRewardMetric: jest.fn(),
-      getRewardMetricQuery: jest.fn(),
-    } as unknown as MoocletRewardsService;
 
     // Create service with mocked dependencies
     moocletExperimentService = new MoocletExperimentService(
@@ -281,8 +273,7 @@ describe('#MoocletExperimentService', () => {
       errorService,
       cacheService,
       queryService,
-      metricService,
-      moocletRewardsService
+      metricService
     );
   });
 
@@ -326,7 +317,6 @@ describe('#MoocletExperimentService', () => {
         .spyOn(moocletExperimentService as any, 'createAndSaveVersionConditionMapEntities')
         .mockResolvedValue(undefined);
       jest.spyOn(moocletExperimentService as any, 'orchestrateDeleteMoocletResources').mockResolvedValue(undefined);
-      jest.spyOn(moocletRewardsService as any, 'createAndSaveRewardMetric').mockResolvedValue(undefined);
     });
 
     afterEach(() => {
@@ -358,7 +348,6 @@ describe('#MoocletExperimentService', () => {
       );
 
       expect(moocletExperimentService.orchestrateDeleteMoocletResources).not.toHaveBeenCalled();
-      expect(moocletRewardsService.createAndSaveRewardMetric).toHaveBeenCalled();
 
       // Verify the result
       expect(result).toEqual({

--- a/backend/packages/Upgrade/test/unit/services/MoocletRewardsService.test.ts
+++ b/backend/packages/Upgrade/test/unit/services/MoocletRewardsService.test.ts
@@ -1,877 +1,715 @@
-import { MoocletExperimentRef } from 'src/api/models/MoocletExperimentRef';
-import { BinaryRewardMetricAllowedValue, BinaryRewardMetricValueMap } from '../../../../../../types/src/Mooclet';
-import { IndividualEnrollment } from '../../../src/api/models/IndividualEnrollment';
-import { IndividualEnrollmentRepository } from '../../../src/api/repositories/IndividualEnrollmentRepository';
+import { MoocletRewardsService } from '../../../src/api/services/MoocletRewardsService';
 import { MoocletExperimentRefRepository } from '../../../src/api/repositories/MoocletExperimentRefRepository';
-import { MetricService } from '../../../src/api/services/MetricService';
+import { IndividualEnrollmentRepository } from '../../../src/api/repositories/IndividualEnrollmentRepository';
 import { MoocletDataService } from '../../../src/api/services/MoocletDataService';
-import { MoocletRewardsService, ValidRewardMetricType } from '../../../src/api/services/MoocletRewardsService';
 import { UpgradeLogger } from '../../../src/lib/logger/UpgradeLogger';
-import { ILogInput, IMetricMetaData } from 'upgrade_types';
+import { MoocletExperimentRef } from '../../../src/api/models/MoocletExperimentRef';
+import { IndividualEnrollment } from '../../../src/api/models/IndividualEnrollment';
+import { Experiment } from '../../../src/api/models/Experiment';
+import { EXPERIMENT_STATE } from 'upgrade_types';
+import { BinaryRewardAllowedValue } from 'upgrade_types';
+import { RewardValidator } from '../../../src/api/controllers/validators/RewardValidator';
 import { RequestedExperimentUser } from '../../../src/api/controllers/validators/ExperimentUserValidator';
-
-// Mock dependencies
-jest.mock('../../../src/lib/logger/UpgradeLogger');
-jest.mock('../../../src/api/services/MetricService');
-jest.mock('../../../src/api/services/MoocletDataService');
+import { HttpError } from 'routing-controllers';
+import { configureLogger } from '../../utils/logger';
 
 describe('MoocletRewardsService', () => {
   let service: MoocletRewardsService;
   let mockLogger: jest.Mocked<UpgradeLogger>;
-  let mockMetricService: jest.Mocked<MetricService>;
   let mockMoocletDataService: jest.Mocked<MoocletDataService>;
   let mockMoocletExperimentRefRepository: jest.Mocked<MoocletExperimentRefRepository>;
   let mockIndividualEnrollmentRepository: jest.Mocked<IndividualEnrollmentRepository>;
 
+  const mockUser = {
+    id: 'user-123',
+    group: {},
+    workingGroup: {},
+  } as RequestedExperimentUser;
+
+  const mockExperiment: Partial<Experiment> = {
+    id: 'experiment-123',
+    state: EXPERIMENT_STATE.ENROLLING,
+  };
+
+  const mockMoocletExperimentRef: Partial<MoocletExperimentRef> = {
+    id: 'ref-123',
+    experimentId: 'experiment-123',
+    moocletId: 456,
+    outcomeVariableName: 'reward_variable',
+    experiment: mockExperiment as Experiment,
+    versionConditionMaps: [
+      {
+        experimentConditionId: 'condition-1',
+        moocletVersionId: 100,
+      } as any,
+      {
+        experimentConditionId: 'condition-2',
+        moocletVersionId: 200,
+      } as any,
+    ],
+  };
+
+  const mockEnrollment: Partial<IndividualEnrollment> = {
+    id: 'enrollment-123',
+    userId: 'user-123',
+    experimentId: 'experiment-123',
+    conditionId: 'condition-1',
+  };
+
+  beforeAll(() => {
+    configureLogger();
+  });
+
   beforeEach(() => {
-    mockLogger = new UpgradeLogger() as jest.Mocked<UpgradeLogger>;
-    mockMetricService = {
-      saveAllMetrics: jest.fn(),
+    mockLogger = {
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
     } as any;
+
     mockMoocletDataService = {
       postNewReward: jest.fn(),
     } as any;
+
     mockMoocletExperimentRefRepository = {
-      getRefsForActivelyEnrollingExperiments: jest.fn(),
+      findOne: jest.fn(),
+      findActivelyEnrollingMoocletExperimentsByContextSiteTarget: jest.fn(),
     } as any;
+
     mockIndividualEnrollmentRepository = {
       findEnrollments: jest.fn(),
     } as any;
 
     service = new MoocletRewardsService(
-      mockMoocletExperimentRefRepository,
-      mockIndividualEnrollmentRepository,
-      mockMetricService,
-      mockMoocletDataService
+      mockMoocletExperimentRefRepository as any,
+      mockIndividualEnrollmentRepository as any,
+      mockMoocletDataService as any
     );
   });
 
-  describe('#getRewardMetricQuery', () => {
-    it('should attach a reward metric query with correct parameters', () => {
-      const rewardMetricKey = 'test-metric';
-
-      const query = service.getRewardMetricQuery(rewardMetricKey);
-
-      expect(query).toMatchObject({
-        name: 'Success Rate',
-        query: {
-          operationType: 'percentage',
-          compareFn: '=',
-          compareValue: BinaryRewardMetricAllowedValue.SUCCESS,
-        },
-        metric: {
-          key: rewardMetricKey,
-        },
-      });
-    });
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
-  describe('#createAndSaveRewardMetric', () => {
-    it('should create and save a reward metric with correct parameters', async () => {
-      const rewardMetricKey = 'test-metric';
-      const context = 'test-context';
+  describe('sendReward', () => {
+    describe('successful reward sending', () => {
+      it('should successfully send reward when all criteria are met using experimentId', async () => {
+        const request: RewardValidator = {
+          experimentId: 'experiment-123',
+          rewardValue: BinaryRewardAllowedValue.SUCCESS,
+          context: undefined,
+          decisionPoint: undefined,
+        };
 
-      mockMetricService.saveAllMetrics.mockResolvedValue([]);
+        mockMoocletExperimentRefRepository.findOne.mockResolvedValue(mockMoocletExperimentRef as MoocletExperimentRef);
+        mockIndividualEnrollmentRepository.findEnrollments.mockResolvedValue([mockEnrollment as IndividualEnrollment]);
 
-      await service.createAndSaveRewardMetric(rewardMetricKey, context, mockLogger);
+        const result = await service.sendReward(mockUser, request, mockLogger as any);
 
-      expect(mockMetricService.saveAllMetrics).toHaveBeenCalledWith(
-        expect.arrayContaining([
-          expect.objectContaining({
-            metric: rewardMetricKey,
-            datatype: IMetricMetaData.CATEGORICAL,
-            allowedValues: [BinaryRewardMetricAllowedValue.SUCCESS, BinaryRewardMetricAllowedValue.FAILURE],
-          }),
-        ]),
-        [context],
-        mockLogger
-      );
-    });
-  });
+        expect(result.message).toBe('Reward sent to mooclet successfuly.');
+        expect(result.reward).toEqual({
+          variable: 'reward_variable',
+          value: 1,
+          mooclet: 456,
+          version: 100,
+          learner: 'user-123',
+        });
+        expect(mockMoocletDataService.postNewReward).toHaveBeenCalledTimes(1);
+        expect(mockLogger.info).toHaveBeenCalledTimes(1);
+      });
 
-  describe('#parseLogsAndSendPotentialRewards', () => {
-    const mockUser = { id: 'user-1' } as RequestedExperimentUser;
-    const mockLogs = [
-      {
-        metrics: {
-          attributes: {
-            'test-metric-1': BinaryRewardMetricAllowedValue.SUCCESS,
-            'test-metric-2': BinaryRewardMetricAllowedValue.FAILURE,
+      it('should successfully send reward using decision point when experimentId not provided', async () => {
+        const request: RewardValidator = {
+          experimentId: undefined,
+          rewardValue: BinaryRewardAllowedValue.FAILURE,
+          context: 'home',
+          decisionPoint: {
+            site: 'site-1',
+            target: 'target-1',
           },
-        },
-      },
-    ] as unknown as ILogInput[];
+        };
 
-    beforeEach(() => {
-      // Reset all mocks before each test
-      jest.clearAllMocks();
-    });
+        mockMoocletExperimentRefRepository.findActivelyEnrollingMoocletExperimentsByContextSiteTarget.mockResolvedValue(
+          [mockMoocletExperimentRef as MoocletExperimentRef]
+        );
+        mockIndividualEnrollmentRepository.findEnrollments.mockResolvedValue([mockEnrollment as IndividualEnrollment]);
 
-    it('should exit early when no valid reward metrics are found', async () => {
-      // Mock gatherValidRewardMetrics to return empty array
-      (service as any).gatherValidRewardMetrics = jest.fn().mockReturnValue([]);
+        const result = await service.sendReward(mockUser, request, mockLogger as any);
 
-      // Act
-      await service.parseLogsAndSendPotentialRewards(mockUser, mockLogs, mockLogger);
+        expect(result.message).toBe('Reward sent to mooclet successfuly.');
+        expect(result.reward.value).toBe(0); // FAILURE maps to 0
+        expect(mockMoocletDataService.postNewReward).toHaveBeenCalledTimes(1);
+      });
 
-      // Assert
-      expect((service as any).gatherValidRewardMetrics).toHaveBeenCalledWith(mockLogs);
-      expect(mockMoocletExperimentRefRepository.getRefsForActivelyEnrollingExperiments).not.toHaveBeenCalled();
-      expect(mockLogger.warn).not.toHaveBeenCalled();
-    });
+      it('should call postNewReward without awaiting (fire-and-forget)', async () => {
+        const request: RewardValidator = {
+          experimentId: 'experiment-123',
+          rewardValue: BinaryRewardAllowedValue.SUCCESS,
+          context: undefined,
+          decisionPoint: undefined,
+        };
 
-    it('should warn and exit when no active mooclet experiment refs are found', async () => {
-      // Mock required dependencies
-      (service as any).gatherValidRewardMetrics = jest
-        .fn()
-        .mockReturnValue([{ key: 'test-metric-1', value: BinaryRewardMetricAllowedValue.SUCCESS }]);
-      (service as any).getAllActiveMoocletExperimentRefs = jest.fn().mockResolvedValue([]);
+        mockMoocletExperimentRefRepository.findOne.mockResolvedValue(mockMoocletExperimentRef as MoocletExperimentRef);
+        mockIndividualEnrollmentRepository.findEnrollments.mockResolvedValue([mockEnrollment as IndividualEnrollment]);
 
-      // Act
-      await service.parseLogsAndSendPotentialRewards(mockUser, mockLogs, mockLogger);
+        await service.sendReward(mockUser, request, mockLogger as any);
 
-      // Assert
-      expect((service as any).gatherValidRewardMetrics).toHaveBeenCalledWith(mockLogs);
-      expect((service as any).getAllActiveMoocletExperimentRefs).toHaveBeenCalledWith(mockLogger);
-      expect(mockLogger.warn).toHaveBeenCalledWith({
-        message: 'No active mooclet experiment refs found',
-        user: mockUser,
+        // Verify postNewReward was called but not awaited
+        expect(mockMoocletDataService.postNewReward).toHaveBeenCalledTimes(1);
+      });
+
+      it('should map SUCCESS reward value to 1', async () => {
+        const request: RewardValidator = {
+          experimentId: 'experiment-123',
+          rewardValue: BinaryRewardAllowedValue.SUCCESS,
+          context: undefined,
+          decisionPoint: undefined,
+        };
+
+        mockMoocletExperimentRefRepository.findOne.mockResolvedValue(mockMoocletExperimentRef as MoocletExperimentRef);
+        mockIndividualEnrollmentRepository.findEnrollments.mockResolvedValue([mockEnrollment as IndividualEnrollment]);
+
+        const result = await service.sendReward(mockUser, request, mockLogger as any);
+
+        expect(result.reward.value).toBe(1);
+      });
+
+      it('should map FAILURE reward value to 0', async () => {
+        const request: RewardValidator = {
+          experimentId: 'experiment-123',
+          rewardValue: BinaryRewardAllowedValue.FAILURE,
+          context: undefined,
+          decisionPoint: undefined,
+        };
+
+        mockMoocletExperimentRefRepository.findOne.mockResolvedValue(mockMoocletExperimentRef as MoocletExperimentRef);
+        mockIndividualEnrollmentRepository.findEnrollments.mockResolvedValue([mockEnrollment as IndividualEnrollment]);
+
+        const result = await service.sendReward(mockUser, request, mockLogger as any);
+
+        expect(result.reward.value).toBe(0);
       });
     });
 
-    it('should warn and exit when no experiments match the logged reward keys', async () => {
-      // Mock required dependencies
-      const validMetrics = [{ key: 'test-metric-1', value: BinaryRewardMetricAllowedValue.SUCCESS }];
-      const activeRefs = [{ id: 'ref-1', rewardMetricKey: 'different-key' }] as MoocletExperimentRef[];
+    describe('mooclet experiment ref validation', () => {
+      it('should throw 409 when no mooclet ref found by experimentId', async () => {
+        const request: RewardValidator = {
+          experimentId: 'nonexistent-experiment',
+          rewardValue: BinaryRewardAllowedValue.SUCCESS,
+          context: undefined,
+          decisionPoint: undefined,
+        };
 
-      (service as any).gatherValidRewardMetrics = jest.fn().mockReturnValue(validMetrics);
-      (service as any).getAllActiveMoocletExperimentRefs = jest.fn().mockResolvedValue(activeRefs);
-      (service as any).findExperimentByRewardMetricKey = jest.fn().mockReturnValue([]);
+        mockMoocletExperimentRefRepository.findOne.mockResolvedValue(null);
 
-      // Act
-      await service.parseLogsAndSendPotentialRewards(mockUser, mockLogs, mockLogger);
+        await expect(service.sendReward(mockUser, request, mockLogger as any)).rejects.toThrow(HttpError);
 
-      // Assert
-      expect((service as any).findExperimentByRewardMetricKey).toHaveBeenCalledWith(activeRefs, validMetrics);
-      expect(mockLogger.warn).toHaveBeenCalledWith({
-        message: 'Reward metrics were logged, but no active experiments matched the rewardMetricKeys',
-        moocletExperimentRefs: activeRefs,
-        validSimpleMetricAttributes: validMetrics,
-      });
-    });
-
-    it('should process rewards when all conditions are met', async () => {
-      // Mock data
-      const validMetrics = [{ key: 'test-metric-1', value: BinaryRewardMetricAllowedValue.SUCCESS }];
-
-      const moocletRef = {
-        id: 'ref-1',
-        experimentId: 'exp-1',
-        moocletId: 123,
-        rewardMetricKey: 'test-metric-1',
-        outcomeVariableName: 'outcome-1',
-        versionConditionMaps: [{ experimentConditionId: 'condition-1', moocletVersionId: 456 }],
-      } as MoocletExperimentRef;
-
-      const activeRefs = [moocletRef];
-
-      const enrollments = [
-        {
-          id: 'enrollment-1',
-          conditionId: 'condition-1',
-          experimentId: 'exp-1',
-        },
-      ] as IndividualEnrollment[];
-
-      // Mock required methods
-      (service as any).gatherValidRewardMetrics = jest
-        .fn()
-        .mockReturnValue(validMetrics)
-        .mockName('gatherValidRewardMetrics');
-      (service as any).getAllActiveMoocletExperimentRefs = jest
-        .fn()
-        .mockResolvedValue(activeRefs)
-        .mockName('getAllActiveMoocletExperimentRefs');
-      (service as any).findExperimentByRewardMetricKey = jest
-        .fn()
-        .mockReturnValue([
-          { moocletExperimentRef: moocletRef, rewardMetricValue: BinaryRewardMetricAllowedValue.SUCCESS },
-        ])
-        .mockName('findExperimentByRewardMetricKey');
-      (service as any).getVersionIdByConditionId = jest.fn().mockReturnValue(456).mockName('getVersionIdByConditionId');
-      mockIndividualEnrollmentRepository.findEnrollments = jest
-        .fn()
-        .mockResolvedValue(enrollments)
-        .mockName('mockIndividualEnrollmentRepository.findEnrollments');
-
-      // Mock the BinaryRewardMetricValueMap
-      const mockRewardValue = 1;
-      BinaryRewardMetricValueMap[BinaryRewardMetricAllowedValue.SUCCESS] = mockRewardValue;
-
-      // Act
-      await service.parseLogsAndSendPotentialRewards(mockUser, mockLogs, mockLogger);
-
-      // Assert
-      expect((service as any).getVersionIdByConditionId).toHaveBeenCalledWith(enrollments[0], moocletRef, mockLogger);
-
-      expect(mockLogger.info).toHaveBeenCalledWith({
-        message: 'Sending reward to mooclet',
-        reward: {
-          variable: 'outcome-1',
-          value: mockRewardValue,
-          mooclet: 123,
-          version: 456,
-          learner: 'user-1',
-        },
-        user: mockUser,
+        try {
+          await service.sendReward(mockUser, request, mockLogger as any);
+        } catch (error) {
+          expect((error as HttpError).httpCode).toBe(409);
+          expect((error as Error).message).toContain('No active mooclet experiment ref found');
+        }
       });
 
-      expect(mockMoocletDataService.postNewReward).toHaveBeenCalledWith(
-        {
-          variable: 'outcome-1',
-          value: mockRewardValue,
-          mooclet: 123,
-          version: 456,
-          learner: 'user-1',
-        },
-        mockLogger
-      );
-    });
-
-    it('should handle errors during enrollment lookup', async () => {
-      // Mock data
-      const validMetrics = [{ key: 'test-metric-1', value: BinaryRewardMetricAllowedValue.SUCCESS }];
-
-      const moocletRef = {
-        id: 'ref-1',
-        experimentId: 'exp-1',
-        moocletId: 123,
-        rewardMetricKey: 'test-metric-1',
-        outcomeVariableName: 'outcome-1',
-      } as MoocletExperimentRef;
-
-      // Mock required methods
-      (service as any).gatherValidRewardMetrics = jest.fn().mockReturnValue(validMetrics);
-      (service as any).getAllActiveMoocletExperimentRefs = jest.fn().mockResolvedValue([moocletRef]);
-      (service as any).findExperimentByRewardMetricKey = jest
-        .fn()
-        .mockReturnValue([
-          { moocletExperimentRef: moocletRef, rewardMetricValue: BinaryRewardMetricAllowedValue.SUCCESS },
-        ]);
-      mockIndividualEnrollmentRepository.findEnrollments = jest
-        .fn()
-        .mockResolvedValue([])
-        .mockName('mockIndividualEnrollmentRepository.findEnrollments');
-
-      // Act
-      await service.parseLogsAndSendPotentialRewards(mockUser, mockLogs, mockLogger);
-
-      // Assert
-      expect(mockLogger.error).toHaveBeenCalledWith({
-        message: 'Could not find user enrollment for experiment.',
-        user: mockUser,
-        moocletExperimentRef: moocletRef,
-      });
-      expect(mockMoocletDataService.postNewReward).not.toHaveBeenCalled();
-    });
-
-    it('should handle errors during version ID lookup', async () => {
-      // Mock data
-      const validMetrics = [{ key: 'test-metric-1', value: BinaryRewardMetricAllowedValue.SUCCESS }];
-
-      const moocletRef = {
-        id: 'ref-1',
-        experimentId: 'exp-1',
-        moocletId: 123,
-        rewardMetricKey: 'test-metric-1',
-        outcomeVariableName: 'outcome-1',
-      } as MoocletExperimentRef;
-
-      const enrollments = [
-        {
-          id: 'enrollment-1',
-          conditionId: 'condition-1',
-          experimentId: 'exp-1',
-        },
-      ] as IndividualEnrollment[];
-
-      // Mock required methods
-      (service as any).gatherValidRewardMetrics = jest.fn().mockReturnValue(validMetrics);
-      (service as any).getAllActiveMoocletExperimentRefs = jest.fn().mockResolvedValue([moocletRef]);
-      (service as any).findExperimentByRewardMetricKey = jest
-        .fn()
-        .mockReturnValue([
-          { moocletExperimentRef: moocletRef, rewardMetricValue: BinaryRewardMetricAllowedValue.SUCCESS },
-        ]);
-      mockIndividualEnrollmentRepository.findEnrollments = jest
-        .fn()
-        .mockResolvedValue(enrollments)
-        .mockName('mockIndividualEnrollmentRepository.findEnrollments');
-      (service as any).getVersionIdByConditionId = jest.fn().mockReturnValue(null); // No version ID found
-
-      // Act
-      await service.parseLogsAndSendPotentialRewards(mockUser, mockLogs, mockLogger);
-
-      // Assert
-      expect(mockLogger.error).toHaveBeenCalledWith({
-        message: 'Could not find version id for user enrollment.',
-        enrollment: enrollments[0],
-        moocletExperimentRef: moocletRef,
-      });
-      expect(mockMoocletDataService.postNewReward).not.toHaveBeenCalled();
-    });
-
-    it('should handle unexpected errors during processing', async () => {
-      // Mock an unexpected error
-      const error = new Error('Unexpected error');
-      (service as any).gatherValidRewardMetrics = jest
-        .fn()
-        .mockReturnValue([{ key: 'test-metric-1', value: BinaryRewardMetricAllowedValue.SUCCESS }]);
-      (service as any).getAllActiveMoocletExperimentRefs = jest.fn().mockRejectedValue(error);
-
-      // Act
-      await service.parseLogsAndSendPotentialRewards(mockUser, mockLogs, mockLogger);
-
-      // Assert
-      expect(mockLogger.error).toHaveBeenCalledWith({
-        message: 'Failure processing and sending rewards',
-        error,
-        logs: mockLogs,
-      });
-    });
-  });
-
-  describe('#gatherValidRewardMetrics', () => {
-    it('should extract valid reward metrics from logs', () => {
-      // Arrange
-      const logs = [
-        {
-          metrics: {
-            attributes: {
-              'metric-1': BinaryRewardMetricAllowedValue.SUCCESS,
-              'metric-2': BinaryRewardMetricAllowedValue.FAILURE,
-              'metric-3': 'INVALID_VALUE',
-              'metric-4': 42,
-            },
+      it('should throw 409 when no mooclet ref found by decision point', async () => {
+        const request: RewardValidator = {
+          experimentId: undefined,
+          rewardValue: BinaryRewardAllowedValue.SUCCESS,
+          context: 'home',
+          decisionPoint: {
+            site: 'site-1',
+            target: 'target-1',
           },
-        },
-        {
-          metrics: {
-            attributes: {
-              'metric-5': BinaryRewardMetricAllowedValue.SUCCESS,
-              'metric-6': 'another-invalid-value',
-            },
-          },
-        },
-      ] as unknown as ILogInput[];
+        };
 
-      // Need to mock the isBinaryRewardMetricAllowedValue method
-      (service as any).isBinaryRewardMetricAllowedValue = jest
-        .fn()
-        .mockImplementation(
-          (value) =>
-            value === BinaryRewardMetricAllowedValue.SUCCESS || value === BinaryRewardMetricAllowedValue.FAILURE
+        mockMoocletExperimentRefRepository.findActivelyEnrollingMoocletExperimentsByContextSiteTarget.mockResolvedValue(
+          []
         );
 
-      // Act
-      const result = (service as any).gatherValidRewardMetrics(logs);
+        await expect(service.sendReward(mockUser, request, mockLogger as any)).rejects.toThrow(HttpError);
 
-      // Assert
-      expect(result).toEqual([
-        { key: 'metric-1', value: BinaryRewardMetricAllowedValue.SUCCESS },
-        { key: 'metric-2', value: BinaryRewardMetricAllowedValue.FAILURE },
-        { key: 'metric-5', value: BinaryRewardMetricAllowedValue.SUCCESS },
-      ]);
+        try {
+          await service.sendReward(mockUser, request, mockLogger as any);
+        } catch (error) {
+          expect((error as HttpError).httpCode).toBe(409);
+          expect((error as Error).message).toContain('No active experiment found for decision point');
+        }
+      });
 
-      // Verify the method was called correctly
-      expect((service as any).isBinaryRewardMetricAllowedValue).toHaveBeenCalledWith(
-        BinaryRewardMetricAllowedValue.SUCCESS
-      );
-      expect((service as any).isBinaryRewardMetricAllowedValue).toHaveBeenCalledWith(
-        BinaryRewardMetricAllowedValue.FAILURE
-      );
-      expect((service as any).isBinaryRewardMetricAllowedValue).toHaveBeenCalledWith('INVALID_VALUE');
-      expect((service as any).isBinaryRewardMetricAllowedValue).toHaveBeenCalledWith(42);
-    });
-
-    it('should return empty array when no valid metrics exist', () => {
-      // Arrange
-      const logs = [
-        {
-          metrics: {
-            attributes: {
-              'metric-1': 'INVALID',
-              'metric-2': 123,
-            },
+      it('should throw 409 when multiple mooclet refs found by decision point', async () => {
+        const request: RewardValidator = {
+          experimentId: undefined,
+          rewardValue: BinaryRewardAllowedValue.SUCCESS,
+          context: 'home',
+          decisionPoint: {
+            site: 'site-1',
+            target: 'target-1',
           },
-        },
-      ] as unknown as ILogInput[];
+        };
 
-      // Mock the validation method to always return false
-      (service as any).isBinaryRewardMetricAllowedValue = jest.fn().mockReturnValue(false);
+        mockMoocletExperimentRefRepository.findActivelyEnrollingMoocletExperimentsByContextSiteTarget.mockResolvedValue(
+          [
+            mockMoocletExperimentRef as MoocletExperimentRef,
+            { ...mockMoocletExperimentRef, id: 'ref-456' } as MoocletExperimentRef,
+          ]
+        );
 
-      // Act
-      const result = (service as any).gatherValidRewardMetrics(logs);
+        await expect(service.sendReward(mockUser, request, mockLogger as any)).rejects.toThrow(HttpError);
 
-      // Assert
-      expect(result).toEqual([]);
-    });
+        try {
+          await service.sendReward(mockUser, request, mockLogger as any);
+        } catch (error) {
+          expect((error as HttpError).httpCode).toBe(409);
+          expect((error as Error).message).toContain('Multiple active experiments found for decision point');
+        }
+      });
 
-    it('should handle empty logs array', () => {
-      // Arrange
-      const logs: ILogInput[] = [];
+      it('should throw 409 when experiment is not in ENROLLING state', async () => {
+        const request: RewardValidator = {
+          experimentId: 'experiment-123',
+          rewardValue: BinaryRewardAllowedValue.SUCCESS,
+          context: undefined,
+          decisionPoint: undefined,
+        };
 
-      // Act
-      const result = (service as any).gatherValidRewardMetrics(logs);
-
-      // Assert
-      expect(result).toEqual([]);
-    });
-
-    it('should handle logs with empty metrics attributes', () => {
-      // Arrange
-      const logs = [
-        {
-          metrics: {
-            attributes: {},
+        const nonEnrollingRef = {
+          ...mockMoocletExperimentRef,
+          experiment: {
+            ...mockExperiment,
+            state: EXPERIMENT_STATE.ENROLLMENT_COMPLETE,
           },
-        },
-      ] as ILogInput[];
+        };
 
-      // Act
-      const result = (service as any).gatherValidRewardMetrics(logs);
+        mockMoocletExperimentRefRepository.findOne.mockResolvedValue(nonEnrollingRef as MoocletExperimentRef);
 
-      // Assert
-      expect(result).toEqual([]);
+        await expect(service.sendReward(mockUser, request, mockLogger as any)).rejects.toThrow(HttpError);
+
+        try {
+          await service.sendReward(mockUser, request, mockLogger as any);
+        } catch (error) {
+          expect((error as HttpError).httpCode).toBe(409);
+          expect((error as Error).message).toContain('not actively enrolling');
+        }
+      });
     });
 
-    it('should process multiple valid metrics from a single log', () => {
-      // Arrange
-      const logs = [
-        {
-          metrics: {
-            attributes: {
-              'metric-1': BinaryRewardMetricAllowedValue.SUCCESS,
-              'metric-2': BinaryRewardMetricAllowedValue.FAILURE,
-              'metric-3': BinaryRewardMetricAllowedValue.SUCCESS,
-            },
-          },
-        },
-      ] as unknown as ILogInput[];
+    describe('user enrollment validation', () => {
+      it('should throw 409 when no enrollment found for user', async () => {
+        const request: RewardValidator = {
+          experimentId: 'experiment-123',
+          rewardValue: BinaryRewardAllowedValue.SUCCESS,
+          context: undefined,
+          decisionPoint: undefined,
+        };
 
-      // Mock the validation method to return true for all values
-      (service as any).isBinaryRewardMetricAllowedValue = jest.fn().mockReturnValue(true);
+        mockMoocletExperimentRefRepository.findOne.mockResolvedValue(mockMoocletExperimentRef as MoocletExperimentRef);
+        mockIndividualEnrollmentRepository.findEnrollments.mockResolvedValue([]);
 
-      // Act
-      const result = (service as any).gatherValidRewardMetrics(logs);
+        await expect(service.sendReward(mockUser, request, mockLogger as any)).rejects.toThrow(HttpError);
 
-      // Assert
-      expect(result).toEqual([
-        { key: 'metric-1', value: BinaryRewardMetricAllowedValue.SUCCESS },
-        { key: 'metric-2', value: BinaryRewardMetricAllowedValue.FAILURE },
-        { key: 'metric-3', value: BinaryRewardMetricAllowedValue.SUCCESS },
-      ]);
+        try {
+          await service.sendReward(mockUser, request, mockLogger as any);
+        } catch (error) {
+          expect((error as HttpError).httpCode).toBe(409);
+          expect((error as Error).message).toContain('Could not find unique user enrollment');
+        }
+      });
+
+      it('should throw 409 when multiple enrollments found for user', async () => {
+        const request: RewardValidator = {
+          experimentId: 'experiment-123',
+          rewardValue: BinaryRewardAllowedValue.SUCCESS,
+          context: undefined,
+          decisionPoint: undefined,
+        };
+
+        mockMoocletExperimentRefRepository.findOne.mockResolvedValue(mockMoocletExperimentRef as MoocletExperimentRef);
+        mockIndividualEnrollmentRepository.findEnrollments.mockResolvedValue([
+          mockEnrollment as IndividualEnrollment,
+          { ...mockEnrollment, id: 'enrollment-456' } as IndividualEnrollment,
+        ]);
+
+        await expect(service.sendReward(mockUser, request, mockLogger as any)).rejects.toThrow(HttpError);
+
+        try {
+          await service.sendReward(mockUser, request, mockLogger as any);
+        } catch (error) {
+          expect((error as HttpError).httpCode).toBe(409);
+          expect((error as Error).message).toContain('Could not find unique user enrollment');
+        }
+      });
+
+      it('should succeed when exactly one enrollment found', async () => {
+        const request: RewardValidator = {
+          experimentId: 'experiment-123',
+          rewardValue: BinaryRewardAllowedValue.SUCCESS,
+          context: undefined,
+          decisionPoint: undefined,
+        };
+
+        mockMoocletExperimentRefRepository.findOne.mockResolvedValue(mockMoocletExperimentRef as MoocletExperimentRef);
+        mockIndividualEnrollmentRepository.findEnrollments.mockResolvedValue([mockEnrollment as IndividualEnrollment]);
+
+        const result = await service.sendReward(mockUser, request, mockLogger as any);
+
+        expect(result.message).toBe('Reward sent to mooclet successfuly.');
+      });
+    });
+
+    describe('version mapping validation', () => {
+      it('should throw 409 when no version mapping found for enrolled condition', async () => {
+        const request: RewardValidator = {
+          experimentId: 'experiment-123',
+          rewardValue: BinaryRewardAllowedValue.SUCCESS,
+          context: undefined,
+          decisionPoint: undefined,
+        };
+
+        const enrollmentWithUnmappedCondition = {
+          ...mockEnrollment,
+          conditionId: 'unmapped-condition',
+        };
+
+        mockMoocletExperimentRefRepository.findOne.mockResolvedValue(mockMoocletExperimentRef as MoocletExperimentRef);
+        mockIndividualEnrollmentRepository.findEnrollments.mockResolvedValue([
+          enrollmentWithUnmappedCondition as IndividualEnrollment,
+        ]);
+
+        await expect(service.sendReward(mockUser, request, mockLogger as any)).rejects.toThrow(HttpError);
+
+        try {
+          await service.sendReward(mockUser, request, mockLogger as any);
+        } catch (error) {
+          expect((error as HttpError).httpCode).toBe(409);
+          expect((error as Error).message).toContain('Version-condtion mapping not found');
+        }
+      });
+
+      it('should find correct versionId for enrolled condition', async () => {
+        const request: RewardValidator = {
+          experimentId: 'experiment-123',
+          rewardValue: BinaryRewardAllowedValue.SUCCESS,
+          context: undefined,
+          decisionPoint: undefined,
+        };
+
+        const enrollmentCondition2 = {
+          ...mockEnrollment,
+          conditionId: 'condition-2',
+        };
+
+        mockMoocletExperimentRefRepository.findOne.mockResolvedValue(mockMoocletExperimentRef as MoocletExperimentRef);
+        mockIndividualEnrollmentRepository.findEnrollments.mockResolvedValue([
+          enrollmentCondition2 as IndividualEnrollment,
+        ]);
+
+        const result = await service.sendReward(mockUser, request, mockLogger as any);
+
+        expect(result.reward.version).toBe(200); // version for condition-2
+      });
+    });
+
+    describe('error handling', () => {
+      it('should wrap unexpected errors as 409 HttpError', async () => {
+        const request: RewardValidator = {
+          experimentId: 'experiment-123',
+          rewardValue: BinaryRewardAllowedValue.SUCCESS,
+          context: undefined,
+          decisionPoint: undefined,
+        };
+
+        mockMoocletExperimentRefRepository.findOne.mockRejectedValue(new Error('Database connection failed'));
+
+        await expect(service.sendReward(mockUser, request, mockLogger as any)).rejects.toThrow(HttpError);
+
+        try {
+          await service.sendReward(mockUser, request, mockLogger as any);
+        } catch (error) {
+          expect((error as HttpError).httpCode).toBe(409);
+          expect((error as Error).message).toContain('Failed to process reward request due to unexpected error');
+        }
+      });
+
+      it('should re-throw HttpErrors without wrapping', async () => {
+        const request: RewardValidator = {
+          experimentId: 'experiment-123',
+          rewardValue: BinaryRewardAllowedValue.SUCCESS,
+          context: undefined,
+          decisionPoint: undefined,
+        };
+
+        const originalError = new HttpError(404, 'Experiment not found');
+        mockMoocletExperimentRefRepository.findOne.mockRejectedValue(originalError);
+
+        await expect(service.sendReward(mockUser, request, mockLogger as any)).rejects.toThrow(originalError);
+      });
+
+      it('should log errors with appropriate context', async () => {
+        const request: RewardValidator = {
+          experimentId: 'experiment-123',
+          rewardValue: BinaryRewardAllowedValue.SUCCESS,
+          context: undefined,
+          decisionPoint: undefined,
+        };
+
+        mockMoocletExperimentRefRepository.findOne.mockResolvedValue(null);
+
+        try {
+          await service.sendReward(mockUser, request, mockLogger as any);
+        } catch (error) {
+          expect(mockLogger.error).toHaveBeenCalledTimes(1);
+          expect(mockLogger.error).toHaveBeenCalledWith(
+            expect.objectContaining({
+              message: expect.any(String),
+              request: expect.any(Object),
+            })
+          );
+        }
+      });
+    });
+
+    describe('reward payload construction', () => {
+      it('should construct reward with all required fields', async () => {
+        const request: RewardValidator = {
+          experimentId: 'experiment-123',
+          rewardValue: BinaryRewardAllowedValue.SUCCESS,
+          context: undefined,
+          decisionPoint: undefined,
+        };
+
+        mockMoocletExperimentRefRepository.findOne.mockResolvedValue(mockMoocletExperimentRef as MoocletExperimentRef);
+        mockIndividualEnrollmentRepository.findEnrollments.mockResolvedValue([mockEnrollment as IndividualEnrollment]);
+
+        const result = await service.sendReward(mockUser, request, mockLogger as any);
+
+        expect(result.reward).toHaveProperty('variable');
+        expect(result.reward).toHaveProperty('value');
+        expect(result.reward).toHaveProperty('mooclet');
+        expect(result.reward).toHaveProperty('version');
+        expect(result.reward).toHaveProperty('learner');
+      });
+
+      it('should use outcomeVariableName from mooclet ref', async () => {
+        const request: RewardValidator = {
+          experimentId: 'experiment-123',
+          rewardValue: BinaryRewardAllowedValue.SUCCESS,
+          context: undefined,
+          decisionPoint: undefined,
+        };
+
+        mockMoocletExperimentRefRepository.findOne.mockResolvedValue(mockMoocletExperimentRef as MoocletExperimentRef);
+        mockIndividualEnrollmentRepository.findEnrollments.mockResolvedValue([mockEnrollment as IndividualEnrollment]);
+
+        const result = await service.sendReward(mockUser, request, mockLogger as any);
+
+        expect(result.reward.variable).toBe('reward_variable');
+      });
+
+      it('should use moocletId from mooclet ref', async () => {
+        const request: RewardValidator = {
+          experimentId: 'experiment-123',
+          rewardValue: BinaryRewardAllowedValue.SUCCESS,
+          context: undefined,
+          decisionPoint: undefined,
+        };
+
+        mockMoocletExperimentRefRepository.findOne.mockResolvedValue(mockMoocletExperimentRef as MoocletExperimentRef);
+        mockIndividualEnrollmentRepository.findEnrollments.mockResolvedValue([mockEnrollment as IndividualEnrollment]);
+
+        const result = await service.sendReward(mockUser, request, mockLogger as any);
+
+        expect(result.reward.mooclet).toBe(456);
+      });
+
+      it('should use user id as learner', async () => {
+        const request: RewardValidator = {
+          experimentId: 'experiment-123',
+          rewardValue: BinaryRewardAllowedValue.SUCCESS,
+          context: undefined,
+          decisionPoint: undefined,
+        };
+
+        mockMoocletExperimentRefRepository.findOne.mockResolvedValue(mockMoocletExperimentRef as MoocletExperimentRef);
+        mockIndividualEnrollmentRepository.findEnrollments.mockResolvedValue([mockEnrollment as IndividualEnrollment]);
+
+        const result = await service.sendReward(mockUser, request, mockLogger as any);
+
+        expect(result.reward.learner).toBe('user-123');
+      });
     });
   });
 
-  describe('#isBinaryRewardMetricAllowedValue', () => {
-    it('should return true for SUCCESS value', () => {
-      // Arrange & Act
-      const result = (service as any).isBinaryRewardMetricAllowedValue(BinaryRewardMetricAllowedValue.SUCCESS);
+  describe('private helper methods', () => {
+    describe('findMoocletExperimentRefById', () => {
+      it('should return mooclet ref when found', async () => {
+        const request: RewardValidator = {
+          experimentId: 'experiment-123',
+          rewardValue: BinaryRewardAllowedValue.SUCCESS,
+          context: undefined,
+          decisionPoint: undefined,
+        };
 
-      // Assert
-      expect(result).toBe(true);
+        mockMoocletExperimentRefRepository.findOne.mockResolvedValue(mockMoocletExperimentRef as MoocletExperimentRef);
+        mockIndividualEnrollmentRepository.findEnrollments.mockResolvedValue([mockEnrollment as IndividualEnrollment]);
+
+        const result = await service.sendReward(mockUser, request, mockLogger as any);
+
+        expect(mockMoocletExperimentRefRepository.findOne).toHaveBeenCalledTimes(1);
+        expect(result.message).toBe('Reward sent to mooclet successfuly.');
+      });
+
+      it('should query with correct relations', async () => {
+        const request: RewardValidator = {
+          experimentId: 'experiment-123',
+          rewardValue: BinaryRewardAllowedValue.SUCCESS,
+          context: undefined,
+          decisionPoint: undefined,
+        };
+
+        mockMoocletExperimentRefRepository.findOne.mockResolvedValue(mockMoocletExperimentRef as MoocletExperimentRef);
+        mockIndividualEnrollmentRepository.findEnrollments.mockResolvedValue([mockEnrollment as IndividualEnrollment]);
+
+        await service.sendReward(mockUser, request, mockLogger as any);
+
+        expect(mockMoocletExperimentRefRepository.findOne).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: expect.objectContaining({ experimentId: 'experiment-123' }),
+            relations: expect.arrayContaining(['versionConditionMaps', 'experiment']),
+          })
+        );
+      });
     });
 
-    it('should return true for FAILURE value', () => {
-      // Arrange & Act
-      const result = (service as any).isBinaryRewardMetricAllowedValue(BinaryRewardMetricAllowedValue.FAILURE);
-
-      // Assert
-      expect(result).toBe(true);
-    });
-
-    it('should return false for non-allowed string values', () => {
-      // Arrange & Act
-      const result1 = (service as any).isBinaryRewardMetricAllowedValue('INVALID_VALUE');
-      const result2 = (service as any).isBinaryRewardMetricAllowedValue('success'); // case sensitive check
-      const result3 = (service as any).isBinaryRewardMetricAllowedValue('failure'); // case sensitive check
-
-      // Assert
-      expect(result1).toBe(false);
-      expect(result2).toBe(false);
-      expect(result3).toBe(false);
-    });
-
-    it('should return false for non-string values', () => {
-      // Arrange & Act
-      const result1 = (service as any).isBinaryRewardMetricAllowedValue(123);
-      const result2 = (service as any).isBinaryRewardMetricAllowedValue(null);
-      const result3 = (service as any).isBinaryRewardMetricAllowedValue(undefined);
-      const result4 = (service as any).isBinaryRewardMetricAllowedValue({});
-      const result5 = (service as any).isBinaryRewardMetricAllowedValue([]);
-      const result6 = (service as any).isBinaryRewardMetricAllowedValue(true);
-
-      // Assert
-      expect(result1).toBe(false);
-      expect(result2).toBe(false);
-      expect(result3).toBe(false);
-      expect(result4).toBe(false);
-      expect(result5).toBe(false);
-      expect(result6).toBe(false);
-    });
-
-    it('should handle Object.values behavior correctly', () => {
-      // This test verifies that the function behaves correctly depending on
-      // what Object.values returns for the enum
-
-      // Mock Object.values to return a specific array for testing
-      const originalObjectValues = Object.values;
-      Object.values = jest
-        .fn()
-        .mockReturnValue([BinaryRewardMetricAllowedValue.SUCCESS, BinaryRewardMetricAllowedValue.FAILURE]);
-
-      // Test with a valid value
-      const resultValid = (service as any).isBinaryRewardMetricAllowedValue(BinaryRewardMetricAllowedValue.SUCCESS);
-      expect(resultValid).toBe(true);
-
-      // Test with an invalid value
-      const resultInvalid = (service as any).isBinaryRewardMetricAllowedValue('SOMETHING_ELSE');
-      expect(resultInvalid).toBe(false);
-
-      // Verify Object.values was called with the correct parameter
-      expect(Object.values).toHaveBeenCalledWith(BinaryRewardMetricAllowedValue);
-
-      // Restore the original Object.values function
-      Object.values = originalObjectValues;
-    });
-  });
-
-  describe('#findExperimentByRewardMetricKey', () => {
-    it('should find matching mooclet experiment refs for reward metric keys', () => {
-      // Arrange
-      const moocletExperimentRefs = [
-        {
-          id: 'ref-1',
-          experimentId: 'exp-1',
-          moocletId: 1,
-          rewardMetricKey: 'metric-1',
-        },
-        {
-          id: 'ref-2',
-          experimentId: 'exp-2',
-          moocletId: 2,
-          rewardMetricKey: 'metric-2',
-        },
-        {
-          id: 'ref-3',
-          experimentId: 'exp-3',
-          moocletId: 3,
-          rewardMetricKey: 'metric-3',
-        },
-      ] as MoocletExperimentRef[];
-
-      const rewardMetricKeys = [
-        { key: 'metric-1', value: BinaryRewardMetricAllowedValue.SUCCESS },
-        { key: 'metric-3', value: BinaryRewardMetricAllowedValue.FAILURE },
-        { key: 'metric-4', value: BinaryRewardMetricAllowedValue.SUCCESS }, // No match
-      ];
-
-      // Act
-      const result = (service as any).findExperimentByRewardMetricKey(moocletExperimentRefs, rewardMetricKeys);
-
-      // Assert
-      expect(result).toEqual([
-        {
-          moocletExperimentRef: moocletExperimentRefs[0],
-          rewardMetricValue: BinaryRewardMetricAllowedValue.SUCCESS,
-        },
-        {
-          moocletExperimentRef: moocletExperimentRefs[2],
-          rewardMetricValue: BinaryRewardMetricAllowedValue.FAILURE,
-        },
-      ]);
-    });
-
-    it('should return empty array when no matches are found', () => {
-      // Arrange
-      const moocletExperimentRefs = [
-        {
-          id: 'ref-1',
-          experimentId: 'exp-1',
-          moocletId: 1,
-          rewardMetricKey: 'metric-1',
-        },
-      ] as MoocletExperimentRef[];
-
-      const rewardMetricKeys = [
-        { key: 'metric-2', value: BinaryRewardMetricAllowedValue.SUCCESS },
-        { key: 'metric-3', value: BinaryRewardMetricAllowedValue.FAILURE },
-      ];
-
-      // Act
-      const result = (service as any).findExperimentByRewardMetricKey(moocletExperimentRefs, rewardMetricKeys);
-
-      // Assert
-      expect(result).toEqual([]);
-    });
-
-    it('should handle empty moocletExperimentRefs array', () => {
-      // Arrange
-      const moocletExperimentRefs: MoocletExperimentRef[] = [];
-      const rewardMetricKeys = [{ key: 'metric-1', value: BinaryRewardMetricAllowedValue.SUCCESS }];
-
-      // Act
-      const result = (service as any).findExperimentByRewardMetricKey(moocletExperimentRefs, rewardMetricKeys);
-
-      // Assert
-      expect(result).toEqual([]);
-    });
-
-    it('should handle empty rewardMetricKeys array', () => {
-      // Arrange
-      const moocletExperimentRefs = [
-        {
-          id: 'ref-1',
-          experimentId: 'exp-1',
-          moocletId: 1,
-          rewardMetricKey: 'metric-1',
-        },
-      ] as MoocletExperimentRef[];
-      const rewardMetricKeys: ValidRewardMetricType[] = [];
-
-      // Act
-      const result = (service as any).findExperimentByRewardMetricKey(moocletExperimentRefs, rewardMetricKeys);
-
-      // Assert
-      expect(result).toEqual([]);
-    });
-
-    it('should find multiple matches for the same experiment ref', () => {
-      // Arrange
-      const moocletExperimentRefs = [
-        {
-          id: 'ref-1',
-          experimentId: 'exp-1',
-          moocletId: 1,
-          rewardMetricKey: 'metric-1',
-        },
-      ] as MoocletExperimentRef[];
-
-      const rewardMetricKeys = [
-        { key: 'metric-1', value: BinaryRewardMetricAllowedValue.SUCCESS },
-        { key: 'metric-1', value: BinaryRewardMetricAllowedValue.FAILURE },
-      ];
-
-      // Act
-      const result = (service as any).findExperimentByRewardMetricKey(moocletExperimentRefs, rewardMetricKeys);
-
-      // Assert
-      expect(result).toEqual([
-        {
-          moocletExperimentRef: moocletExperimentRefs[0],
-          rewardMetricValue: BinaryRewardMetricAllowedValue.SUCCESS,
-        },
-        {
-          moocletExperimentRef: moocletExperimentRefs[0],
-          rewardMetricValue: BinaryRewardMetricAllowedValue.FAILURE,
-        },
-      ]);
-    });
-
-    it('should handle case sensitivity in metric keys', () => {
-      // Arrange
-      const moocletExperimentRefs = [
-        {
-          id: 'ref-1',
-          experimentId: 'exp-1',
-          moocletId: 1,
-          rewardMetricKey: 'Metric-1',
-        },
-      ] as MoocletExperimentRef[];
-
-      const rewardMetricKeys = [
-        { key: 'metric-1', value: BinaryRewardMetricAllowedValue.SUCCESS }, // Different case
-      ];
-
-      // Act
-      const result = (service as any).findExperimentByRewardMetricKey(moocletExperimentRefs, rewardMetricKeys);
-
-      // Assert
-      expect(result).toEqual([]);
-    });
-  });
-
-  describe('#getVersionIdByConditionId', () => {
-    it('should return the mooclet version ID when a matching condition is found', () => {
-      // Arrange
-      const enrollment = {
-        id: 'enrollment-1',
-        conditionId: 'condition-1',
-        condition: {
-          id: 'condition-1',
-          name: 'Control',
-        },
-      } as IndividualEnrollment;
-
-      const moocletExperimentRef = {
-        id: 'ref-1',
-        versionConditionMaps: [
-          {
-            experimentConditionId: 'condition-2',
-            moocletVersionId: 2,
+    describe('findMoocletExperimentRefByDecisionPoint', () => {
+      it('should use context, site, and target to find experiment', async () => {
+        const request: RewardValidator = {
+          experimentId: undefined,
+          rewardValue: BinaryRewardAllowedValue.SUCCESS,
+          context: 'home',
+          decisionPoint: {
+            site: 'site-1',
+            target: 'target-1',
           },
-          {
-            experimentConditionId: 'condition-1',
-            moocletVersionId: 1,
-          },
-          {
-            experimentConditionId: 'condition-3',
-            moocletVersionId: 3,
-          },
-        ],
-      } as MoocletExperimentRef;
+        };
 
-      // Act
-      const result = (service as any).getVersionIdByConditionId(enrollment, moocletExperimentRef, mockLogger);
+        mockMoocletExperimentRefRepository.findActivelyEnrollingMoocletExperimentsByContextSiteTarget.mockResolvedValue(
+          [mockMoocletExperimentRef as MoocletExperimentRef]
+        );
+        mockIndividualEnrollmentRepository.findEnrollments.mockResolvedValue([mockEnrollment as IndividualEnrollment]);
 
-      // Assert
-      expect(result).toBe(1);
-      expect(mockLogger.error).not.toHaveBeenCalled();
+        await service.sendReward(mockUser, request, mockLogger as any);
+
+        expect(
+          mockMoocletExperimentRefRepository.findActivelyEnrollingMoocletExperimentsByContextSiteTarget
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          mockMoocletExperimentRefRepository.findActivelyEnrollingMoocletExperimentsByContextSiteTarget
+        ).toHaveBeenCalledWith('home', 'site-1', 'target-1');
+      });
     });
 
-    it('should return null when no matching condition is found', () => {
-      // Arrange
-      const enrollment = {
-        id: 'enrollment-1',
-        conditionId: 'condition-4', // Not in the maps
-        condition: {
-          id: 'condition-4', // Not in the maps
-          name: 'Unknown',
-        },
-      } as IndividualEnrollment;
+    describe('getVersionIdByConditionId', () => {
+      it('should return mooclet version ID when matching condition is found', async () => {
+        const request: RewardValidator = {
+          experimentId: 'experiment-123',
+          rewardValue: BinaryRewardAllowedValue.SUCCESS,
+          context: undefined,
+          decisionPoint: undefined,
+        };
 
-      const moocletExperimentRef = {
-        id: 'ref-1',
-        versionConditionMaps: [
-          {
-            experimentConditionId: 'condition-1',
-            moocletVersionId: 1,
-          },
-          {
-            experimentConditionId: 'condition-2',
-            moocletVersionId: 2,
-          },
-        ],
-      } as MoocletExperimentRef;
+        mockMoocletExperimentRefRepository.findOne.mockResolvedValue(mockMoocletExperimentRef as MoocletExperimentRef);
+        mockIndividualEnrollmentRepository.findEnrollments.mockResolvedValue([mockEnrollment as IndividualEnrollment]);
 
-      // Act
-      const result = (service as any).getVersionIdByConditionId(enrollment, moocletExperimentRef, mockLogger);
+        const result = await service.sendReward(mockUser, request, mockLogger as any);
 
-      // Assert
-      expect(result).toBeNull();
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: 'Could not find a version for the user enrollment.',
-          versionConditionMaps: moocletExperimentRef.versionConditionMaps,
-        })
-      );
-    });
+        expect(result.reward.version).toBe(100); // version for condition-1
+      });
 
-    it('should return null when enrollment condition is undefined', () => {
-      // Arrange
-      const enrollment = {
-        id: 'enrollment-1',
-        condition: undefined, // No condition
-      } as IndividualEnrollment;
+      it('should throw 409 when no matching condition found', async () => {
+        const request: RewardValidator = {
+          experimentId: 'experiment-123',
+          rewardValue: BinaryRewardAllowedValue.SUCCESS,
+          context: undefined,
+          decisionPoint: undefined,
+        };
 
-      const moocletExperimentRef = {
-        id: 'ref-1',
-        versionConditionMaps: [
-          {
-            experimentConditionId: 'condition-1',
-            moocletVersionId: 1,
-          },
-        ],
-      } as MoocletExperimentRef;
+        const unmappedEnrollment = {
+          ...mockEnrollment,
+          conditionId: 'unmapped-condition',
+        };
 
-      // Act
-      const result = (service as any).getVersionIdByConditionId(enrollment, moocletExperimentRef, mockLogger);
+        mockMoocletExperimentRefRepository.findOne.mockResolvedValue(mockMoocletExperimentRef as MoocletExperimentRef);
+        mockIndividualEnrollmentRepository.findEnrollments.mockResolvedValue([
+          unmappedEnrollment as IndividualEnrollment,
+        ]);
 
-      // Assert
-      expect(result).toBeNull();
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: 'Could not find a version for the user enrollment.',
-          versionConditionMaps: moocletExperimentRef.versionConditionMaps,
-        })
-      );
-    });
+        await expect(service.sendReward(mockUser, request, mockLogger as any)).rejects.toThrow(HttpError);
 
-    it('should return null when versionConditionMaps is empty', () => {
-      // Arrange
-      const enrollment = {
-        id: 'enrollment-1',
-        conditionId: 'condition-1',
-        condition: {
-          id: 'condition-1',
-          name: 'Control',
-        },
-      } as IndividualEnrollment;
+        try {
+          await service.sendReward(mockUser, request, mockLogger as any);
+        } catch (error) {
+          expect((error as HttpError).httpCode).toBe(409);
+        }
+      });
 
-      const moocletExperimentRef = {
-        id: 'ref-1',
-        versionConditionMaps: [], // Empty maps
-      } as MoocletExperimentRef;
+      it('should correctly match when multiple maps exist', async () => {
+        const request: RewardValidator = {
+          experimentId: 'experiment-123',
+          rewardValue: BinaryRewardAllowedValue.SUCCESS,
+          context: undefined,
+          decisionPoint: undefined,
+        };
 
-      // Act
-      const result = (service as any).getVersionIdByConditionId(enrollment, moocletExperimentRef, mockLogger);
+        const refWithMultipleMaps = {
+          ...mockMoocletExperimentRef,
+          versionConditionMaps: [
+            { experimentConditionId: 'condition-1', moocletVersionId: 100 },
+            { experimentConditionId: 'condition-2', moocletVersionId: 200 },
+            { experimentConditionId: 'condition-3', moocletVersionId: 300 },
+          ],
+        };
 
-      // Assert
-      expect(result).toBeNull();
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: 'Could not find a version for the user enrollment.',
+        const enrollmentCondition3 = {
+          ...mockEnrollment,
+          conditionId: 'condition-3',
+        };
+
+        mockMoocletExperimentRefRepository.findOne.mockResolvedValue(refWithMultipleMaps as any);
+        mockIndividualEnrollmentRepository.findEnrollments.mockResolvedValue([
+          enrollmentCondition3 as IndividualEnrollment,
+        ]);
+
+        const result = await service.sendReward(mockUser, request, mockLogger as any);
+
+        expect(result.reward.version).toBe(300);
+      });
+
+      it('should throw 409 when versionConditionMaps is empty', async () => {
+        const request: RewardValidator = {
+          experimentId: 'experiment-123',
+          rewardValue: BinaryRewardAllowedValue.SUCCESS,
+          context: undefined,
+          decisionPoint: undefined,
+        };
+
+        const refWithEmptyMaps = {
+          ...mockMoocletExperimentRef,
           versionConditionMaps: [],
-        })
-      );
-    });
+        };
 
-    it('should correctly match when multiple maps exist', () => {
-      // Arrange
-      const enrollment = {
-        id: 'enrollment-1',
-        conditionId: 'condition-3',
-        condition: {
-          id: 'condition-3',
-          name: 'Treatment B',
-        },
-      } as IndividualEnrollment;
+        mockMoocletExperimentRefRepository.findOne.mockResolvedValue(refWithEmptyMaps as any);
+        mockIndividualEnrollmentRepository.findEnrollments.mockResolvedValue([mockEnrollment as IndividualEnrollment]);
 
-      const moocletExperimentRef = {
-        id: 'ref-1',
-        versionConditionMaps: [
-          {
-            experimentConditionId: 'condition-1',
-            moocletVersionId: 1,
-          },
-          {
-            experimentConditionId: 'condition-2',
-            moocletVersionId: 2,
-          },
-          {
-            experimentConditionId: 'condition-3',
-            moocletVersionId: 3,
-          },
-        ],
-      } as MoocletExperimentRef;
+        await expect(service.sendReward(mockUser, request, mockLogger as any)).rejects.toThrow(HttpError);
 
-      // Act
-      const result = (service as any).getVersionIdByConditionId(enrollment, moocletExperimentRef, mockLogger);
-
-      // Assert
-      expect(result).toBe(3);
-      expect(mockLogger.error).not.toHaveBeenCalled();
+        try {
+          await service.sendReward(mockUser, request, mockLogger as any);
+        } catch (error) {
+          expect((error as HttpError).httpCode).toBe(409);
+        }
+      });
     });
   });
 });

--- a/backend/packages/Upgrade/test/unit/services/MoocletRewardsService.test.ts
+++ b/backend/packages/Upgrade/test/unit/services/MoocletRewardsService.test.ts
@@ -107,7 +107,7 @@ describe('MoocletRewardsService', () => {
 
         const result = await service.sendReward(mockUser, request, mockLogger as any);
 
-        expect(result.message).toBe('Reward sent to mooclet successfuly.');
+        expect(result.message).toBe('Reward sent to mooclet successfully.');
         expect(result.reward).toEqual({
           variable: 'reward_variable',
           value: 1,
@@ -137,7 +137,7 @@ describe('MoocletRewardsService', () => {
 
         const result = await service.sendReward(mockUser, request, mockLogger as any);
 
-        expect(result.message).toBe('Reward sent to mooclet successfuly.');
+        expect(result.message).toBe('Reward sent to mooclet successfully.');
         expect(result.reward.value).toBe(0); // FAILURE maps to 0
         expect(mockMoocletDataService.postNewReward).toHaveBeenCalledTimes(1);
       });
@@ -209,7 +209,7 @@ describe('MoocletRewardsService', () => {
           await service.sendReward(mockUser, request, mockLogger as any);
         } catch (error) {
           expect((error as HttpError).httpCode).toBe(409);
-          expect((error as Error).message).toContain('No active mooclet experiment ref found');
+          expect((error as HttpError).message).toContain('No active mooclet experiment ref found');
         }
       });
 
@@ -234,7 +234,7 @@ describe('MoocletRewardsService', () => {
           await service.sendReward(mockUser, request, mockLogger as any);
         } catch (error) {
           expect((error as HttpError).httpCode).toBe(409);
-          expect((error as Error).message).toContain('No active experiment found for decision point');
+          expect((error as HttpError).message).toContain('No active experiment found for decision point');
         }
       });
 
@@ -262,7 +262,7 @@ describe('MoocletRewardsService', () => {
           await service.sendReward(mockUser, request, mockLogger as any);
         } catch (error) {
           expect((error as HttpError).httpCode).toBe(409);
-          expect((error as Error).message).toContain('Multiple active experiments found for decision point');
+          expect((error as HttpError).message).toContain('Multiple active experiments found for decision point');
         }
       });
 
@@ -290,7 +290,7 @@ describe('MoocletRewardsService', () => {
           await service.sendReward(mockUser, request, mockLogger as any);
         } catch (error) {
           expect((error as HttpError).httpCode).toBe(409);
-          expect((error as Error).message).toContain('not actively enrolling');
+          expect((error as HttpError).message).toContain('not actively enrolling');
         }
       });
     });
@@ -337,7 +337,7 @@ describe('MoocletRewardsService', () => {
           await service.sendReward(mockUser, request, mockLogger as any);
         } catch (error) {
           expect((error as HttpError).httpCode).toBe(409);
-          expect((error as Error).message).toContain('Could not find unique user enrollment');
+          expect((error as HttpError).message).toContain('Could not find unique user enrollment');
         }
       });
 
@@ -354,7 +354,7 @@ describe('MoocletRewardsService', () => {
 
         const result = await service.sendReward(mockUser, request, mockLogger as any);
 
-        expect(result.message).toBe('Reward sent to mooclet successfuly.');
+        expect(result.message).toBe('Reward sent to mooclet successfully.');
       });
     });
 
@@ -383,7 +383,7 @@ describe('MoocletRewardsService', () => {
           await service.sendReward(mockUser, request, mockLogger as any);
         } catch (error) {
           expect((error as HttpError).httpCode).toBe(409);
-          expect((error as Error).message).toContain('Version-condtion mapping not found');
+          expect((error as HttpError).message).toContain('Version-condition mapping not found');
         }
       });
 
@@ -428,7 +428,7 @@ describe('MoocletRewardsService', () => {
           await service.sendReward(mockUser, request, mockLogger as any);
         } catch (error) {
           expect((error as HttpError).httpCode).toBe(409);
-          expect((error as Error).message).toContain('Failed to process reward request due to unexpected error');
+          expect((error as HttpError).message).toContain('Failed to process reward request due to unexpected error');
         }
       });
 
@@ -557,7 +557,7 @@ describe('MoocletRewardsService', () => {
         const result = await service.sendReward(mockUser, request, mockLogger as any);
 
         expect(mockMoocletExperimentRefRepository.findOne).toHaveBeenCalledTimes(1);
-        expect(result.message).toBe('Reward sent to mooclet successfuly.');
+        expect(result.message).toBe('Reward sent to mooclet successfully.');
       });
 
       it('should query with correct relations', async () => {

--- a/clientlibs/.gitignore
+++ b/clientlibs/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 dist/
+index.d.ts

--- a/clientlibs/js/package-lock.json
+++ b/clientlibs/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "upgrade_client_lib",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "upgrade_client_lib",
-      "version": "6.2.1",
+      "version": "6.2.2",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.4.0",

--- a/clientlibs/js/package.json
+++ b/clientlibs/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upgrade_client_lib",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "description": "Client library to communicate with the Upgrade server",
   "files": [
     "dist/*",

--- a/clientlibs/js/package.json
+++ b/clientlibs/js/package.json
@@ -3,7 +3,8 @@
   "version": "6.2.2",
   "description": "Client library to communicate with the Upgrade server",
   "files": [
-    "dist/*"
+    "dist/*",
+    "index.d.ts"
   ],
   "exports": {
     ".": {
@@ -11,7 +12,7 @@
       "browser-lite": "./dist/browser-lite/index.js",
       "node": "./dist/node/index.js",
       "node-lite": "./dist/node-lite/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./index.d.ts"
     },
     "./dist/browser": {
       "default": "./dist/browser/index.js",
@@ -33,7 +34,7 @@
   "scripts": {
     "build:bundler": "webpack",
     "build:types": "concurrently \"npm:build:types-*\"",
-    "build:types-default": "./node_modules/.bin/dts-bundle-generator -o dist/index.d.ts src/index.ts",
+    "build:types-default": "./node_modules/.bin/dts-bundle-generator -o ./index.d.ts src/index.ts",
     "build:types-browser": "./node_modules/.bin/dts-bundle-generator -o dist/browser/index.d.ts src/index.ts",
     "build:types-node": "./node_modules/.bin/dts-bundle-generator -o dist/node/index.d.ts src/index.ts",
     "build:types-browser-lite": "./node_modules/.bin/dts-bundle-generator -o dist/browser-lite/index.d.ts src/index.ts",

--- a/clientlibs/js/package.json
+++ b/clientlibs/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upgrade_client_lib",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "description": "Client library to communicate with the Upgrade server",
   "files": [
     "dist/*"

--- a/clientlibs/js/package.json
+++ b/clientlibs/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upgrade_client_lib",
-  "version": "6.2.3",
+  "version": "6.2.4",
   "description": "Client library to communicate with the Upgrade server",
   "files": [
     "dist/*",

--- a/clientlibs/js/quickTest.ts
+++ b/clientlibs/js/quickTest.ts
@@ -1,16 +1,7 @@
 // to run: npx ts-node clientlibs/js/quickTest.ts
 
+import { AxiosError } from 'axios';
 import UpgradeClient, { MARKED_DECISION_POINT_STATUS, UpGradeClientInterfaces } from './dist/node';
-import {
-  ASSIGNMENT_ALGORITHM,
-  ASSIGNMENT_UNIT,
-  CONSISTENCY_RULE,
-  EXPERIMENT_STATE,
-  EXPERIMENT_TYPE,
-  FILTER_MODE,
-  MoocletTSConfigurablePolicyParametersDTO,
-  POST_EXPERIMENT_RULE,
-} from '../../types';
 
 const URL = {
   LOCAL: 'http://localhost:3030',
@@ -20,7 +11,7 @@ const URL = {
   ECS_STAGING: 'https://apps.qa-cli.com/upgrade-service',
 };
 
-const userId = 'qwerty6';
+const userId = 'quicktest_user_' + new Date().getTime();
 const useEphemeralGroups = false;
 const group = { classId: ['STORED_USER_GROUP'] };
 const workingGroup = 'STORED_USER_GROUP';
@@ -33,101 +24,13 @@ const site = 'asdf';
 const target = 'fssfs';
 const status = MARKED_DECISION_POINT_STATUS.CONDITION_APPLIED;
 const featureFlagKey = 'TEST_FEATURE_FLAG';
+
+// reward testing variables ----- //
 const experimentId = 'f9c3927c-b786-45f5-a96c-dd9262e3b4b6'; // needed for reward testing
-const rewardSite = site;
-const rewardTarget = target;
-
-// Experiment creation variables - modify these to create different types of experiments
-// const experimentConfig = {
-//   name: 'Quick Test Experiment ' + Date.now(),
-//   description: 'A test experiment created via quickTest.ts',
-//   context: [context],
-//   state: EXPERIMENT_STATE.ENROLLING,
-//   startOn: null, // ISO date string or null
-//   endOn: null, // ISO date string or null
-//   consistencyRule: CONSISTENCY_RULE.INDIVIDUAL, // 'individual', 'experiment', 'group'
-//   assignmentUnit: ASSIGNMENT_UNIT.INDIVIDUAL, // 'individual', 'group', 'within-subjects'
-//   postExperimentRule: POST_EXPERIMENT_RULE.CONTINUE,
-//   assignmentAlgorithm: ASSIGNMENT_ALGORITHM.MOOCLET_TS_CONFIGURABLE,
-//   enrollmentCompleteCondition: null, // { userCount: 100, groupCount: 20 } or null
-//   revertTo: null, // condition id to revert to, or null
-//   tags: ['quicktest', 'automated'],
-//   group: null, // group key if assignmentUnit is 'group', otherwise null
-//   conditionOrder: null, // 'random', 'ordered_round_robin', 'ordered_sequential' (only for within-subjects)
-//   filterMode: FILTER_MODE.INCLUDE_ALL, // 'includeAll', 'excludeAll'
-//   stratificationFactor: null, // { stratificationFactorName: 'gender' } or null
-//   type: EXPERIMENT_TYPE.SIMPLE, // 'Simple', 'Factorial'
-
-//   // Conditions - at least one required
-//   conditions: [
-//     {
-//       id: 'control' + Date.now(),
-//       name: 'control',
-//       description: 'Control condition',
-//       conditionCode: 'control',
-//       assignmentWeight: 50,
-//       order: 1,
-//     },
-//     {
-//       id: 'variant' + Date.now(),
-//       name: 'variant',
-//       description: 'Treatment condition',
-//       conditionCode: 'variant',
-//       assignmentWeight: 50,
-//       order: 2,
-//     },
-//   ],
-
-//   // Factors - only for factorial experiments
-//   factors: [],
-
-//   // Partitions (decision points) - at least one required
-//   partitions: [
-//     {
-//       id: 'partition_1_' + Date.now(),
-//       twoCharacterId: 'P1',
-//       site: site,
-//       target: target,
-//       description: 'Test decision point',
-//       order: 1,
-//       excludeIfReached: false,
-//     },
-//   ],
-
-//   // Queries - optional, for analytics
-//   queries: [],
-
-//   conditionPayloads: [],
-
-//   // Segment inclusion - required
-//   experimentSegmentInclusion: {
-//     segment: {
-//       type: 'public', // 'public', 'private'
-//       name: null,
-//       description: null,
-//       context: null,
-//       individualForSegment: [],
-//       groupForSegment: [],
-//       subSegments: [],
-//     },
-//   },
-
-//   // Segment exclusion - required
-//   experimentSegmentExclusion: {
-//     segment: {
-//       type: 'public', // 'public', 'private'
-//       name: null,
-//       description: null,
-//       context: null,
-//       individualForSegment: [],
-//       groupForSegment: [],
-//       subSegments: [],
-//     },
-//   },
-
-//   // Mooclet policy parameters - only for adaptive experiments
-//   // moocletPolicyParameters: new MoocletTSConfigurablePolicyParametersDTO(),
-// };
+const rewardSite = site; // if using decision point for reward
+const rewardTarget = target; // if using decision point for reward
+const rewardValue = 'SUCCESS'; // or 'FAILURE' or use an UpgradeClient.BINARY_REWARD_VALUE enum
+// ---------------------------- //
 
 const options: UpGradeClientInterfaces.IConfigOptions = {
   featureFlagUserGroupsForSession: useEphemeralGroups
@@ -174,18 +77,14 @@ quickTest();
 
 /** main test *******************************************************************************/
 async function quickTest() {
-  // Create experiment first (optional - uncomment to test)
-  // const createdExperimentId = await doCreateExperiment();
-
   const client = new UpgradeClient(userId, hostUrl, context, options);
   await doInit(client);
-  // await doGroupMembership(client);
-  // await doWorkingGroupMembership(client);
-  // await doAliases(client);
-  await doAssign(client);
+  await doGroupMembership(client);
+  await doWorkingGroupMembership(client);
+  await doAliases(client);
+  // await doAssign(client);
   // await doAssignIgnoreCache(client);
   // await doAssign(client);
-
   const condition = await doGetDecisionPointAssignment(client);
   // doSetFeatureFlagUserGroupsForSession(client, options);
   // await doFeatureFlags(client);
@@ -193,12 +92,8 @@ async function quickTest() {
   // await doHasFeatureFlag(client);
   // await doHasFeatureFlag(client);
   await doMark(client, condition);
-
   // Use the created experiment ID for reward testing (optional)
-  if (experimentId) {
-    // await doSendRewardByExperimentId(client);
-    // await doSendRewardWithEnum(client);
-  }
+  // await doSendRewardByExperimentId(client);
   await doSendRewardByDecisionPoint(client);
   // await doLog(client);
 }
@@ -210,7 +105,7 @@ async function doInit(client: UpgradeClient) {
     const response = await client.init();
     console.log('\n[Init response]:', JSON.stringify(response));
   } catch (error) {
-    console.error('\n[Init error]:', error);
+    logAxiosError('Init', error);
   }
 }
 
@@ -221,7 +116,7 @@ async function doGroupMembership(client: UpgradeClient) {
     const response = await client.setGroupMembership(groupRequest);
     console.log('\n[Group response]:', JSON.stringify(response));
   } catch (error) {
-    console.error('\n[Group error]:', error);
+    logAxiosError('Group', error);
   }
 }
 
@@ -231,7 +126,7 @@ async function doWorkingGroupMembership(client: UpgradeClient) {
     const response = await client.setWorkingGroup(workingGroupRequest);
     console.log('\n[Working Group response]:', JSON.stringify(response));
   } catch (error) {
-    console.error('\n[Working Group error]:', error);
+    logAxiosError('Working Group', error);
   }
 }
 
@@ -241,7 +136,7 @@ async function doAliases(client: UpgradeClient) {
     const response = await client.setAltUserIds(aliasRequest);
     console.log('\n[Aliases response]:', JSON.stringify(response));
   } catch (error) {
-    console.error('\n[Aliases error]:', error);
+    logAxiosError('Aliases', error);
   }
 }
 
@@ -250,7 +145,7 @@ async function doAssign(client: UpgradeClient) {
     const response = await client.getAllExperimentConditions();
     console.log('\n[Assign response]:', JSON.stringify(response));
   } catch (error) {
-    console.error('\n[Assign error]:', error);
+    logAxiosError('Assign', error);
   }
 }
 
@@ -259,7 +154,7 @@ async function doAssignIgnoreCache(client: UpgradeClient) {
     const response = await client.getAllExperimentConditions({ ignoreCache: true });
     console.log('\n[Assign response]:', JSON.stringify(response));
   } catch (error) {
-    console.error('\n[Assign error]:', error);
+    logAxiosError('Assign', error);
   }
 }
 
@@ -281,7 +176,7 @@ async function doGetDecisionPointAssignment(client: UpgradeClient): Promise<stri
     console.log('\n[payloadValue]:', JSON.stringify(payloadValue));
     return condition;
   } catch (error) {
-    console.error('\n[Decision Point Assignment error]:', error);
+    logAxiosError('Decision Point Assignment', error);
     return null;
   }
 }
@@ -299,7 +194,7 @@ async function doFeatureFlags(client: UpgradeClient) {
     const response = await client.getAllFeatureFlags();
     console.log('\n[Feature Flag response]:', JSON.stringify(response));
   } catch (error) {
-    console.error('\n[Feature Flag error]:', error);
+    logAxiosError('Feature Flag', error);
   }
 }
 
@@ -308,7 +203,7 @@ async function doFeatureFlagsIgnoreCache(client: UpgradeClient) {
     const response = await client.getAllFeatureFlags({ ignoreCache: true });
     console.log('\n[Feature Flag response]:', JSON.stringify(response));
   } catch (error) {
-    console.error('\n[Feature Flag error]:', error);
+    logAxiosError('Feature Flag', error);
   }
 }
 
@@ -317,7 +212,7 @@ async function doHasFeatureFlag(client: UpgradeClient) {
     const response = await client.hasFeatureFlag(featureFlagKey);
     console.log('\n[Has Feature Flag response]:', response);
   } catch (error) {
-    console.error('\n[Has Feature Flag error]:', error);
+    logAxiosError('Has Feature Flag', error);
   }
 }
 
@@ -326,7 +221,7 @@ async function doMark(client: UpgradeClient, condition: string | null) {
     const response = await client.markDecisionPoint(site, target, condition, status);
     console.log('\n[Mark response]:', JSON.stringify(response));
   } catch (error) {
-    console.error('\n[Mark error]:', error);
+    logAxiosError('Mark', error);
   }
 }
 
@@ -335,26 +230,26 @@ async function doLog(client: UpgradeClient) {
     const response = await client.log(logRequest);
     console.log('\n[Log response]:', JSON.stringify(response));
   } catch (error) {
-    console.error('\n[Log error]:', error);
+    logAxiosError('Log', error);
   }
 }
 
 async function doSendRewardByExperimentId(client: UpgradeClient) {
   try {
     const response = await client.sendReward({
-      rewardValue: 'SUCCESS',
+      rewardValue,
       experimentId,
     });
     console.log('\n[Send Reward by ExperimentId response]:', JSON.stringify(response));
   } catch (error) {
-    console.error('\n[Send Reward by ExperimentId error]:', error);
+    logAxiosError('Send Reward by ExperimentId', error);
   }
 }
 
 async function doSendRewardByDecisionPoint(client: UpgradeClient) {
   try {
     const response = await client.sendReward({
-      rewardValue: 'FAILURE',
+      rewardValue,
       context,
       decisionPoint: {
         site: rewardSite,
@@ -363,79 +258,24 @@ async function doSendRewardByDecisionPoint(client: UpgradeClient) {
     });
     console.log('\n[Send Reward by Decision Point response]:', JSON.stringify(response));
   } catch (error) {
-    console.error('\n[Send Reward by Decision Point error]:', error);
+    logAxiosError('Send Reward by Decision Point', error);
   }
 }
 
-async function doSendRewardWithEnum(client: UpgradeClient) {
+/** utility functions *******************************************************************************/
+
+function logAxiosError(functionContext: string, error: unknown) {
+  const axiosError = error as AxiosError;
   try {
-    const response = await client.sendReward({
-      rewardValue: UpgradeClient.BINARY_REWARD_VALUE.SUCCESS,
-      experimentId,
+    const parsedError = JSON.parse(axiosError.message);
+
+    console.error(`\n[${functionContext} error]:`, {
+      status: parsedError.status,
+      request: parsedError.config.data,
+      message: parsedError.message,
+      stack: parsedError.stack,
     });
-    console.log('\n[Send Reward with Enum response]:', JSON.stringify(response));
-  } catch (error) {
-    console.error('\n[Send Reward with Enum error]:', error);
+  } catch {
+    console.error(`\n[${functionContext} error]:`, error);
   }
 }
-
-// async function doCreateExperiment(): Promise<string | null> {
-//   try {
-//     // Build the experiment payload from config
-//     const experimentPayload = {
-//       name: experimentConfig.name,
-//       description: experimentConfig.description,
-//       context: experimentConfig.context,
-//       state: experimentConfig.state,
-//       startOn: experimentConfig.startOn,
-//       endOn: experimentConfig.endOn,
-//       consistencyRule: experimentConfig.consistencyRule,
-//       assignmentUnit: experimentConfig.assignmentUnit,
-//       postExperimentRule: experimentConfig.postExperimentRule,
-//       assignmentAlgorithm: experimentConfig.assignmentAlgorithm,
-//       enrollmentCompleteCondition: experimentConfig.enrollmentCompleteCondition,
-//       revertTo: experimentConfig.revertTo,
-//       tags: experimentConfig.tags,
-//       group: experimentConfig.group,
-//       conditionOrder: experimentConfig.conditionOrder,
-//       filterMode: experimentConfig.filterMode,
-//       stratificationFactor: experimentConfig.stratificationFactor,
-//       type: experimentConfig.type,
-//       conditions: experimentConfig.conditions,
-//       factors: experimentConfig.factors,
-//       partitions: experimentConfig.partitions,
-//       queries: experimentConfig.queries,
-//       conditionPayloads: experimentConfig.conditionPayloads,
-//       experimentSegmentInclusion: experimentConfig.experimentSegmentInclusion,
-//       experimentSegmentExclusion: experimentConfig.experimentSegmentExclusion,
-//       // moocletPolicyParameters: experimentConfig.moocletPolicyParameters,
-//     };
-
-//     console.log('\n[Creating experiment with payload]:', JSON.stringify(experimentPayload, null, 2));
-
-//     const response = await fetch(`${hostUrl}/api/experiments`, {
-//       method: 'POST',
-//       headers: {
-//         'Content-Type': 'application/json',
-//       },
-//       body: JSON.stringify(experimentPayload),
-//     });
-
-//     if (!response.ok) {
-//       const errorText = await response.text();
-//       console.error('\n[Create Experiment HTTP error]:', response.status, errorText);
-//       return null;
-//     }
-
-//     const data = await response.json();
-//     console.log('\n[Create Experiment response]:', JSON.stringify(data, null, 2));
-
-//     const experimentId = data.id;
-//     console.log('\n[✓ Created Experiment ID]:', experimentId);
-
-//     return experimentId;
-//   } catch (error) {
-//     console.error('\n[Create Experiment error]:', error);
-//     return null;
-//   }
-// }

--- a/clientlibs/js/quickTest.ts
+++ b/clientlibs/js/quickTest.ts
@@ -1,6 +1,16 @@
 // to run: npx ts-node clientlibs/js/quickTest.ts
 
 import UpgradeClient, { MARKED_DECISION_POINT_STATUS, UpGradeClientInterfaces } from './dist/node';
+import {
+  ASSIGNMENT_ALGORITHM,
+  ASSIGNMENT_UNIT,
+  CONSISTENCY_RULE,
+  EXPERIMENT_STATE,
+  EXPERIMENT_TYPE,
+  FILTER_MODE,
+  MoocletTSConfigurablePolicyParametersDTO,
+  POST_EXPERIMENT_RULE,
+} from '../../types';
 
 const URL = {
   LOCAL: 'http://localhost:3030',
@@ -18,11 +28,106 @@ const groupsForSession = { classId: ['EPHEMERAL_USER_GROUP'] };
 const includeStoredUserGroups = true; // true to merge with stored user groups, false for session-only groups
 const alias = 'alias' + userId;
 const hostUrl = URL.LOCAL;
-const context = 'mathstream';
-const site = 'SelectSection';
-const target = 'absolute_value_plot_equality';
+const context = 'upgrade-internal';
+const site = 'asdf';
+const target = 'fssfs';
 const status = MARKED_DECISION_POINT_STATUS.CONDITION_APPLIED;
 const featureFlagKey = 'TEST_FEATURE_FLAG';
+const experimentId = 'f9c3927c-b786-45f5-a96c-dd9262e3b4b6'; // needed for reward testing
+const rewardSite = site;
+const rewardTarget = target;
+
+// Experiment creation variables - modify these to create different types of experiments
+// const experimentConfig = {
+//   name: 'Quick Test Experiment ' + Date.now(),
+//   description: 'A test experiment created via quickTest.ts',
+//   context: [context],
+//   state: EXPERIMENT_STATE.ENROLLING,
+//   startOn: null, // ISO date string or null
+//   endOn: null, // ISO date string or null
+//   consistencyRule: CONSISTENCY_RULE.INDIVIDUAL, // 'individual', 'experiment', 'group'
+//   assignmentUnit: ASSIGNMENT_UNIT.INDIVIDUAL, // 'individual', 'group', 'within-subjects'
+//   postExperimentRule: POST_EXPERIMENT_RULE.CONTINUE,
+//   assignmentAlgorithm: ASSIGNMENT_ALGORITHM.MOOCLET_TS_CONFIGURABLE,
+//   enrollmentCompleteCondition: null, // { userCount: 100, groupCount: 20 } or null
+//   revertTo: null, // condition id to revert to, or null
+//   tags: ['quicktest', 'automated'],
+//   group: null, // group key if assignmentUnit is 'group', otherwise null
+//   conditionOrder: null, // 'random', 'ordered_round_robin', 'ordered_sequential' (only for within-subjects)
+//   filterMode: FILTER_MODE.INCLUDE_ALL, // 'includeAll', 'excludeAll'
+//   stratificationFactor: null, // { stratificationFactorName: 'gender' } or null
+//   type: EXPERIMENT_TYPE.SIMPLE, // 'Simple', 'Factorial'
+
+//   // Conditions - at least one required
+//   conditions: [
+//     {
+//       id: 'control' + Date.now(),
+//       name: 'control',
+//       description: 'Control condition',
+//       conditionCode: 'control',
+//       assignmentWeight: 50,
+//       order: 1,
+//     },
+//     {
+//       id: 'variant' + Date.now(),
+//       name: 'variant',
+//       description: 'Treatment condition',
+//       conditionCode: 'variant',
+//       assignmentWeight: 50,
+//       order: 2,
+//     },
+//   ],
+
+//   // Factors - only for factorial experiments
+//   factors: [],
+
+//   // Partitions (decision points) - at least one required
+//   partitions: [
+//     {
+//       id: 'partition_1_' + Date.now(),
+//       twoCharacterId: 'P1',
+//       site: site,
+//       target: target,
+//       description: 'Test decision point',
+//       order: 1,
+//       excludeIfReached: false,
+//     },
+//   ],
+
+//   // Queries - optional, for analytics
+//   queries: [],
+
+//   conditionPayloads: [],
+
+//   // Segment inclusion - required
+//   experimentSegmentInclusion: {
+//     segment: {
+//       type: 'public', // 'public', 'private'
+//       name: null,
+//       description: null,
+//       context: null,
+//       individualForSegment: [],
+//       groupForSegment: [],
+//       subSegments: [],
+//     },
+//   },
+
+//   // Segment exclusion - required
+//   experimentSegmentExclusion: {
+//     segment: {
+//       type: 'public', // 'public', 'private'
+//       name: null,
+//       description: null,
+//       context: null,
+//       individualForSegment: [],
+//       groupForSegment: [],
+//       subSegments: [],
+//     },
+//   },
+
+//   // Mooclet policy parameters - only for adaptive experiments
+//   // moocletPolicyParameters: new MoocletTSConfigurablePolicyParametersDTO(),
+// };
 
 const options: UpGradeClientInterfaces.IConfigOptions = {
   featureFlagUserGroupsForSession: useEphemeralGroups
@@ -69,22 +174,32 @@ quickTest();
 
 /** main test *******************************************************************************/
 async function quickTest() {
+  // Create experiment first (optional - uncomment to test)
+  // const createdExperimentId = await doCreateExperiment();
+
   const client = new UpgradeClient(userId, hostUrl, context, options);
   await doInit(client);
-  await doGroupMembership(client);
-  await doWorkingGroupMembership(client);
-  await doAliases(client);
+  // await doGroupMembership(client);
+  // await doWorkingGroupMembership(client);
+  // await doAliases(client);
   await doAssign(client);
-  await doAssignIgnoreCache(client);
-  await doAssign(client);
+  // await doAssignIgnoreCache(client);
+  // await doAssign(client);
 
   const condition = await doGetDecisionPointAssignment(client);
-  doSetFeatureFlagUserGroupsForSession(client, options);
-  await doFeatureFlags(client);
-  await doFeatureFlagsIgnoreCache(client);
-  await doHasFeatureFlag(client);
-  await doHasFeatureFlag(client);
-  // await doMark(client, condition);
+  // doSetFeatureFlagUserGroupsForSession(client, options);
+  // await doFeatureFlags(client);
+  // await doFeatureFlagsIgnoreCache(client);
+  // await doHasFeatureFlag(client);
+  // await doHasFeatureFlag(client);
+  await doMark(client, condition);
+
+  // Use the created experiment ID for reward testing (optional)
+  if (experimentId) {
+    // await doSendRewardByExperimentId(client);
+    // await doSendRewardWithEnum(client);
+  }
+  await doSendRewardByDecisionPoint(client);
   // await doLog(client);
 }
 
@@ -223,3 +338,104 @@ async function doLog(client: UpgradeClient) {
     console.error('\n[Log error]:', error);
   }
 }
+
+async function doSendRewardByExperimentId(client: UpgradeClient) {
+  try {
+    const response = await client.sendReward({
+      rewardValue: 'SUCCESS',
+      experimentId,
+    });
+    console.log('\n[Send Reward by ExperimentId response]:', JSON.stringify(response));
+  } catch (error) {
+    console.error('\n[Send Reward by ExperimentId error]:', error);
+  }
+}
+
+async function doSendRewardByDecisionPoint(client: UpgradeClient) {
+  try {
+    const response = await client.sendReward({
+      rewardValue: 'FAILURE',
+      context,
+      decisionPoint: {
+        site: rewardSite,
+        target: rewardTarget,
+      },
+    });
+    console.log('\n[Send Reward by Decision Point response]:', JSON.stringify(response));
+  } catch (error) {
+    console.error('\n[Send Reward by Decision Point error]:', error);
+  }
+}
+
+async function doSendRewardWithEnum(client: UpgradeClient) {
+  try {
+    const response = await client.sendReward({
+      rewardValue: UpgradeClient.BINARY_REWARD_VALUE.SUCCESS,
+      experimentId,
+    });
+    console.log('\n[Send Reward with Enum response]:', JSON.stringify(response));
+  } catch (error) {
+    console.error('\n[Send Reward with Enum error]:', error);
+  }
+}
+
+// async function doCreateExperiment(): Promise<string | null> {
+//   try {
+//     // Build the experiment payload from config
+//     const experimentPayload = {
+//       name: experimentConfig.name,
+//       description: experimentConfig.description,
+//       context: experimentConfig.context,
+//       state: experimentConfig.state,
+//       startOn: experimentConfig.startOn,
+//       endOn: experimentConfig.endOn,
+//       consistencyRule: experimentConfig.consistencyRule,
+//       assignmentUnit: experimentConfig.assignmentUnit,
+//       postExperimentRule: experimentConfig.postExperimentRule,
+//       assignmentAlgorithm: experimentConfig.assignmentAlgorithm,
+//       enrollmentCompleteCondition: experimentConfig.enrollmentCompleteCondition,
+//       revertTo: experimentConfig.revertTo,
+//       tags: experimentConfig.tags,
+//       group: experimentConfig.group,
+//       conditionOrder: experimentConfig.conditionOrder,
+//       filterMode: experimentConfig.filterMode,
+//       stratificationFactor: experimentConfig.stratificationFactor,
+//       type: experimentConfig.type,
+//       conditions: experimentConfig.conditions,
+//       factors: experimentConfig.factors,
+//       partitions: experimentConfig.partitions,
+//       queries: experimentConfig.queries,
+//       conditionPayloads: experimentConfig.conditionPayloads,
+//       experimentSegmentInclusion: experimentConfig.experimentSegmentInclusion,
+//       experimentSegmentExclusion: experimentConfig.experimentSegmentExclusion,
+//       // moocletPolicyParameters: experimentConfig.moocletPolicyParameters,
+//     };
+
+//     console.log('\n[Creating experiment with payload]:', JSON.stringify(experimentPayload, null, 2));
+
+//     const response = await fetch(`${hostUrl}/api/experiments`, {
+//       method: 'POST',
+//       headers: {
+//         'Content-Type': 'application/json',
+//       },
+//       body: JSON.stringify(experimentPayload),
+//     });
+
+//     if (!response.ok) {
+//       const errorText = await response.text();
+//       console.error('\n[Create Experiment HTTP error]:', response.status, errorText);
+//       return null;
+//     }
+
+//     const data = await response.json();
+//     console.log('\n[Create Experiment response]:', JSON.stringify(data, null, 2));
+
+//     const experimentId = data.id;
+//     console.log('\n[✓ Created Experiment ID]:', experimentId);
+
+//     return experimentId;
+//   } catch (error) {
+//     console.error('\n[Create Experiment error]:', error);
+//     return null;
+//   }
+// }

--- a/clientlibs/js/src/ApiService/ApiService.ts
+++ b/clientlibs/js/src/ApiService/ApiService.ts
@@ -38,6 +38,7 @@ export default class ApiService {
       log: `${this.hostUrl}/api/${this.apiVersion}/log`,
       logCaliper: `${this.hostUrl}/api/${this.apiVersion}/log/caliper`,
       altUserIds: `${this.hostUrl}/api/${this.apiVersion}/useraliases`,
+      reward: `${this.hostUrl}/api/${this.apiVersion}/reward`,
     };
     this.httpClient = this.setHttpClient(config.httpClient);
     this.groupsForSession = config.featureFlagUserGroupsForSession?.groupsForSession ?? null;
@@ -315,5 +316,25 @@ export default class ApiService {
     });
 
     return response;
+  }
+
+  public sendReward(params: {
+    rewardValue: 'SUCCESS' | 'FAILURE';
+    experimentId?: string;
+    context?: string;
+    decisionPoint?: { site: string; target: string };
+  }): Promise<UpGradeClientInterfaces.ISendRewardResponse> {
+    const requestBody: UpGradeClientRequests.ISendRewardRequestBody = {
+      rewardValue: params.rewardValue,
+      experimentId: params.experimentId,
+      context: params.context,
+      decisionPoint: params.decisionPoint,
+    };
+
+    return this.sendRequest<UpGradeClientInterfaces.ISendRewardResponse, UpGradeClientRequests.ISendRewardRequestBody>({
+      path: this.api.reward,
+      method: UpGradeClientEnums.REQUEST_METHOD.POST,
+      body: requestBody,
+    });
   }
 }

--- a/clientlibs/js/src/ApiService/ApiService.types.ts
+++ b/clientlibs/js/src/ApiService/ApiService.types.ts
@@ -16,4 +16,5 @@ export interface IEndpoints {
   log: string;
   logCaliper: string;
   altUserIds: string;
+  reward: string;
 }

--- a/clientlibs/js/src/UpGradeClient/UpgradeClient.ts
+++ b/clientlibs/js/src/UpGradeClient/UpgradeClient.ts
@@ -5,6 +5,7 @@ import {
   IExperimentAssignmentv5,
   MARKED_DECISION_POINT_STATUS,
   IUserAliases,
+  BinaryRewardAllowedValue,
 } from 'upgrade_types';
 import Assignment from '../Assignment/Assignment';
 import ApiService from '../ApiService/ApiService';
@@ -45,6 +46,10 @@ export default class UpgradeClient {
   // allow MARKED_DECISION_POINT_STATUS to be exposed on the client a la UpgradeClient.MARKED_DECISION_POINT_STATUS
   // this will allow js users who are not using the upgrade types package to use this enum for markExperimentPoint()
   public static MARKED_DECISION_POINT_STATUS = MARKED_DECISION_POINT_STATUS;
+
+  // allow BINARY_REWARD_VALUE to be exposed on the client a la UpgradeClient.BINARY_REWARD_VALUE
+  // this will allow js users who are not using the upgrade types package to use this enum for sendReward()
+  public static BINARY_REWARD_VALUE = BinaryRewardAllowedValue;
 
   /**
    * When constructing UpgradeClient, the user id, api host url, and "context" identifier are required.
@@ -558,5 +563,78 @@ export default class UpgradeClient {
    */
   async setAltUserIds(altUserIds: string[]): Promise<IUserAliases> {
     return await this.apiService.setAltUserIds(altUserIds);
+  }
+
+  /**
+   * Sends a binary reward signal for an adaptive experiment (Mooclet).
+   *
+   * This method allows sending reward feedback (SUCCESS or FAILURE) for adaptive experiments.
+   * The reward is used by the adaptive algorithm to update its learning model and improve future assignments.
+   *
+   * **Reward Values:**
+   * You can pass reward values in two ways:
+   * - As string literals: 'SUCCESS' or 'FAILURE'
+   * - Using the enum: UpgradeClient.BINARY_REWARD_VALUE.SUCCESS or UpgradeClient.BINARY_REWARD_VALUE.FAILURE
+   *
+   * **Lookup Methods:**
+   *
+   * The method supports two ways to identify the experiment:
+   *
+   * 1. **Direct Lookup** - Provide the `experimentId` directly
+   * 2. **Decision Point Lookup** - Provide `context` and `decisionPoint` (site and target) to look up the experiment
+   *
+   * At least one of these methods must be provided.
+   *
+   * @example
+   * ```ts
+   * // Example 1: Using string literals with experimentId
+   * const response = await upgradeClient.sendReward({
+   *   rewardValue: 'SUCCESS',
+   *   experimentId: 'exp_adaptive_123'
+   * });
+   * ```
+   *
+   * @example
+   * ```ts
+   * // Example 2: Using the enum with experimentId
+   * const response = await upgradeClient.sendReward({
+   *   rewardValue: UpgradeClient.BINARY_REWARD_VALUE.SUCCESS,
+   *   experimentId: 'exp_adaptive_123'
+   * });
+   * ```
+   *
+   * @example
+   * ```ts
+   * // Example 3: Using decision point lookup with string literals
+   * const response = await upgradeClient.sendReward({
+   *   rewardValue: 'FAILURE',
+   *   context: 'learning-module',
+   *   decisionPoint: {
+   *     site: 'math-course',
+   *     target: 'problem-set-1'
+   *   }
+   * });
+   * ```
+   *
+   * @example
+   * ```ts
+   * // Example 4: Using decision point lookup with enum
+   * const response = await upgradeClient.sendReward({
+   *   rewardValue: UpgradeClient.BINARY_REWARD_VALUE.FAILURE,
+   *   context: 'learning-module',
+   *   decisionPoint: {
+   *     site: 'math-course',
+   *     target: 'problem-set-1'
+   *   }
+   * });
+   * ```
+   */
+  async sendReward(params: {
+    rewardValue: 'SUCCESS' | 'FAILURE';
+    experimentId?: string;
+    context?: string;
+    decisionPoint?: { site: string; target: string };
+  }): Promise<UpGradeClientInterfaces.ISendRewardResponse> {
+    return await this.apiService.sendReward(params);
   }
 }

--- a/clientlibs/js/src/types/Interfaces.ts
+++ b/clientlibs/js/src/types/Interfaces.ts
@@ -87,6 +87,26 @@ export namespace UpGradeClientInterfaces {
     aliases: IExperimentUserAliases;
   }
 
+  export interface ISendRewardResponse {
+    message: string;
+    request: {
+      rewardValue: 'SUCCESS' | 'FAILURE';
+      experimentId?: string;
+      context?: string;
+      decisionPoint?: {
+        site: string;
+        target: string;
+      };
+    };
+    reward: {
+      variable: string;
+      value: number;
+      mooclet: number;
+      version: number;
+      learner: string;
+    };
+  }
+
   export interface IHttpClientWrapperRequestConfig {
     headers?: {
       [key: string]: string | string[];

--- a/clientlibs/js/src/types/requests.ts
+++ b/clientlibs/js/src/types/requests.ts
@@ -44,4 +44,14 @@ export namespace UpGradeClientRequests {
     uniquifier?: string;
     clientError?: string;
   }
+
+  export interface ISendRewardRequestBody {
+    rewardValue: 'SUCCESS' | 'FAILURE';
+    experimentId?: string;
+    context?: string;
+    decisionPoint?: {
+      site: string;
+      target: string;
+    };
+  }
 }

--- a/frontend/projects/upgrade/src/app/core/experiments/experiments.service.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/experiments.service.ts
@@ -258,16 +258,4 @@ export class ExperimentService {
   getOutcomeVariableName(experimentName: string) {
     return `${this.formatExperimentName(experimentName)}_REWARD_VARIABLE`;
   }
-
-  getRewardMetricKey(experimentName: string) {
-    return `${this.formatExperimentName(experimentName)}_REWARD`;
-  }
-
-  getRewardMetricData(rewardMetricKey: string) {
-    return {
-      metric_Key: rewardMetricKey,
-      metric_Operation: 'Percentage (Success)',
-      metric_Name: 'Success Rate',
-    };
-  }
 }

--- a/frontend/projects/upgrade/src/app/core/experiments/store/experiments.model.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/store/experiments.model.ts
@@ -258,7 +258,6 @@ export interface Experiment {
   groupSatisfied?: number;
   backendVersion: string;
   moocletPolicyParameters?: MoocletTSConfigurablePolicyParametersDTO;
-  rewardMetricKey?: string;
 }
 
 export interface ParticipantsMember {
@@ -379,10 +378,4 @@ export interface InteractionEffectGraphData {
   name: string;
   series: InteractionEffectLineChartSeriesData[];
   dot: boolean;
-}
-
-export interface RewardMetricData {
-  metric_Key: string;
-  metric_Operation: string;
-  metric_Name: string;
 }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/experiment-overview/experiment-overview.component.ts
@@ -225,7 +225,6 @@ export class ExperimentOverviewComponent implements OnInit, OnDestroy {
         }
 
         if (this.experimentInfo.assignmentAlgorithm in MOOCLET_POLICY_SCHEMA_MAP) {
-          this.overviewForm.get('experimentName').disable(); // disable due to rewardMetricKey naming convention using the experiment name, a complication we are just going to avoid
           this.overviewForm.get('assignmentAlgorithm').disable();
         }
         this.currentContext = this.experimentInfo.context[0];

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.html
@@ -218,15 +218,8 @@
               >
                 <mat-icon
                   class="remove-icon"
-                  [class.remove-icon--disabled]="isRewardMetric(queryIndex)"
-                  [attr.aria-disabled]="isRewardMetric(queryIndex)"
-                  [attr.tabindex]="isRewardMetric(queryIndex) ? -1 : 0"
-                  (click)="!isRewardMetric(queryIndex) && removeMetric(queryIndex)"
-                  (keydown)="
-                    $event.key === 'Enter' || $event.key === ' '
-                      ? !isRewardMetric(queryIndex) && removeMetric(queryIndex)
-                      : null
-                  "
+                  (click)="removeMetric(queryIndex)"
+                  (keydown)="$event.key === 'Enter' || $event.key === ' ' ? removeMetric(queryIndex) : null"
                 >
                   delete_outline
                 </mat-icon>
@@ -281,39 +274,6 @@
           ></span>
         </div>
       </ng-template>
-
-      <!-- Reward Metric Section -->
-      <div class="reward-metric-container" *ngIf="isMoocletExperimentDesign$ | async">
-        <span class="title">{{ 'home.new-experiment.metrics.reward-metric.text' | translate }}</span>
-        <div class="reward-metric-description" *ngIf="rewardMetricDataSource | async as rewardMetricData">
-          <div class="reward-metric-item" *ngFor="let row of rewardMetricData">
-            <span>
-              <span class="ft-14-600">Key:</span>
-              <span class="ft-14-400"> "{{ row.metric_Key }}"</span>
-            </span>
-            <span>
-              <span class="ft-14-600">Allowed Values:</span>
-              <span class="ft-14-400"> ["SUCCESS", "FAILURE"]</span>
-            </span>
-            <span class="ft-12-400">
-              Adaptive experiments require "reward" feedback to be logged from enrolled users, which will tilt the
-              probability of experimental assignments towards conditions that receive more successful feedback. Use this
-              key when logging metrics as a simple metric value.
-            </span>
-            <span class="ft-12-600" *ngIf="!experimentInfo">
-              UpGrade automatically creates this metric for your experiment when created, and a metric query for success
-              rate will also be automatically applied.
-              <a
-                class="learn-more-link"
-                href="https://www.upgradeplatform.org/"
-                target="_blank"
-                rel="noopener noreferrer"
-                >Learn more</a
-              >
-            </span>
-          </div>
-        </div>
-      </div>
     </form>
   </section>
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.scss
@@ -144,19 +144,4 @@
     padding-top: 8px;
     height: 64px;
   }
-
-  .reward-metric-container {
-    padding-top: 16px;
-
-    .reward-metric-description {
-      padding: 16px 8px 0;
-      color: var(--black-2);
-
-      .reward-metric-item {
-        display: flex;
-        flex-direction: column;
-        gap: 8px;
-      }
-    }
-  }
 }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/components/metrics/metrics.component.ts
@@ -6,7 +6,6 @@ import {
   NewExperimentDialogEvents,
   NewExperimentDialogData,
   NewExperimentPaths,
-  RewardMetricData,
 } from '../../../../../core/experiments/store/experiments.model';
 import { Component, OnInit, OnDestroy, Input, EventEmitter, Output } from '@angular/core';
 import { Subscription, Observable } from 'rxjs';
@@ -67,10 +66,8 @@ export class MonitoredMetricsComponent implements OnInit, OnChanges, OnDestroy {
   controlTitles = ['Type', 'Key', 'Metric']; // Used to show different titles in grouped metrics
 
   metricsDataSource = new BehaviorSubject<AbstractControl[]>([]);
-  rewardMetricDataSource = new BehaviorSubject<RewardMetricData[]>([]);
 
   metricsDisplayedColumns = ['keys', 'operationType', 'queryName', 'removeMetric'];
-  rewardMetricDisplayedColumns = ['metricsKey', 'metricsOperation', 'metricsName'];
   queryIndex = 0;
   editMode = false;
 
@@ -83,7 +80,6 @@ export class MonitoredMetricsComponent implements OnInit, OnChanges, OnDestroy {
   currentAssignmentUnit: ASSIGNMENT_UNIT;
   currentExperimentName$ = this.experimentDesignStepperService.currentExperimentName$;
   isMoocletExperimentDesign$ = this.experimentDesignStepperService.isMoocletExperimentDesign$;
-  private rewardMetricSubscription: Subscription;
 
   constructor(
     private analysisService: AnalysisService,
@@ -104,32 +100,6 @@ export class MonitoredMetricsComponent implements OnInit, OnChanges, OnDestroy {
           : this.allMetrics.filter((metric) =>
               metric.context?.includes(this.currentContext || this.experimentInfo?.context)
             );
-      this.filterOutRewardMetricKeysFromOtherExperiments();
-    });
-  }
-
-  /**
-   * No *_REWARD metric keys should be shown on Add Experiment flow.
-   * Only the current experiment's reward metric key should be shown on Edit Experiment flow.
-   * This function will work regardless of whether mooclet is enabled or not.
-   */
-  filterOutRewardMetricKeysFromOtherExperiments() {
-    // Filter out reward metric keys from other experiments
-    this.options = this.options.filter((option) => {
-      if (option.key.endsWith('_REWARD')) {
-        const isAddMode = !this.experimentInfo?.name;
-        if (isAddMode) {
-          // Exclude all reward keys if in add mode
-          return false;
-        } else {
-          // Else, exclude all reward keys except the current experiment's reward key
-          const isCurrentExperimentRewardKey =
-            option.key === this.experimentService.getRewardMetricKey(this.experimentInfo.name);
-          return isCurrentExperimentRewardKey;
-        }
-      } else {
-        return true;
-      }
     });
   }
 
@@ -153,21 +123,6 @@ export class MonitoredMetricsComponent implements OnInit, OnChanges, OnDestroy {
           repeatedMeasure: [null, Validators.required],
         }),
       ]),
-    });
-
-    // Subscribe to experiment name changes for reward metric
-    this.rewardMetricSubscription = combineLatest([
-      this.isMoocletExperimentDesign$,
-      this.currentExperimentName$,
-    ]).subscribe(([isMooclet, experimentName]) => {
-      // If mooclet and name is non-empty, set the reward metric
-      if (isMooclet && experimentName) {
-        const rewardMetricKey = this.experimentService.getRewardMetricKey(experimentName);
-        this.rewardMetricDataSource.next([this.experimentService.getRewardMetricData(rewardMetricKey)]);
-      } else {
-        // If not mooclet or no name, clear out the reward metric
-        this.rewardMetricDataSource.next([]);
-      }
     });
 
     // Bind predefined values of metrics from backend env file for auto complete:
@@ -302,17 +257,6 @@ export class MonitoredMetricsComponent implements OnInit, OnChanges, OnDestroy {
     return this._formBuilder.group({
       metricKey: [key, Validators.required],
     });
-  }
-
-  isRewardMetric(queryIndex: number): boolean {
-    const keysFormArray = this.queries.at(queryIndex)?.get('keys') as UntypedFormArray;
-    const firstKey = keysFormArray?.at(0);
-    const metricKey = firstKey?.get('metricKey')?.value;
-    if (!metricKey) return false;
-
-    // Extract the key string, handling both string and object formats
-    const keyString = metricKey.key ? metricKey.key : metricKey;
-    return keyString && keyString.endsWith('_REWARD');
   }
 
   displayFn(node?: any): string | undefined {
@@ -760,13 +704,6 @@ export class MonitoredMetricsComponent implements OnInit, OnChanges, OnDestroy {
       this.queryMetricDropDownError.length === 0 &&
       this.queryNameError.length === 0
     ) {
-      const rewardMetricData = this.rewardMetricDataSource.getValue();
-
-      // If rewardMetricDataSource has data, include the rewardMetricKey
-      if (rewardMetricData.length > 0) {
-        monitoredMetricsFormData.rewardMetricKey = rewardMetricData[0].metric_Key;
-      }
-
       this.emitExperimentDialogEvent.emit({
         type: eventType,
         formData: monitoredMetricsFormData,
@@ -791,9 +728,5 @@ export class MonitoredMetricsComponent implements OnInit, OnChanges, OnDestroy {
 
   ngOnDestroy() {
     this.allMetricsSub.unsubscribe();
-
-    if (this.rewardMetricSubscription) {
-      this.rewardMetricSubscription.unsubscribe();
-    }
   }
 }

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.html
@@ -932,28 +932,6 @@
               <mat-row *matRowDef="let row; columns: displayedMetricsColumns"></mat-row>
             </mat-table>
           </div>
-
-          <!-- Experiment reward metric section -->
-          <div class="table-container" *ngIf="experiment?.rewardMetricKey">
-            <span class="ft-24-700">{{ 'home.new-experiment.metrics.reward-metric.text' | translate }}</span>
-            <div class="reward-metric-description" *ngIf="displayRewardMetrics as rewardMetricData">
-              <div class="reward-metric-item" *ngFor="let row of rewardMetricData">
-                <span>
-                  <span class="ft-14-600">Key:</span>
-                  <span class="ft-14-400"> "{{ row.metric_Key }}"</span>
-                </span>
-                <span>
-                  <span class="ft-14-600">Allowed Values:</span>
-                  <span class="ft-14-400"> ["SUCCESS", "FAILURE"]</span>
-                </span>
-                <span class="ft-12-400">
-                  Adaptive experiments require "reward" feedback to be logged from enrolled users, which will tilt the
-                  probability of experimental assignments towards conditions that receive more successful feedback. Use
-                  this key when logging metrics as a simple metric value.
-                </span>
-              </div>
-            </div>
-          </div>
         </div>
       </mat-tab>
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.scss
@@ -409,17 +409,6 @@ $font-size-small: 15px;
       margin-right: 20px;
     }
   }
-
-  .reward-metric-description {
-    padding: 16px 8px 0;
-    color: var(--black-2);
-
-    .reward-metric-item {
-      display: flex;
-      flex-direction: column;
-      gap: 8px;
-    }
-  }
 }
 
 ::ng-deep .owl-dt-calendar-table .owl-dt-calendar-cell-selected {

--- a/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/home/pages/view-experiment/view-experiment.component.ts
@@ -10,7 +10,6 @@ import {
   EXPERIMENT_SEARCH_KEY,
   ExperimentLevel,
   ExperimentConditionPayload,
-  RewardMetricData,
 } from '../../../../../core/experiments/store/experiments.model';
 import { Observable, Subscription } from 'rxjs';
 import { filter, withLatestFrom } from 'rxjs/operators';
@@ -105,7 +104,6 @@ export class ViewExperimentComponent implements OnInit, OnDestroy {
   includeParticipants: Participants[] = [];
   excludeParticipants: Participants[] = [];
   displayMetrics: Metrics[] = [];
-  displayRewardMetrics: RewardMetricData[] = [];
   simpleExperimentPayloadTableData: SimpleExperimentPayloadTableRowData[] = [];
 
   constructor(
@@ -181,7 +179,6 @@ export class ViewExperimentComponent implements OnInit, OnDestroy {
         this.onExperimentChange(experiment, isPolling);
         this.loadParticipants();
         this.loadMetrics();
-        this.loadRewardMetrics();
 
         if (experiment.type === EXPERIMENT_TYPE.SIMPLE) {
           this.loadPayloadTable(experiment);
@@ -313,14 +310,6 @@ export class ViewExperimentComponent implements OnInit, OnDestroy {
         });
       });
     }
-  }
-
-  loadRewardMetrics() {
-    if (!this.experiment?.rewardMetricKey) {
-      return;
-    }
-
-    this.displayRewardMetrics = [this.experimentService.getRewardMetricData(this.experiment.rewardMetricKey)];
   }
 
   openDialog(dialogType: DialogType) {

--- a/frontend/projects/upgrade/src/assets/i18n/en.json
+++ b/frontend/projects/upgrade/src/assets/i18n/en.json
@@ -197,7 +197,6 @@
   "home.new-experiment.metrics.metric-name-exist.validation.text": "Metric must be selected from the menu. Please choose an option.",
   "home.new-experiment.metrics.invalid-metric.text": "Metric must be selected from the menu. Please choose an option.",
   "home.new-experiment.metrics.no-available-metrics.text": "Currently no metrics available to select. Metrics can be added later when available. You can continue to next step.",
-  "home.new-experiment.metrics.reward-metric.text": "Reward Metric",
   "home.new-experiment.schedule.start-automatically.text": "Start Automatically",
   "home.new-experiment.schedule.end-automatically.text": "End Automatically",
   "home.new-experiment.schedule.start-on.text": "Starts on",

--- a/types/package-lock.json
+++ b/types/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "upgrade_types",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "upgrade_types",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "license": "ISC",
       "dependencies": {
         "class-transformer": "^0.5.1",
@@ -18,33 +18,6 @@
         "eslint": "^8.27.0",
         "prettier": "^2.7.1",
         "typescript": "~5.3.3"
-      }
-    },
-    "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
-      "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
-      "dev": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^3.4.3"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
-      }
-    },
-    "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
-      "dev": true,
-      "engines": {
-        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/types/src/Experiment/enums.ts
+++ b/types/src/Experiment/enums.ts
@@ -77,6 +77,7 @@ export enum SERVER_ERROR {
   MISSING_HEADER_USER_ID = 'Missing `User-Id` header',
   SEGMENT_DUPLICATE_NAME = 'Segment with same name already exists for this app-context.',
   INVALID_APP_CONTEXT = 'Invalid app context',
+  MOOCLET_REWARD_ERROR = 'Error processing Mooclet reward',
 }
 
 export enum MARKED_DECISION_POINT_STATUS {

--- a/types/src/Mooclet/index.ts
+++ b/types/src/Mooclet/index.ts
@@ -13,14 +13,14 @@ const MOOCLET_POLICY_SCHEMA_MAP = {
 
 const SUPPORTED_MOOCLET_ALGORITHMS = Object.keys(MOOCLET_POLICY_SCHEMA_MAP);
 
-enum BinaryRewardMetricAllowedValue {
+enum BinaryRewardAllowedValue {
   SUCCESS = 'SUCCESS',
   FAILURE = 'FAILURE',
 }
 
-const BinaryRewardMetricValueMap = {
-  [BinaryRewardMetricAllowedValue.SUCCESS]: 1,
-  [BinaryRewardMetricAllowedValue.FAILURE]: 0,
+const BinaryRewardValueMap = {
+  [BinaryRewardAllowedValue.SUCCESS]: 1,
+  [BinaryRewardAllowedValue.FAILURE]: 0,
 };
 
 export {
@@ -30,6 +30,6 @@ export {
   CurrentPosteriors,
   MoocletPolicyParametersDTO,
   MoocletTSConfigurablePolicyParametersDTO,
-  BinaryRewardMetricAllowedValue,
-  BinaryRewardMetricValueMap,
+  BinaryRewardAllowedValue,
+  BinaryRewardValueMap,
 };

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -85,6 +85,6 @@ export {
   MoocletTSConfigurablePolicyParametersDTO,
   MOOCLET_POLICY_SCHEMA_MAP,
   SUPPORTED_MOOCLET_ALGORITHMS,
-  BinaryRewardMetricAllowedValue,
-  BinaryRewardMetricValueMap,
+  BinaryRewardAllowedValue,
+  BinaryRewardValueMap,
 } from './Mooclet';


### PR DESCRIPTION
https://github.com/CarnegieLearningWeb/UpGrade/issues/2741

Removes Reward Metric views from UI
Removes unique name constraints on Mooclet Experiments
Removes /log based reward system and all tie-ins to upgrade metrics systems
Removes the automatic metric query creation
Adds a /reward endpoint to client controller, which will lookup experiment info and do a more direct call to mooclet
Adds a sendReward() endpoint to TS client lib
Updates quicktest to add rewards and some more readable errors