### PR TITLE
Disable 'Create' button when required fields are missing in the Upsert Experiment modal

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/modals/upsert-experiment-modal/upsert-experiment-modal.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/modals/upsert-experiment-modal/upsert-experiment-modal.component.ts
@@ -340,8 +340,14 @@ export class UpsertExperimentModalComponent implements OnInit, OnDestroy {
 
   listenForPrimaryButtonDisabled() {
     this.isPrimaryButtonDisabled$ = this.isLoadingUpsertExperiment$.pipe(
-      combineLatestWith(this.isInitialFormValueChanged$),
-      map(([isLoading, isInitialFormValueChanged]) => isLoading || !isInitialFormValueChanged)
+      combineLatestWith(
+        this.isInitialFormValueChanged$,
+        this.experimentForm.statusChanges.pipe(startWith(this.experimentForm.status))
+      ),
+      map(
+        ([isLoading, isInitialFormValueChanged, formStatus]) =>
+          isLoading || !isInitialFormValueChanged || formStatus !== 'VALID'
+      )
     );
     this.subscriptions.add(this.isPrimaryButtonDisabled$.subscribe());
   }


### PR DESCRIPTION
Resolves #2789 