### PR TITLE
move old enrollment data page components into new structure

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-condition-table/enrollment-condition-expandable-row/enrollment-condition-expandable-row.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-condition-table/enrollment-condition-expandable-row/enrollment-condition-expandable-row.component.html
@@ -1,0 +1,55 @@
+<div>
+  <mat-table [dataSource]="dataSource" multiTemplateDataRows>
+    <!-- COLUMNS AND ROWS-->
+    <ng-container *ngFor="let key of displayedColumns" [matColumnDef]="key">
+      <mat-header-cell
+        [ngClass]="{ 'weight-column': key === 'weight' }"
+        style="justify-content: left; padding-left: 15px"
+        class="ft-12-700"
+        *matHeaderCellDef
+      >
+        {{ key.includes('Icon') ? '' : columnHeaders[key] }}
+      </mat-header-cell>
+
+      <mat-cell
+        [ngClass]="{ 'weight-column': key === 'weight' }"
+        style="justify-content: left"
+        class="ft-12-600"
+        *matCellDef="let element; let i = dataIndex"
+      >
+        <!-- Special handling for weight column when experiment has moocletPolicyParameters -->
+        <span *ngIf="key === 'weight' && experiment?.moocletPolicyParameters; else regularCell">N/A</span>
+
+        <ng-template #regularCell>
+          <span *ngIf="!key.includes('Icon'); else icon" style="padding-left: -5px">{{ element.data[key] }}</span>
+          <ng-template #icon>
+            <mat-icon
+              style="margin-left: -17.5px"
+              *ngIf="element.partitions && key === 'expandIcon'"
+              [class.active]="element.data[referenceId] === expandedId"
+              (click)="toggleExpandableSymbol(element.data[referenceId])"
+            >
+              chevron_right
+            </mat-icon>
+          </ng-template>
+        </ng-template>
+      </mat-cell>
+    </ng-container>
+
+    <!-- EXPANDABLE ROW -->
+    <ng-container matColumnDef="expandedDetail">
+      <mat-cell class="ft-12-600" *matCellDef="let element">
+        <div *ngIf="element.data[referenceId] === expandedId" class="inner-table-container">
+          <app-enrollment-point-partition-table [partitionData]="element.partitions" [experiment]="experiment">
+          </app-enrollment-point-partition-table>
+        </div>
+      </mat-cell>
+    </ng-container>
+
+    <!-- -->
+    <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+    <mat-row *matRowDef="let row; columns: displayedColumns"></mat-row>
+
+    <mat-row class="expandable-row" *matRowDef="let row; columns: ['expandedDetail']"> </mat-row>
+  </mat-table>
+</div>

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-condition-table/enrollment-condition-expandable-row/enrollment-condition-expandable-row.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-condition-table/enrollment-condition-expandable-row/enrollment-condition-expandable-row.component.scss
@@ -1,0 +1,62 @@
+div {
+  width: 100%;
+
+  .inner-table-container {
+    border: 1px solid #d3d3d3;
+    border-radius: 5px;
+    margin: 10px 5px 10px 23px;
+  }
+
+  .mat-mdc-table {
+    mat-cell,
+    mat-header-cell {
+      display: flex;
+      &:not(:first-child):not(:nth-child(2)) {
+        justify-content: flex-end !important;
+      }
+      padding: 0px 15px !important;
+      text-align: center;
+      word-break: break-word;
+    }
+
+    mat-header-cell {
+      background-color: var(--zircon);
+    }
+
+    .mat-column-expandIcon {
+      flex: 0 0 60px;
+      width: 30px;
+      padding-left: 10px;
+      justify-content: center !important;
+      margin-right: -16px;
+    }
+
+    mat-cell:nth-child(2),
+    mat-cell:nth-child(3),
+    mat-header-cell:nth-child(2),
+    mat-header-cell:nth-child(3) {
+      flex: 0 0 20%;
+      width: 20%;
+    }
+
+    .mat-icon {
+      position: relative;
+      cursor: pointer;
+
+      &.active {
+        transform: rotate(90deg);
+      }
+    }
+  }
+
+  .expandable-row {
+    mat-cell,
+    mat-header-cell {
+      padding: 0px;
+    }
+
+    .mat-column-experimentPoint {
+      padding-left: 20px;
+    }
+  }
+}

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-condition-table/enrollment-condition-expandable-row/enrollment-condition-expandable-row.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-condition-table/enrollment-condition-expandable-row/enrollment-condition-expandable-row.component.ts
@@ -1,0 +1,61 @@
+import { Component, ChangeDetectionStrategy, Input, OnDestroy, forwardRef } from '@angular/core';
+import { ExperimentVM } from '../../../../../../../../../core/experiments/store/experiments.model';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { Subscription } from 'rxjs';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTableModule } from '@angular/material/table';
+import { CommonModule } from '@angular/common';
+import { EnrollmentPointPartitionTableComponent } from '../enrollment-point-partition-table/enrollment-point-partition-table.component';
+
+@Component({
+  selector: 'app-enrollment-condition-expandable-row',
+  templateUrl: './enrollment-condition-expandable-row.component.html',
+  styleUrls: ['./enrollment-condition-expandable-row.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    TranslateModule,
+    CommonModule,
+    MatTableModule,
+    MatIconModule,
+    forwardRef(() => EnrollmentPointPartitionTableComponent),
+  ],
+})
+export class EnrollmentConditionExpandableRowComponent implements OnDestroy {
+  @Input() dataSource: any;
+  @Input() displayedColumns: string[];
+  @Input() referenceId: string;
+  @Input() experiment: ExperimentVM;
+
+  expandedId = '';
+  columnHeaders = {};
+  translateSub: Subscription;
+  constructor(private translate: TranslateService) {
+    this.translateSub = this.translate
+      .get([
+        'global.condition.text',
+        'home.view-experiment.global.weight.text',
+        'home.view-experiment.global.users-enrolled.text',
+        'home.view-experiment.global.group-enrolled.text',
+        'home.view-experiment-global.experiment-site.text',
+        'home.view-experiment-global.experiment-target.text',
+      ])
+      .subscribe((arrayValues) => {
+        this.columnHeaders = {
+          condition: arrayValues['global.condition.text'],
+          weight: arrayValues['home.view-experiment.global.weight.text'],
+          userEnrolled: arrayValues['home.view-experiment.global.users-enrolled.text'],
+          groupEnrolled: arrayValues['home.view-experiment.global.group-enrolled.text'],
+          experimentPoint: arrayValues['home.view-experiment-global.experiment-site.text'],
+          experimentId: arrayValues['home.view-experiment-global.experiment-target.text'],
+        };
+      });
+  }
+
+  toggleExpandableSymbol(id: string): void {
+    this.expandedId = this.expandedId === id ? '' : id;
+  }
+
+  ngOnDestroy() {
+    this.translateSub.unsubscribe();
+  }
+}

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-condition-table/enrollment-condition-table.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-condition-table/enrollment-condition-table.component.html
@@ -1,0 +1,34 @@
+<div class="condition-table-container">
+  <span class="ft-18-700 title">{{ 'home.view-experiment.enrollments-by-condition.title.text' | translate }}</span>
+  <div class="spinner" *ngIf="isStatLoading; else conditionTableTemplate">
+    <mat-spinner diameter="60"></mat-spinner>
+  </div>
+  <ng-template #conditionTableTemplate>
+    <div class="data">
+      <div class="enrollment-condition-table-container">
+        <app-enrollment-condition-expandable-row
+          [dataSource]="experimentData"
+          [displayedColumns]="displayedColumns"
+          [referenceId]="'condition'"
+          [experiment]="experiment"
+        >
+        </app-enrollment-condition-expandable-row>
+      </div>
+
+      <div class="enrollment-statistic">
+        <div class="enrollment-statistic__unique">
+          <span class="ft-14-600 title">
+            {{ 'home.view-experiment.global.users-excluded.text' | translate }}
+          </span>
+          <span class="ft-30-700 numbers">{{ experiment.stat?.usersExcluded || 0 }}</span>
+        </div>
+        <div class="enrollment-statistic__class" *ngIf="experiment.assignmentUnit === AssignmentUnit.GROUP">
+          <span class="ft-14-600 title">
+            {{ 'home.view-experiment.global.group-excluded.text' | translate }}
+          </span>
+          <span class="ft-30-700 numbers">{{ experiment.stat?.groupsExcluded || 0 }}</span>
+        </div>
+      </div>
+    </div>
+  </ng-template>
+</div>

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-condition-table/enrollment-condition-table.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-condition-table/enrollment-condition-table.component.scss
@@ -1,0 +1,58 @@
+.condition-table-container {
+  display: flex;
+  flex-direction: column;
+  padding: 0 34px 14px 34px;
+  width: 100%;
+  min-height: 150px;
+
+  .title {
+    display: block;
+    margin-bottom: 20px;
+  }
+
+  .spinner {
+    display: flex;
+    position: absolute;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 150px;
+  }
+
+  .data {
+    display: flex;
+
+    .enrollment-condition-table-container {
+      flex-grow: 1;
+    }
+
+    .enrollment-statistic {
+      display: flex;
+      flex-direction: column;
+      margin-left: 30px;
+      padding-top: 16px;
+      width: 200px;
+
+      &__unique {
+        padding-bottom: 25px;
+        text-align: center;
+      }
+
+      &__class {
+        border-top: 1px solid var(--grey);
+        padding: 25px 0;
+        text-align: center;
+      }
+
+      .title {
+        display: block;
+        color: var(--grey-5);
+      }
+
+      .numbers {
+        align-self: center;
+        color: var(--blue);
+      }
+    }
+  }
+}

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-condition-table/enrollment-condition-table.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-condition-table/enrollment-condition-table.component.ts
@@ -1,0 +1,96 @@
+import { Component, Input, OnChanges, OnInit } from '@angular/core';
+import {
+  ASSIGNMENT_UNIT,
+  ExperimentVM,
+  EnrollmentByConditionOrPartitionData,
+} from '../../../../../../../../core/experiments/store/experiments.model';
+import { ExperimentService } from '../../../../../../../../core/experiments/experiments.service';
+import { Subscription } from 'rxjs';
+import { TranslateModule } from '@ngx-translate/core';
+import { CommonModule } from '@angular/common';
+import { EnrollmentConditionExpandableRowComponent } from './enrollment-condition-expandable-row/enrollment-condition-expandable-row.component';
+
+@Component({
+  selector: 'app-enrollment-condition-table',
+  templateUrl: './enrollment-condition-table.component.html',
+  styleUrls: ['./enrollment-condition-table.component.scss'],
+  imports: [CommonModule, TranslateModule, EnrollmentConditionExpandableRowComponent],
+})
+export class EnrollmentConditionTableComponent implements OnChanges, OnInit {
+  @Input() experiment: ExperimentVM;
+  experimentData: any[] = [];
+  commonColumns = ['expandIcon', 'condition', 'weight', 'userEnrolled'];
+  displayedColumns: string[] = [];
+  isStatLoading = true;
+  experimentStateSub: Subscription;
+
+  constructor(private experimentService: ExperimentService) {}
+
+  ngOnChanges() {
+    if (this.experiment.assignmentUnit === ASSIGNMENT_UNIT.INDIVIDUAL) {
+      this.displayedColumns = this.commonColumns;
+    } else {
+      this.displayedColumns = [...this.commonColumns, 'groupEnrolled'];
+    }
+  }
+
+  ngOnInit() {
+    this.experimentStateSub = this.experimentService.experimentStatById$(this.experiment.id).subscribe((stat) => {
+      this.experimentData = [];
+      if (stat && stat.conditions) {
+        this.isStatLoading = false;
+        stat.conditions.forEach((condition) => {
+          const conditionObj: EnrollmentByConditionOrPartitionData = {
+            condition: this.getConditionData(condition.id, 'conditionCode'),
+            weight: this.getConditionData(condition.id, 'assignmentWeight'),
+            userEnrolled: condition.users,
+            groupEnrolled: condition.groups,
+          };
+          let experimentObj: any = {
+            data: conditionObj,
+          };
+
+          const partitions = [];
+          condition.partitions.forEach((partition) => {
+            const partitionObj: EnrollmentByConditionOrPartitionData = {
+              experimentPoint: this.getPartitionData(partition.id, 'site'),
+              experimentId: this.getPartitionData(partition.id, 'target') || '',
+              userEnrolled: partition.users,
+              groupEnrolled: partition.groups,
+            };
+            partitions.push({
+              data: partitionObj,
+            });
+          });
+          experimentObj = {
+            ...experimentObj,
+            partitions,
+          };
+          this.experimentData.push(experimentObj);
+        });
+      }
+    });
+  }
+
+  getPartitionData(partitionId: string, key: string) {
+    return this.experiment.partitions.reduce(
+      (acc, partition) => (partition.id === partitionId ? (acc = partition[key]) : acc),
+      null
+    );
+  }
+
+  getConditionData(conditionId: string, key: string) {
+    return this.experiment.conditions.reduce(
+      (acc, condition) => (condition.id === conditionId ? (acc = condition[key]) : acc),
+      null
+    );
+  }
+
+  ngOnDestroy() {
+    this.experimentStateSub.unsubscribe();
+  }
+
+  get AssignmentUnit() {
+    return ASSIGNMENT_UNIT;
+  }
+}

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-condition-table/enrollment-condition-table.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-condition-table/enrollment-condition-table.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnInit } from '@angular/core';
+import { Component, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
 import {
   ASSIGNMENT_UNIT,
   ExperimentVM,
@@ -9,14 +9,15 @@ import { Subscription } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
 import { CommonModule } from '@angular/common';
 import { EnrollmentConditionExpandableRowComponent } from './enrollment-condition-expandable-row/enrollment-condition-expandable-row.component';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 
 @Component({
   selector: 'app-enrollment-condition-table',
   templateUrl: './enrollment-condition-table.component.html',
   styleUrls: ['./enrollment-condition-table.component.scss'],
-  imports: [CommonModule, TranslateModule, EnrollmentConditionExpandableRowComponent],
+  imports: [CommonModule, TranslateModule, EnrollmentConditionExpandableRowComponent, MatProgressSpinnerModule],
 })
-export class EnrollmentConditionTableComponent implements OnChanges, OnInit {
+export class EnrollmentConditionTableComponent implements OnChanges, OnInit, OnDestroy {
   @Input() experiment: ExperimentVM;
   experimentData: any[] = [];
   commonColumns = ['expandIcon', 'condition', 'weight', 'userEnrolled'];

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-condition-table/enrollment-point-partition-table/enrollment-point-partition-table.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-condition-table/enrollment-point-partition-table/enrollment-point-partition-table.component.html
@@ -1,0 +1,7 @@
+<app-enrollment-condition-expandable-row
+  [dataSource]="partitionData"
+  [displayedColumns]="displayedColumns"
+  [referenceId]="'experimentPoint'"
+  [experiment]="experiment"
+>
+</app-enrollment-condition-expandable-row>

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-condition-table/enrollment-point-partition-table/enrollment-point-partition-table.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-condition-table/enrollment-point-partition-table/enrollment-point-partition-table.component.ts
@@ -1,0 +1,26 @@
+import { Component, ChangeDetectionStrategy, OnChanges, Input, forwardRef } from '@angular/core';
+import { ExperimentVM, ASSIGNMENT_UNIT } from '../../../../../../../../../core/experiments/store/experiments.model';
+import { EnrollmentConditionExpandableRowComponent } from '../enrollment-condition-expandable-row/enrollment-condition-expandable-row.component';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-enrollment-point-partition-table',
+  templateUrl: './enrollment-point-partition-table.component.html',
+  styleUrls: ['./enrollment-point-partition-table.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [forwardRef(() => EnrollmentConditionExpandableRowComponent), CommonModule],
+})
+export class EnrollmentPointPartitionTableComponent implements OnChanges {
+  @Input() partitionData: any[];
+  @Input() experiment: ExperimentVM;
+  commonColumns = ['expandIcon', 'experimentPoint', 'experimentId', 'userEnrolled'];
+  displayedColumns: string[] = [];
+
+  ngOnChanges() {
+    if (this.experiment.assignmentUnit === ASSIGNMENT_UNIT.INDIVIDUAL) {
+      this.displayedColumns = this.commonColumns;
+    } else {
+      this.displayedColumns = [...this.commonColumns, 'groupEnrolled'];
+    }
+  }
+}

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-over-time/enrollment-over-time.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-over-time/enrollment-over-time.component.html
@@ -1,0 +1,141 @@
+<div class="enrollment-over-time">
+  <span class="ft-18-700 title">{{ 'home.view-experiment.enrollments-by-decision-point.title.text' | translate }}</span>
+  <div class="enrollment-filters">
+    <mat-form-field class="dense-2 sites" appearance="outline" subscriptSizing="dynamic">
+      <mat-label class="ft-14-400 dropdown-label">
+        {{ 'home.view-experiment.graph-decision-point.text' | translate }}
+      </mat-label>
+      <mat-select
+        class="ft-14-400"
+        [(ngModel)]="selectedPartition"
+        multiple
+        (selectionChange)="applyExperimentFilter(ExperimentFilter.PARTITION_FILTER)"
+      >
+        <mat-checkbox
+          color="primary"
+          class="mat-option"
+          [indeterminate]="isIndeterminate('partitions')"
+          [checked]="isChecked('partitions')"
+          (click)="$event.stopPropagation()"
+          (change)="toggleSelection($event, 'partitions')"
+        >
+          <span class="ft-16-400 checkbox-label">
+            {{ 'home.view-experiment.graph-select-all.text' | translate }}
+          </span>
+        </mat-checkbox>
+        <mat-option class="ft-14-400" *ngFor="let partition of partitionsFilterOptions" [value]="partition.id">
+          {{ partition.point + ' (' + partition.twoCharacterId + ')' }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field class="dense-2 conditions" appearance="outline" subscriptSizing="dynamic">
+      <mat-label class="ft-14-400 dropdown-label">
+        {{ 'home.view-experiment.graph-conditions.text' | translate }}
+      </mat-label>
+      <mat-select
+        class="ft-14-400"
+        [(ngModel)]="selectedCondition"
+        multiple
+        (selectionChange)="applyExperimentFilter(ExperimentFilter.CONDITION_FILTER)"
+      >
+        <mat-checkbox
+          color="primary"
+          class="mat-option"
+          [indeterminate]="isIndeterminate('conditions')"
+          [checked]="isChecked('conditions')"
+          (click)="$event.stopPropagation()"
+          (change)="toggleSelection($event, 'conditions')"
+        >
+          <span class="ft-16-400 checkbox-label">
+            {{ 'home.view-experiment.graph-select-all.text' | translate }}
+          </span>
+        </mat-checkbox>
+        <mat-option class="ft-14-400" *ngFor="let condition of conditionsFilterOptions" [value]="condition.id">
+          {{ condition.code }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field class="dense-2" appearance="outline" subscriptSizing="dynamic">
+      <mat-label class="ft-14-400 dropdown-label">
+        {{ 'home.view-experiment.graph-type.text' | translate }}
+      </mat-label>
+      <mat-select
+        class="ft-14-400"
+        [disabled]="experiment.assignmentUnit === AssignmentUnit.INDIVIDUAL"
+        [(ngModel)]="selectedGroupFilter"
+        (selectionChange)="applyExperimentFilter(ExperimentFilter.GROUP_FILTER)"
+      >
+        <mat-option class="ft-14-400" *ngFor="let groupValue of groupFiltersOptions" [value]="groupValue">
+          {{ groupValue }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field class="dense-2" appearance="outline" subscriptSizing="dynamic">
+      <mat-label class="ft-14-400 dropdown-label">
+        {{ 'home.view-experiment.graph-time.text' | translate }}
+      </mat-label>
+      <mat-select
+        class="ft-14-400"
+        [(ngModel)]="selectedDateFilter"
+        (selectionChange)="applyExperimentFilter(ExperimentFilter.DATE_FILTER)"
+      >
+        <mat-option class="ft-14-400" *ngFor="let dateFilterType of dateFilterOptions" [value]="dateFilterType.value">
+          {{ dateFilterType.viewValue | titlecase }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+  </div>
+
+  <div class="chart-container">
+    <div class="condition-container">
+      <div class="condition" *ngFor="let condition of graphColorIndicators; let index = index">
+        <span class="color-box" [ngStyle]="{ 'background-color': colors[index] }"></span>
+        <span>{{ condition.conditionCode }}</span>
+      </div>
+    </div>
+    <br />
+    <div class="chart">
+      <div class="chart-data">
+        <ngx-charts-bar-vertical-stacked
+          [scheme]="colorScheme"
+          [results]="graphData"
+          [xAxis]="showLabelOfxAxis"
+          [yAxis]="true"
+          [legend]="false"
+          [barPadding]="8"
+          [noBarWhenZero]="true"
+          [xAxisTickFormatting]="formateXAxisLabel"
+          [yAxisTickFormatting]="formateYAxisLabel"
+        >
+        </ngx-charts-bar-vertical-stacked>
+        <div class="spinner" *ngIf="isGraphLoading$ | async">
+          <mat-spinner diameter="60"></mat-spinner>
+        </div>
+      </div>
+
+      <div class="enrollment-statistic">
+        <div class="enrollment-statistic__total">
+          <span class="ft-16-600 title">
+            {{ 'home.view-experiment.enrollment-over-time.user-enrollments-across-sites.text' | translate }}
+          </span>
+          <span class="ft-36-700 numbers">{{ totalMarkedUsers }}</span>
+        </div>
+        <div class="enrollment-statistic__unique">
+          <span class="ft-16-600 title">
+            {{ 'home.view-experiment.enrollment-over-time.unique-users-enrolled.text' | translate }}
+          </span>
+          <span class="ft-36-700 numbers">{{ experiment.stat.users }}</span>
+        </div>
+        <div class="enrollment-statistic__class" [ngClass]="{ 'group-enabled': selectedGroupFilter !== 'individual' }">
+          <span class="ft-16-600 title">
+            {{ 'home.view-experiment.enrollment-over-time.group-enrollments-across-sites.text' | translate }}
+          </span>
+          <span class="ft-36-700 numbers">{{ totalMarkedGroups }}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-over-time/enrollment-over-time.component.scss
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-over-time/enrollment-over-time.component.scss
@@ -1,0 +1,118 @@
+.enrollment-over-time {
+  padding: 0 34px 34px;
+
+  .title {
+    display: block;
+    margin-bottom: 20px;
+  }
+
+  .enrollment-filters {
+    display: flex;
+    justify-content: space-between;
+    column-gap: 20px;
+
+    .sites {
+      width: 250px;
+    }
+
+    .conditions {
+      width: 400px;
+    }
+  }
+
+  .chart-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    margin-top: 20px;
+
+    .condition-container {
+      display: flex;
+      flex-direction: column;
+      margin-bottom: 20px;
+      padding-left: 15px;
+
+      .condition {
+        display: flex;
+        align-items: center;
+        margin-right: 30px;
+
+        .color-box {
+          display: inline-block;
+          margin-right: 12px;
+          border-radius: 4px;
+          width: 20px;
+          height: 20px;
+        }
+      }
+    }
+
+    .chart {
+      display: flex;
+
+      &-data {
+        position: relative;
+        flex-grow: 1;
+
+        .spinner {
+          display: flex;
+          position: absolute;
+          align-items: center;
+          justify-content: center;
+          width: 100%;
+          height: 100%;
+        }
+      }
+    }
+
+    .enrollment-statistic {
+      display: flex;
+      flex-direction: column;
+      margin-left: 30px;
+      width: 225px;
+      text-align: center;
+
+      &__total {
+        padding-bottom: 28px;
+      }
+
+      &__unique {
+        padding-bottom: 28px;
+        border-top: 1px solid var(--grey);
+        padding-top: 28px;
+      }
+
+      &__class {
+        visibility: hidden;
+        border-top: 1px solid var(--grey);
+        padding-top: 28px;
+
+        &.group-enabled {
+          visibility: visible;
+        }
+      }
+
+      .title {
+        display: block;
+        color: var(--grey-5);
+      }
+
+      .numbers {
+        display: block;
+        margin-top: 10px;
+        color: var(--blue);
+      }
+    }
+  }
+
+  ::ng-deep .ngx-charts {
+    ::ng-deep text {
+      font-family: 'Open Sans';
+      font-weight: 600;
+    }
+  }
+}
+
+.mat-mdc-checkbox {
+  padding-left: 4px;
+}

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-over-time/enrollment-over-time.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-over-time/enrollment-over-time.component.ts
@@ -1,0 +1,356 @@
+import { Component, Input, OnChanges, SimpleChanges, OnInit, OnDestroy } from '@angular/core';
+import { ASSIGNMENT_UNIT } from 'upgrade_types';
+import {
+  ExperimentVM,
+  DATE_RANGE,
+  IEnrollmentStatByDate,
+  ExperimentConditionFilterOptions,
+  ExperimentPartitionFilterOptions,
+  ExperimentDateFilterOptions,
+  ExperimentCondition,
+} from '../../../../../../../../core/experiments/store/experiments.model';
+import { ExperimentService } from '../../../../../../../../core/experiments/experiments.service';
+import { filter } from 'rxjs/operators';
+import { MatCheckboxChange, MatCheckboxModule } from '@angular/material/checkbox';
+import { Subscription } from 'rxjs';
+import { TranslateModule } from '@ngx-translate/core';
+import { CommonModule } from '@angular/common';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { NgxChartsModule } from '@swimlane/ngx-charts';
+import { MatInputModule } from '@angular/material/input';
+import { FormsModule } from '@angular/forms';
+
+// Used in EnrollmentOverTimeComponent
+enum ExperimentFilterType {
+  GROUP_FILTER = 'Group filter',
+  CONDITION_FILTER = 'Condition filter',
+  PARTITION_FILTER = 'Partition filter',
+  DATE_FILTER = 'Date filter',
+}
+
+const INDIVIDUAL = 'individual';
+
+@Component({
+  selector: 'app-enrollment-over-time',
+  templateUrl: './enrollment-over-time.component.html',
+  imports: [
+    CommonModule,
+    TranslateModule,
+    MatFormFieldModule,
+    MatSelectModule,
+    NgxChartsModule,
+    MatInputModule,
+    FormsModule,
+    MatCheckboxModule,
+  ],
+  styleUrls: ['./enrollment-over-time.component.scss'],
+  standalone: true,
+})
+export class EnrollmentOverTimeComponent implements OnChanges, OnInit, OnDestroy {
+  @Input() experiment: ExperimentVM;
+  groupFiltersOptions: string[] = [];
+  conditionsFilterOptions: ExperimentConditionFilterOptions[] = [];
+  partitionsFilterOptions: ExperimentPartitionFilterOptions[] = [];
+  dateFilterOptions: ExperimentDateFilterOptions[] = [
+    { value: DATE_RANGE.LAST_SEVEN_DAYS, viewValue: 'Last 7 days' },
+    { value: DATE_RANGE.LAST_TWO_WEEKS, viewValue: 'Last 2 weeks' },
+    { value: DATE_RANGE.LAST_ONE_MONTH, viewValue: 'Last 1 month' },
+    { value: DATE_RANGE.LAST_THREE_MONTHS, viewValue: 'Last 3 months' },
+    { value: DATE_RANGE.LAST_SIX_MONTHS, viewValue: 'Last 6 months' },
+    { value: DATE_RANGE.LAST_TWELVE_MONTHS, viewValue: 'Last 12 months' },
+    { value: DATE_RANGE.TOTAL, viewValue: 'Total' },
+  ];
+  selectedGroupFilter: string = INDIVIDUAL;
+  selectedCondition: string[] = [];
+  selectedPartition: string[] = [];
+  selectedDateFilter: DATE_RANGE = DATE_RANGE.TOTAL;
+  effectiveDateFilter: DATE_RANGE;
+  graphData = [];
+  copyGraphData: IEnrollmentStatByDate[] = [];
+  isInitialLoad = true;
+  showLabelOfxAxis = true;
+  graphColorIndicators: ExperimentCondition[] = [];
+
+  colors = [
+    '#31e8dd',
+    '#7dc7fb',
+    '#fedb64',
+    '#51ed8f',
+    '#ddaaf8',
+    '#fd9099',
+    '#14c9be',
+    '#57ff6d',
+    '#3dffec',
+    '#fedb64',
+    '#0a6de6',
+    '#da0766',
+    '#cd8014',
+    '#fa59a1',
+  ];
+  colorScheme = {
+    domain: this.colors,
+  };
+  totalMarkedUsers = 0;
+  totalMarkedGroups = 0;
+
+  graphInfoSub: Subscription;
+  isGraphLoading$ = this.experimentService.isGraphLoading$;
+
+  constructor(private experimentService: ExperimentService) {
+    this.formateXAxisLabel = this.formateXAxisLabel.bind(this);
+  }
+
+  // Getters
+  get ExperimentFilter() {
+    return ExperimentFilterType;
+  }
+
+  get AssignmentUnit() {
+    return ASSIGNMENT_UNIT;
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.experiment && this.isInitialLoad) {
+      this.isInitialLoad = false;
+      this.conditionsFilterOptions = [];
+      this.selectedCondition = [];
+      this.experiment.conditions.forEach((condition) => {
+        this.conditionsFilterOptions.push({ code: condition.conditionCode, id: condition.id });
+        this.selectedCondition.push(condition.id);
+      });
+      this.conditionsFilterOptions.sort((a, b) => a.code.localeCompare(b.code));
+
+      this.partitionsFilterOptions = [];
+      this.selectedPartition = [];
+      this.experiment.partitions.forEach((partition) => {
+        this.partitionsFilterOptions.push({
+          point: partition.site,
+          id: partition.id,
+          twoCharacterId: partition.twoCharacterId,
+        });
+        this.selectedPartition.push(partition.id);
+      });
+
+      this.groupFiltersOptions =
+        this.experiment.assignmentUnit === ASSIGNMENT_UNIT.INDIVIDUAL
+          ? [INDIVIDUAL]
+          : [INDIVIDUAL, this.experiment.group];
+    }
+    if (this.totalMarkedUsers > 0) {
+      this.showLabelOfxAxis = true;
+    } else {
+      this.showLabelOfxAxis = false;
+    }
+  }
+
+  ngOnInit() {
+    // Creating a new array with experiment conditionCode for the condition colour indicator to align with sorted graphData
+    this.graphColorIndicators = [...this.experiment.conditions];
+    this.graphColorIndicators.sort((a, b) => a.conditionCode.localeCompare(b.conditionCode));
+
+    this.graphInfoSub = this.experimentService.selectExperimentGraphInfo$
+      .pipe(filter((info) => !!info))
+      .subscribe((graphInfo: IEnrollmentStatByDate[]) => {
+        this.copyGraphData = graphInfo;
+        this.populateGraphData(graphInfo);
+      });
+    this.setEffectiveDateFilter();
+
+    // Used to fetch graph data for the whole date range initially
+    this.experimentService.setGraphRange(this.effectiveDateFilter, this.experiment.id, -new Date().getTimezoneOffset());
+  }
+
+  // remove empty series data labels
+  formateXAxisLabel(value) {
+    if (
+      this.effectiveDateFilter === DATE_RANGE.LAST_SEVEN_DAYS ||
+      this.effectiveDateFilter === DATE_RANGE.LAST_TWO_WEEKS ||
+      this.effectiveDateFilter === DATE_RANGE.LAST_ONE_MONTH
+    ) {
+      return typeof value === 'string' ? value.substring(0, 5) : '';
+    } else if (this.effectiveDateFilter === DATE_RANGE.TOTAL) {
+      return typeof value === 'string' ? value.substring(0, 4) : '';
+    }
+    return typeof value === 'string' ? value.substring(0, 3) : '';
+  }
+
+  formateYAxisLabel(value) {
+    return value % 1 !== 0 ? '' : value;
+  }
+
+  populateGraphData(graphData: IEnrollmentStatByDate[]) {
+    this.graphData = this.setDataInGraphFormat(graphData);
+    switch (this.effectiveDateFilter) {
+      case DATE_RANGE.LAST_SEVEN_DAYS:
+        this.graphData = [...this.graphData, ...this.formEmptyGraphSeriesData(5)];
+        break;
+      case DATE_RANGE.LAST_TWO_WEEKS:
+        this.graphData = [...this.graphData, ...this.formEmptyGraphSeriesData(1)];
+        break;
+      case DATE_RANGE.LAST_THREE_MONTHS:
+        this.graphData = [...this.graphData, ...this.formEmptyGraphSeriesData(9)];
+        break;
+      case DATE_RANGE.LAST_SIX_MONTHS:
+        this.graphData = [...this.graphData, ...this.formEmptyGraphSeriesData(6)];
+        break;
+      default:
+        this.graphData = [...this.graphData];
+        break;
+    }
+  }
+
+  setDataInGraphFormat(data: IEnrollmentStatByDate[]) {
+    const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+    const months = [
+      'January',
+      'February',
+      'March',
+      'April',
+      'May',
+      'June',
+      'July',
+      'August',
+      'September',
+      'October',
+      'November',
+      'December',
+    ];
+    this.totalMarkedUsers = 0;
+    this.totalMarkedGroups = 0;
+
+    let series = [];
+    return data.map((graphData) => {
+      series = [];
+      const graphInfoConditions = graphData.stats.conditions;
+      this.experiment.conditions.map((condition) => {
+        if (this.selectedCondition.includes(condition.id)) {
+          let users = 0;
+          let groups = 0;
+          // Find index based on experiment conditions from graphInfoConditions to maintain colors
+          const index = graphInfoConditions.findIndex((graphCondition) => graphCondition.id === condition.id);
+          graphInfoConditions[index]?.partitions.map((partition) => {
+            if (this.selectedPartition.includes(partition.id)) {
+              users += partition.users;
+              groups += partition.groups;
+            }
+          });
+          series.push({
+            name: this.getConditionCode(condition.id),
+            value: this.selectedGroupFilter === INDIVIDUAL ? users : groups,
+          });
+          this.totalMarkedUsers += users;
+          this.totalMarkedGroups += groups;
+        } else {
+          series.push({
+            name: this.getConditionCode(condition.id),
+            value: 0,
+          });
+        }
+      });
+
+      // Sort the series array alphabetically based on the condition names.
+      // This ensures consistent ordering of conditions in the resulting graph.
+      series.sort((a, b) => a.name.localeCompare(b.name));
+
+      return {
+        name:
+          this.effectiveDateFilter === DATE_RANGE.LAST_SEVEN_DAYS ||
+          this.effectiveDateFilter === DATE_RANGE.LAST_TWO_WEEKS ||
+          this.effectiveDateFilter === DATE_RANGE.LAST_ONE_MONTH
+            ? this.dateToString(new Date(graphData.date), days)
+            : this.effectiveDateFilter === DATE_RANGE.TOTAL
+            ? new Date(graphData.date).getFullYear().toString()
+            : months[new Date(graphData.date).getMonth()],
+        series,
+      };
+    });
+  }
+
+  applyExperimentFilter(type: ExperimentFilterType) {
+    switch (type) {
+      case ExperimentFilterType.DATE_FILTER:
+        this.setEffectiveDateFilter();
+        this.experimentService.setGraphRange(
+          this.effectiveDateFilter,
+          this.experiment.id,
+          -new Date().getTimezoneOffset()
+        );
+        break;
+      default:
+        this.populateGraphData(this.copyGraphData);
+    }
+  }
+
+  setEffectiveDateFilter() {
+    const now = new Date();
+    const createdAt = new Date(this.experiment.createdAt);
+    const monthAgo = new Date(now.getFullYear(), now.getMonth() - 1, now.getDate());
+    const yearAgo = new Date(now.getFullYear() - 1, now.getMonth(), now.getDate());
+
+    if (this.selectedDateFilter === DATE_RANGE.TOTAL) {
+      if (createdAt > monthAgo) {
+        this.effectiveDateFilter = DATE_RANGE.LAST_ONE_MONTH;
+      } else if (createdAt > yearAgo) {
+        this.effectiveDateFilter = DATE_RANGE.LAST_TWELVE_MONTHS;
+      } else {
+        this.effectiveDateFilter = DATE_RANGE.TOTAL;
+      }
+    } else {
+      this.effectiveDateFilter = this.selectedDateFilter;
+    }
+  }
+
+  getConditionCode(conditionId: string): string {
+    return this.experiment.conditions.reduce(
+      (acc, condition) => (acc = condition.id === conditionId ? condition.conditionCode : acc),
+      ''
+    );
+  }
+
+  // Used to form empty series data to keep graph bar width same different value of time filter
+  formEmptyGraphSeriesData(limit: number) {
+    const emptySeries = [];
+    for (let i = 0; i < limit; i++) {
+      emptySeries.push({
+        name: i,
+        series: [{ name: '', value: 0 }],
+      });
+    }
+    return emptySeries;
+  }
+
+  // For maintaining checkbox Select All in condition and partition filter
+  isChecked(type: string): boolean {
+    const selectedType = type === 'conditions' ? this.selectedCondition : this.selectedPartition;
+    const filterOptions = type === 'conditions' ? this.conditionsFilterOptions : this.partitionsFilterOptions;
+    return selectedType.length && filterOptions.length && selectedType.length === filterOptions.length;
+  }
+
+  isIndeterminate(type: string): boolean {
+    const selectedType = type === 'conditions' ? this.selectedCondition : this.selectedPartition;
+    const filterOptions = type === 'conditions' ? this.conditionsFilterOptions : this.partitionsFilterOptions;
+    return selectedType && filterOptions.length && selectedType.length && selectedType.length < filterOptions.length;
+  }
+
+  toggleSelection(change: MatCheckboxChange, type: string): void {
+    const selectedType = type === 'conditions' ? 'selectedCondition' : 'selectedPartition';
+    const filterOptions = type === 'conditions' ? 'conditionsFilterOptions' : 'partitionsFilterOptions';
+    this[selectedType] = change.checked ? this[filterOptions].map((data) => data.id) : [];
+    this.populateGraphData(this.copyGraphData);
+  }
+
+  dateToString(date: Date, days: string[]) {
+    const dd = String(date.getDate()).padStart(2, '0');
+    const mm = String(date.getMonth() + 1).padStart(2, '0');
+    const yy = date.getFullYear();
+    const day = days[date.getDay()].substring(0, 3);
+    const newDate = mm + '/' + dd + '/' + yy + '-' + day;
+    return newDate;
+  }
+
+  ngOnDestroy() {
+    this.experimentService.setGraphRange(null, this.experiment.id, -new Date().getTimezoneOffset());
+    this.graphInfoSub.unsubscribe();
+  }
+}

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/experiment-enrollment-data-section-card.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/experiment-enrollment-data-section-card.component.ts
@@ -7,7 +7,6 @@ import {
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 import { ExperimentEnrollmentDataComponent } from './experiment-enrollment-data/experiment-enrollment-data.component';
-import { EnrollmentOverTimeComponent } from '../../../../../home/components/enrollment-over-time/enrollment-over-time.component';
 import { ExperimentService } from '../../../../../../../core/experiments/experiments.service';
 import { AuthService } from '../../../../../../../core/auth/auth.service';
 
@@ -19,7 +18,6 @@ import { AuthService } from '../../../../../../../core/auth/auth.service';
     CommonSectionCardTitleHeaderComponent,
     CommonSectionCardActionButtonsComponent,
     ExperimentEnrollmentDataComponent,
-    EnrollmentOverTimeComponent,
     TranslateModule,
   ],
   templateUrl: './experiment-enrollment-data-section-card.component.html',

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/experiment-enrollment-data/experiment-enrollment-data.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/experiment-enrollment-data/experiment-enrollment-data.component.html
@@ -1,5 +1,5 @@
 <div class="data-container">
-  <enrollment-over-time [experiment]="experiment"></enrollment-over-time>
+  <app-enrollment-over-time [experiment]="experiment"></app-enrollment-over-time>
 
-  <enrollment-condition-table [experiment]="experiment"></enrollment-condition-table>
+  <app-enrollment-condition-table [experiment]="experiment"></app-enrollment-condition-table>
 </div>

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/experiment-enrollment-data/experiment-enrollment-data.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/experiment-enrollment-data/experiment-enrollment-data.component.ts
@@ -1,8 +1,8 @@
 import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
-import { EnrollmentConditionTableComponent } from '../../../../../../home/components/enrollment-condition-table/enrollment-condition-table.component';
-import { EnrollmentOverTimeComponent } from '../../../../../../home/components/enrollment-over-time/enrollment-over-time.component';
+import { EnrollmentConditionTableComponent } from '../enrollment-condition-table/enrollment-condition-table.component';
+import { EnrollmentOverTimeComponent } from '../enrollment-over-time/enrollment-over-time.component';
 import { ExperimentVM } from '../../../../../../../../core/experiments/store/experiments.model';
 import { ExperimentService } from '../../../../../../../../core/experiments/experiments.service';
 


### PR DESCRIPTION
this moves the 'old' enrollment data page components out of the old file directory into new structure as standalone components nested under the section card that uses them.

also renamed "table-row" to be something more like our newer component names, "enrollment-condition-expandable-row"