### PR TITLE
Update experiment status chip text and color

### DIFF
--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-action-buttons/common-section-card-action-buttons.component.scss
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-action-buttons/common-section-card-action-buttons.component.scss
@@ -14,20 +14,20 @@
     }
 
     button {
-      --mdc-filled-button-label-text-color: white;
+      --mat-button-filled-label-text-color: white;
 
       // Experiment action button colors
       &.button-start,
       &.button-resume {
-        --mdc-filled-button-container-color: var(--status-enrolling);
+        --mat-button-filled-container-color: var(--status-running);
       }
 
       &.button-pause {
-        --mdc-filled-button-container-color: var(--status-paused);
+        --mat-button-filled-container-color: var(--status-paused);
       }
 
       &.button-stop {
-        --mdc-filled-button-container-color: var(--status-cancelled);
+        --mat-button-filled-container-color: var(--red-2);
       }
     }
   }

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-status-indicator-chip/common-status-indicator-chip.component.scss
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-status-indicator-chip/common-status-indicator-chip.component.scss
@@ -6,35 +6,11 @@
     pointer-events: none;
     --mat-chip-container-shape-radius: 4px;
 
-    &.disabled {
-      --mat-chip-label-text-color: var(--status-disabled);
-      border: 1px solid var(--status-disabled);
-      background-color: var(--status-disabled-alpha);
-    }
-
-    &.enabled {
-      --mat-chip-label-text-color: var(--status-enabled);
-      border: 1px solid var(--status-enabled);
-      background-color: var(--status-enabled-alpha);
-    }
-
-    &.draft {
-      --mat-chip-label-text-color: var(--status-draft);
-      border: 1px solid var(--status-draft);
-      background-color: var(--status-draft-alpha);
-    }
-
-    &.inactive,
-    &.warning {
+    // experiment statuses
+    &.inactive {
       --mat-chip-label-text-color: var(--status-inactive);
       border: 1px solid var(--status-inactive);
       background-color: var(--status-inactive-alpha);
-    }
-
-    &.enrolling {
-      --mat-chip-label-text-color: var(--status-enrolling);
-      border: 1px solid var(--status-enrolling);
-      background-color: var(--status-enrolling-alpha);
     }
 
     &.scheduled {
@@ -49,18 +25,25 @@
       background-color: var(--status-preview-alpha);
     }
 
+    &.enrolling,
+    &.running {
+      --mat-chip-label-text-color: var(--status-running);
+      border: 1px solid var(--status-running);
+      background-color: var(--status-running-alpha);
+    }
+
     &.enrollmentComplete,
-    &.compatible {
-      --mat-chip-label-text-color: var(--status-enrollment-complete);
-      border: 1px solid var(--status-enrollment-complete);
-      background-color: var(--status-enrollment-complete-alpha);
+    &.paused {
+      --mat-chip-label-text-color: var(--status-paused);
+      border: 1px solid var(--status-paused);
+      background-color: var(--status-paused-alpha);
     }
 
     &.cancelled,
-    &.incompatible {
-      --mat-chip-label-text-color: var(--status-cancelled);
-      border: 1px solid var(--status-cancelled);
-      background-color: var(--status-cancelled-alpha);
+    &.completed {
+      --mat-chip-label-text-color: var(--status-completed);
+      border: 1px solid var(--status-completed);
+      background-color: var(--status-completed-alpha);
     }
 
     &.archived {
@@ -69,6 +52,20 @@
       background-color: var(--status-archived-alpha);
     }
 
+    // feature flag statuses
+    &.disabled {
+      --mat-chip-label-text-color: var(--status-disabled);
+      border: 1px solid var(--status-disabled);
+      background-color: var(--status-disabled-alpha);
+    }
+
+    &.enabled {
+      --mat-chip-label-text-color: var(--status-enabled);
+      border: 1px solid var(--status-enabled);
+      background-color: var(--status-enabled-alpha);
+    }
+
+    // segment statuses
     &.excluded {
       --mat-chip-label-text-color: var(--status-excluded);
       border: 1px solid var(--status-excluded);
@@ -85,6 +82,25 @@
       --mat-chip-label-text-color: var(--status-used);
       border: 1px solid var(--status-used);
       background-color: var(--status-used-alpha);
+    }
+
+    // import compatibility statuses
+    &.incompatible {
+      --mat-chip-label-text-color: var(--status-incompatible);
+      border: 1px solid var(--status-incompatible);
+      background-color: var(--status-incompatible-alpha);
+    }
+
+    &.warning {
+      --mat-chip-label-text-color: var(--status-warning);
+      border: 1px solid var(--status-warning);
+      background-color: var(--status-warning-alpha);
+    }
+
+    &.compatible {
+      --mat-chip-label-text-color: var(--status-compatible);
+      border: 1px solid var(--status-compatible);
+      background-color: var(--status-compatible-alpha);
     }
   }
 

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-status-indicator-chip/common-status-indicator-chip.component.ts
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-status-indicator-chip/common-status-indicator-chip.component.ts
@@ -40,6 +40,12 @@ export class CommonStatusIndicatorChipComponent {
   @Input() warningMessage?: string;
   chipText = '';
 
+  private readonly DISPLAY_NAME_OVERRIDES: Record<string, string> = {
+    [STATUS_INDICATOR_CHIP_TYPE.ENROLLING]: 'Running',
+    [STATUS_INDICATOR_CHIP_TYPE.ENROLLMENT_COMPLETE]: 'Paused',
+    [STATUS_INDICATOR_CHIP_TYPE.CANCELLED]: 'Completed',
+  };
+
   ngOnInit() {
     this.chipText = this.convertToTitleCase(this.chipClass);
   }
@@ -51,9 +57,9 @@ export class CommonStatusIndicatorChipComponent {
   }
 
   convertToTitleCase(value: STATUS_INDICATOR_CHIP_TYPE): string {
-    // Handle special case for enrollmentComplete
-    if (value === STATUS_INDICATOR_CHIP_TYPE.ENROLLMENT_COMPLETE) {
-      return 'Enrollment Complete';
+    // Check for special display name overrides first
+    if (this.DISPLAY_NAME_OVERRIDES[value]) {
+      return this.DISPLAY_NAME_OVERRIDES[value];
     }
 
     // For all other cases, just capitalize the first letter

--- a/frontend/projects/upgrade/src/styles/variables.scss
+++ b/frontend/projects/upgrade/src/styles/variables.scss
@@ -1,42 +1,35 @@
 :root {
-  /* color variables (added for new design) */
-  --zircon: #f5f7fe;
-  --water: #f0f2f9;
-  --light-grey-2: #dce0e6;
-  --grey-3: #929fae; /* same as --grey-3 */
-  --disabled-text: #8b8b8b;
-  --dark-grey: #646e7b;
-  --darker-grey: #444e5b;
-  --light-black: #222b45; /* same as --black-2 */
-  --red-2: #ff3333;
-  --status-disabled: #ff9933;
-  --status-enabled: #3366ff;
-  --status-draft: #cc66ff;
+  /* status variables */
   --status-inactive: #ff9933;
-  --status-enrolling: #3366ff;
-  --status-paused: #6478c8;
   --status-scheduled: #829bf8;
   --status-preview: #829bf8;
-  --status-enrollment-complete: #33cc66;
-  --status-cancelled: #ff3333;
+  --status-running: #3366ff;
+  --status-paused: #6478c8;
+  --status-completed: #33cc66;
   --status-archived: #999999;
+  --status-disabled: #ff9933;
+  --status-enabled: #3366ff;
   --status-excluded: #ff3333;
   --status-unused: #999999;
   --status-used: #3366ff;
-  --status-disabled-alpha: #ff99330c;
-  --status-enabled-alpha: #3366ff0c;
-  --status-draft-alpha: #cc66ff0c;
+  --status-incompatible: #ff3333;
+  --status-warning: #ff9933;
+  --status-compatible: #33cc66;
   --status-inactive-alpha: #ff99330c;
-  --status-enrolling-alpha: #3366ff0c;
-  --status-paused-alpha: #6478c80c;
   --status-scheduled-alpha: #829bf80c;
   --status-preview-alpha: #829bf80c;
-  --status-enrollment-complete-alpha: #33cc660c;
-  --status-cancelled-alpha: #ff33330c;
+  --status-running-alpha: #3366ff0c;
+  --status-paused-alpha: #6478c80c;
+  --status-completed-alpha: #33cc660c;
   --status-archived-alpha: #9999990c;
+  --status-disabled-alpha: #ff99330c;
+  --status-enabled-alpha: #3366ff0c;
   --status-excluded-alpha: #ff33330c;
   --status-unused-alpha: #9999990c;
   --status-used-alpha: #3366ff0c;
+  --status-incompatible-alpha: #ff33330c;
+  --status-warning-alpha: #ff99330c;
+  --status-compatible-alpha: #33cc660c;
 
   /* color variables */
   --blue: #3366ff;
@@ -51,9 +44,18 @@
   --grey-5: #939bab;
   --grey-6: #6e6f72;
   --light-grey: #d3d3d3;
+  --light-black: #222b45;
   --grey-message: #8f9bb3;
   --red: #ff0000;
+  --red-2: #ff3333;
   --green: #008000;
+  --green-2: #33cc66;
+  --zircon: #f5f7fe;
+  --water: #f0f2f9;
+  --light-grey-2: #dce0e6;
+  --disabled-text: #8b8b8b;
+  --dark-grey: #646e7b;
+  --darker-grey: #444e5b;
 
   /* font-size variables */
   --text-size-xxxxx-large: 2rem;

--- a/types/src/Experiment/enums.ts
+++ b/types/src/Experiment/enums.ts
@@ -61,13 +61,12 @@ export enum PAUSE_BEHAVIOR {
 
 export enum EXPERIMENT_STATE {
   INACTIVE = 'inactive',
-  PREVIEW = 'preview',
   SCHEDULED = 'scheduled',
-  ENROLLING = 'enrolling',
-  ENROLLMENT_COMPLETE = 'enrollmentComplete',
-  CANCELLED = 'cancelled',
+  PREVIEW = 'preview',
+  ENROLLING = 'enrolling', // New design: Running
+  ENROLLMENT_COMPLETE = 'enrollmentComplete', // New design: Paused
+  CANCELLED = 'cancelled', // New design: Completed
   ARCHIVED = 'archived',
-  DRAFT = 'draft',
 }
 
 export enum FEATURE_FLAG_STATUS {
@@ -325,21 +324,21 @@ export enum CACHE_PREFIX {
 }
 
 export enum STATUS_INDICATOR_CHIP_TYPE {
-  EXCLUDED = 'excluded',
-  USED = 'used',
-  UNUSED = 'unused',
-  ENABLED = 'enabled',
-  DISABLED = 'disabled',
-  DRAFT = 'draft',
-  ARCHIVED = 'archived',
   INACTIVE = 'inactive',
-  ENROLLING = 'enrolling',
-  ENROLLMENT_COMPLETE = 'enrollmentComplete',
-  CANCELLED = 'cancelled',
   SCHEDULED = 'scheduled',
-  COMPATIBLE = 'compatible',
+  PREVIEW = 'preview',
+  ENROLLING = 'enrolling', // New design: Running
+  ENROLLMENT_COMPLETE = 'enrollmentComplete', // New design: Paused
+  CANCELLED = 'cancelled', // New design: Completed
+  ARCHIVED = 'archived',
+  DISABLED = 'disabled',
+  ENABLED = 'enabled',
+  EXCLUDED = 'excluded',
+  UNUSED = 'unused',
+  USED = 'used',
   INCOMPATIBLE = 'incompatible',
   WARNING = 'warning',
+  COMPATIBLE = 'compatible',
 }
 
 export enum FEATURE_FLAG_PARTICIPANT_LIST_KEY {


### PR DESCRIPTION
Resolves #2833

Changes:
- Updated deprecated `--mdc-filled-` classes to `--mdc-button-filled`
- Cleaned up the chip styles in `common-status-indicator-chip.component.scss`
- Handled the chip text overrides in `common-status-indicator-chip.component.ts`
- Cleaned up the color variables in `variables.scss` (reordered some of them)
- Cleaned up the `enums.ts` by reordering, adding comments, and removing unused statuses (e.g., Draft)
