### PR TITLE
NO-TICKET tech/upgrade_client_lib: Add custom export for `lite` implementation

### DIFF
--- a/clientlibs/js/package-lock.json
+++ b/clientlibs/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "upgrade_client_lib",
-  "version": "6.2.2",
+  "version": "6.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "upgrade_client_lib",
-      "version": "6.2.2",
+      "version": "6.2.5",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.4.0",

--- a/clientlibs/js/package.json
+++ b/clientlibs/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upgrade_client_lib",
-  "version": "6.2.4",
+  "version": "6.2.5",
   "description": "Client library to communicate with the Upgrade server",
   "files": [
     "dist/*",
@@ -12,6 +12,11 @@
       "browser-lite": "./dist/browser-lite/index.js",
       "node": "./dist/node/index.js",
       "node-lite": "./dist/node-lite/index.js",
+      "types": "./index.d.ts"
+    },
+    "./lite": {
+      "browser": "./dist/browser-lite/index.js",
+      "node": "./dist/node-lite/index.js",
       "types": "./index.d.ts"
     },
     "./dist/browser": {


### PR DESCRIPTION
- This would help fixing the "Please import `lite` version of the to use custom httpClient" issue, while using the default entrypoint in CLC
  - For context, the `upgrade_client_lib` was created originally for the open-source community as an all-in-one package which includes an axios-based client, but for CL we needed a way to use cli-services angular httpClient, for which the team came up with a "lite" version
- Kept `browser-lite`/`node-lite` as part of the default entrypoint (`.`), just in case anyone would use it