### PR TITLE
Update the font styling of the ID label on details pages

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-overview-details-section-card/experiment-overview-details-section-card.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-overview-details-section-card/experiment-overview-details-section-card.component.html
@@ -7,6 +7,7 @@
     [updatedAt]="experiment.updatedAt"
     [versionNumber]="experiment.versionNumber"
     [chipClass]="experiment.state"
+    [id]="experiment.id"
     [pauseBehaviorText]="experiment.state === EXPERIMENT_STATE.ENROLLMENT_COMPLETE ? getPauseBehaviorText(experiment) : undefined"
     (pauseBehaviorClick)="handlePauseBehaviorClick(experiment)"
   ></app-common-section-card-title-header>

--- a/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-overview-details-section-card/feature-flag-overview-details-section-card.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-overview-details-section-card/feature-flag-overview-details-section-card.component.html
@@ -6,6 +6,7 @@
     [createdAt]="flag.createdAt"
     [updatedAt]="flag.updatedAt"
     [chipClass]="flag.status"
+    [id]="flag.id"
     [warningMessage]="
       (shouldShowWarning$ | async) ? ('feature-flags.global-status-warning-tooltip.text' | translate) : ''
     "

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-title-header/common-section-card-title-header.component.html
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-title-header/common-section-card-title-header.component.html
@@ -37,7 +37,5 @@
       </ng-container>
     </ng-container>
   </p>
-  <ng-container *ngIf="id">
-    <div class="subtitle ft-14-400">ID: {{ id }}</div>
-  </ng-container>
+  <span *ngIf="id" class="segment-id ft-10-400">ID: {{ id }}</span>
 </div>

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-title-header/common-section-card-title-header.component.html
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-title-header/common-section-card-title-header.component.html
@@ -37,5 +37,5 @@
       </ng-container>
     </ng-container>
   </p>
-  <span *ngIf="id" class="segment-id ft-10-400">ID: {{ id }}</span>
+  <span *ngIf="id" class="item-id ft-10-400">ID: {{ id }}</span>
 </div>

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-title-header/common-section-card-title-header.component.scss
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-title-header/common-section-card-title-header.component.scss
@@ -38,4 +38,10 @@
       cursor: pointer;
     }
   }
+
+  .segment-id {
+    margin-top: 4px;
+    color: var(--dark-grey);
+    opacity: 0.75;
+  }
 }

--- a/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-title-header/common-section-card-title-header.component.scss
+++ b/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-section-card-title-header/common-section-card-title-header.component.scss
@@ -39,7 +39,7 @@
     }
   }
 
-  .segment-id {
+  .item-id {
     margin-top: 4px;
     color: var(--dark-grey);
     opacity: 0.75;


### PR DESCRIPTION
Resolves #2851 

### Screenshot after change applied:
<img width="1000" height="851" alt="Screenshot 2026-01-15 at 3 12 43 PM" src="https://github.com/user-attachments/assets/8701a84e-126e-4088-b4a4-41953b7e014c" />
