### PR TITLE
Optimize experiment pagination query by removing unused JOINs

### DIFF
--- a/backend/packages/Upgrade/src/api/services/ExperimentService.ts
+++ b/backend/packages/Upgrade/src/api/services/ExperimentService.ts
@@ -184,28 +184,7 @@ export class ExperimentService {
 
     let queryBuilderToReturn = this.experimentRepository
       .createQueryBuilder('experiment')
-      .leftJoinAndSelect('experiment.conditions', 'conditions')
       .leftJoinAndSelect('experiment.partitions', 'partitions')
-      .leftJoinAndSelect('experiment.queries', 'queries')
-      .leftJoinAndSelect('experiment.factors', 'factors')
-      .leftJoinAndSelect('factors.levels', 'levels')
-      .leftJoinAndSelect('queries.metric', 'metric')
-      .leftJoinAndSelect('experiment.stratificationFactor', 'stratificationFactor')
-      .leftJoinAndSelect('experiment.experimentSegmentInclusion', 'experimentSegmentInclusion')
-      .leftJoinAndSelect('experimentSegmentInclusion.segment', 'segmentInclusion')
-      .leftJoinAndSelect('segmentInclusion.individualForSegment', 'individualForSegment')
-      .leftJoinAndSelect('segmentInclusion.groupForSegment', 'groupForSegment')
-      .leftJoinAndSelect('segmentInclusion.subSegments', 'subSegment')
-      .leftJoinAndSelect('experiment.experimentSegmentExclusion', 'experimentSegmentExclusion')
-      .leftJoinAndSelect('experimentSegmentExclusion.segment', 'segmentExclusion')
-      .leftJoinAndSelect('segmentExclusion.individualForSegment', 'individualForSegmentExclusion')
-      .leftJoinAndSelect('segmentExclusion.groupForSegment', 'groupForSegmentExclusion')
-      .leftJoinAndSelect('segmentExclusion.subSegments', 'subSegmentExclusion')
-      .leftJoinAndSelect('conditions.levelCombinationElements', 'levelCombinationElements')
-      .leftJoinAndSelect('levelCombinationElements.level', 'level')
-      .leftJoinAndSelect('conditions.conditionPayloads', 'conditionPayload')
-      .leftJoinAndSelect('partitions.conditionPayloads', 'ConditionPayloadsArray')
-      .leftJoinAndSelect('ConditionPayloadsArray.parentCondition', 'parentCondition')
       .where(`experiment.id IN ${paginatedParentSubQuery.getQuery()}`);
 
     if (sortParams) {
@@ -214,20 +193,7 @@ export class ExperimentService {
       queryBuilderToReturn = queryBuilderToReturn.addOrderBy('experiment.updatedAt', 'DESC');
     }
     const [experimentData, count] = await Promise.all([queryBuilderToReturn.getMany(), countQuery.getCount()]);
-    experimentData.forEach((experiment) => {
-      experiment.experimentSegmentExclusion = this.inferListTypesForExperimentListForExperimentRedesignDataChange(
-        experiment.experimentSegmentExclusion
-      );
-      experiment.experimentSegmentInclusion = this.inferListTypesForExperimentListForExperimentRedesignDataChange(
-        experiment.experimentSegmentInclusion
-      );
-    });
-    return [
-      experimentData.map((experiment) => {
-        return this.reducedConditionPayload(this.formattingPayload(this.formattingConditionPayload(experiment)));
-      }),
-      count || 0,
-    ];
+    return [experimentData, count || 0];
   }
 
   public async getSingleExperiment(id: string, logger?: UpgradeLogger): Promise<ExperimentDTO | undefined> {


### PR DESCRIPTION
Resolves #2859

This PR removes unused JOINs in the `/api/experiments/paginated` endpoint to improve query performance. I also reverted the indexing changes as suggested. In my testing, this made the endpoint ~10x faster.

Since I’m less familiar with this area of the codebase, I’d appreciate a careful review to confirm the changes are safe and correct.
