### PR TITLE
Default to the Data tab for experiments that have started

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-details-page-content.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-details-page-content.component.html
@@ -2,6 +2,7 @@
   <ng-container *ngIf="experiment$ | async as experiment; else loading">
     <app-common-section-card-list class="common-section-card-list">
       <app-experiment-overview-details-section-card
+        [activeTabIndex]="activeTabIndex"
         [isSectionCardExpanded]="isSectionCardExpanded"
         (sectionCardExpandChange)="onSectionCardExpandChange($event)"
         (tabChange)="onTabChange($event)"

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-details-page-content.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-details-page-content.component.ts
@@ -16,7 +16,7 @@ import { ActivatedRoute, Router, NavigationEnd } from '@angular/router';
 import { ExperimentService } from '../../../../../../core/experiments/experiments.service';
 import { Observable, Subscription, combineLatest } from 'rxjs';
 import { map, filter, startWith } from 'rxjs/operators';
-import { Experiment } from '../../../../../../core/experiments/store/experiments.model';
+import { Experiment, EXPERIMENT_STATE } from '../../../../../../core/experiments/store/experiments.model';
 import { SegmentsService } from '../../../../../../core/segments/segments.service';
 import { MoocletExperimentHelperService } from '../../../../../../core/experiments/mooclet-helper.service';
 import { ASSIGNMENT_ALGORITHM } from 'upgrade_types';
@@ -47,7 +47,14 @@ export class ExperimentDetailsPageContentComponent implements OnInit, OnDestroy 
   activeTabIndex = 0; // 0 for Design, 1 for Data
   experiment$: Observable<Experiment>;
   experimentIdSub: Subscription;
+  experimentStateSub: Subscription;
   shouldShowRewardFeedback$: Observable<boolean>;
+  private lastExperimentId?: string;
+  private readonly dataTabStates = new Set<EXPERIMENT_STATE>([
+    EXPERIMENT_STATE.ENROLLING,
+    EXPERIMENT_STATE.ENROLLMENT_COMPLETE,
+    EXPERIMENT_STATE.CANCELLED,
+  ]);
 
   constructor(
     private readonly experimentsService: ExperimentService,
@@ -81,6 +88,15 @@ export class ExperimentDetailsPageContentComponent implements OnInit, OnDestroy 
     });
 
     this.experiment$ = this.experimentsService.selectedExperiment$;
+    this.experimentStateSub = this.experiment$
+      .pipe(filter((experiment): experiment is Experiment => !!experiment))
+      .subscribe((experiment) => {
+        // Default the tab based on experiment state only when switching to a new experiment
+        if (this.lastExperimentId !== experiment.id) {
+          this.lastExperimentId = experiment.id;
+          this.activeTabIndex = this.dataTabStates.has(experiment.state) ? 1 : 0;
+        }
+      });
     this.segmentService.fetchAllSegmentListOptions();
 
     // Determine if reward feedback card should be shown
@@ -107,5 +123,6 @@ export class ExperimentDetailsPageContentComponent implements OnInit, OnDestroy 
 
   ngOnDestroy() {
     this.experimentIdSub.unsubscribe();
+    this.experimentStateSub.unsubscribe();
   }
 }

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-metrics-data-section-card/experiment-query-result/experiment-query-result.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-metrics-data-section-card/experiment-query-result/experiment-query-result.component.ts
@@ -101,12 +101,13 @@ export class ExperimentQueryResultComponent implements OnInit, OnDestroy {
     } else {
       this.setConditionCount();
     }
-    this.queryResults = this.experiment.queries.map((query) => {
-      queryIds.push(query.id);
-      return {
-        [query.id]: [],
-      };
-    });
+    this.queryResults =
+      this.experiment?.queries?.map((query) => {
+        queryIds.push(query.id);
+        return {
+          [query.id]: [],
+        };
+      }) ?? [];
 
     this.analysisSub = this.analysisService.experimentQueryResult$(this.experiment.id).subscribe((queryResults) => {
       if (queryResults && queryResults.length) {
@@ -327,7 +328,7 @@ export class ExperimentQueryResultComponent implements OnInit, OnDestroy {
   }
 
   setConditionCount() {
-    this.maxLevelCount = this.experiment.conditions.length;
+    this.maxLevelCount = this.experiment?.conditions?.length ?? 0;
   }
 
   getFactorIndex(levelId: string): number {

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-overview-details-section-card/experiment-overview-details-footer/experiment-overview-details-footer.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-overview-details-section-card/experiment-overview-details-footer/experiment-overview-details-footer.component.html
@@ -1,4 +1,5 @@
 <app-common-tabbed-section-card-footer
   [tabLabels]="tabLabels"
+  [selectedIndex]="selectedIndex"
   (selectedTabChange)="onSelectedTabChange($event)"
 ></app-common-tabbed-section-card-footer>

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-overview-details-section-card/experiment-overview-details-footer/experiment-overview-details-footer.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-overview-details-section-card/experiment-overview-details-footer/experiment-overview-details-footer.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, OnInit, Input, Output } from '@angular/core';
 import { CommonTabbedSectionCardFooterComponent } from '../../../../../../../../shared-standalone-component-lib/components/common-tabbed-section-card-footer/common-tabbed-section-card-footer.component';
 
 @Component({
@@ -9,6 +9,7 @@ import { CommonTabbedSectionCardFooterComponent } from '../../../../../../../../
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ExperimentOverviewDetailsFooterComponent implements OnInit {
+  @Input() selectedIndex = 0;
   @Output() tabChange = new EventEmitter<number>();
 
   tabLabels = [

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-overview-details-section-card/experiment-overview-details-section-card.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-overview-details-section-card/experiment-overview-details-section-card.component.html
@@ -39,6 +39,7 @@
   <!-- footer -->
   <app-experiment-overview-details-footer
     footer
+    [selectedIndex]="activeTabIndex"
     (tabChange)="onSelectedTabChange($event)"
   ></app-experiment-overview-details-footer>
 </app-common-section-card>

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-overview-details-section-card/experiment-overview-details-section-card.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-overview-details-section-card/experiment-overview-details-section-card.component.ts
@@ -47,6 +47,7 @@ import { isMenuItemDisabled } from '../../../../../../../core/experiments/experi
 })
 export class ExperimentOverviewDetailsSectionCardComponent implements OnInit, OnDestroy {
   @Input() isSectionCardExpanded = true;
+  @Input() activeTabIndex = 0;
   @Output() sectionCardExpandChange = new EventEmitter<boolean>();
   @Output() tabChange = new EventEmitter<number>();
   permissions$: Observable<UserPermission> = this.authService.userPermissions$;

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-overview-details-section-card/experiment-overview-details-section-card.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-overview-details-section-card/experiment-overview-details-section-card.component.ts
@@ -339,7 +339,7 @@ export class ExperimentOverviewDetailsSectionCardComponent implements OnInit, On
       return this.translate.instant('experiments.details.pause-behavior-no-condition.text');
     } else if (experiment.postExperimentRule === POST_EXPERIMENT_RULE.ASSIGN && experiment.revertTo) {
       // Find the condition name from revertTo ID
-      const condition = experiment.conditions.find((c) => c.id === experiment.revertTo);
+      const condition = experiment.conditions?.find((c) => c.id === experiment.revertTo);
       const conditionName = condition ? condition.conditionCode : 'Unknown';
       return this.translate.instant('experiments.details.pause-behavior-assign.text', { conditionName });
     }


### PR DESCRIPTION
Resolves #2892

I know this wasn’t planned for 6.3, but it’s something we discussed a long time ago and felt closer to a small UX refinement than a new feature. I think defaulting to the Data tab once an experiment has started better matches the primary user intent for this page.

I’ve tested it locally and it behaves as expected. The changes are relatively small and straightforward, but if this feels risky to include this late (or if you dislike this new behavior), I’m totally fine deferring it.

**Note**: the changes in `experiment-query-result.component.ts` only add a couple of null-safety guards and are not related to the UX change in this PR.
