### PR TITLE
Add optional chaining to prevent null access errors

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-metrics-data-section-card/experiment-query-result/experiment-query-result.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-metrics-data-section-card/experiment-query-result/experiment-query-result.component.ts
@@ -101,12 +101,13 @@ export class ExperimentQueryResultComponent implements OnInit, OnDestroy {
     } else {
       this.setConditionCount();
     }
-    this.queryResults = this.experiment.queries.map((query) => {
-      queryIds.push(query.id);
-      return {
-        [query.id]: [],
-      };
-    });
+    this.queryResults =
+      this.experiment?.queries?.map((query) => {
+        queryIds.push(query.id);
+        return {
+          [query.id]: [],
+        };
+      }) ?? [];
 
     this.analysisSub = this.analysisService.experimentQueryResult$(this.experiment.id).subscribe((queryResults) => {
       if (queryResults && queryResults.length) {
@@ -327,7 +328,7 @@ export class ExperimentQueryResultComponent implements OnInit, OnDestroy {
   }
 
   setConditionCount() {
-    this.maxLevelCount = this.experiment.conditions.length;
+    this.maxLevelCount = this.experiment?.conditions?.length ?? 0;
   }
 
   getFactorIndex(levelId: string): number {

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-metrics-data-section-card/experiment-query-result/experiment-query-result.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-metrics-data-section-card/experiment-query-result/experiment-query-result.component.ts
@@ -83,7 +83,7 @@ export class ExperimentQueryResultComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     const queryIds = [];
-    this.experimentType = this.experiment.type;
+    this.experimentType = this.experiment?.type;
 
     if (this.experimentType === EXPERIMENT_TYPE.FACTORIAL) {
       this.setMaxLevelsCount();
@@ -108,6 +108,8 @@ export class ExperimentQueryResultComponent implements OnInit, OnDestroy {
           [query.id]: [],
         };
       }) ?? [];
+
+    if (!this.experiment?.id) return;
 
     this.analysisSub = this.analysisService.experimentQueryResult$(this.experiment.id).subscribe((queryResults) => {
       if (queryResults && queryResults.length) {

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-overview-details-section-card/experiment-overview-details-section-card.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-overview-details-section-card/experiment-overview-details-section-card.component.ts
@@ -334,7 +334,7 @@ export class ExperimentOverviewDetailsSectionCardComponent implements OnInit, On
       return this.translate.instant('experiments.details.pause-behavior-no-condition.text');
     } else if (experiment.postExperimentRule === POST_EXPERIMENT_RULE.ASSIGN && experiment.revertTo) {
       // Find the condition name from revertTo ID
-      const condition = experiment.conditions.find((c) => c.id === experiment.revertTo);
+      const condition = experiment.conditions?.find((c) => c.id === experiment.revertTo);
       const conditionName = condition ? condition.conditionCode : 'Unknown';
       return this.translate.instant('experiments.details.pause-behavior-assign.text', { conditionName });
     }


### PR DESCRIPTION
This PR just adds a few null-safety guards to prevent null access errors (I saw these errors while QA testing).