### PR TITLE
create an integer validator

### DIFF
--- a/frontend/projects/upgrade/src/app/core/experiments/mooclet-helper.service.spec.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/mooclet-helper.service.spec.ts
@@ -304,12 +304,12 @@ describe('MoocletAlgorithmHelperService', () => {
       const validators = service.getTSConfigurableFieldValidators();
       const defaults = service.getTSConfigurableDefaults();
 
-      // Each field should have 3 validators: required, min, max
-      expect(validators.batch_size.length).toBe(3);
-      expect(validators.uniform_threshold.length).toBe(3);
+      expect(validators.batch_size.length).toBe(4);
+      expect(validators.uniform_threshold.length).toBe(4);
+      expect(validators.prior_success.length).toBe(4);
+      expect(validators.prior_failure.length).toBe(4);
+
       expect(validators.tspostdiff_thresh.length).toBe(3);
-      expect(validators.prior_success.length).toBe(3);
-      expect(validators.prior_failure.length).toBe(3);
 
       // Test that min validator works correctly for batch_size
       const batchSizeMinValidator = validators.batch_size[1];
@@ -325,7 +325,11 @@ describe('MoocletAlgorithmHelperService', () => {
       const validators = service.getTSConfigurableFieldValidators();
 
       Object.values(validators).forEach((fieldValidators) => {
-        expect(fieldValidators.length).toBe(3);
+        if (fieldValidators === validators.tspostdiff_thresh) {
+          expect(fieldValidators.length).toBe(3);
+          return;
+        }
+        expect(fieldValidators.length).toBe(4);
       });
     });
   });

--- a/frontend/projects/upgrade/src/app/core/experiments/mooclet-helper.service.ts
+++ b/frontend/projects/upgrade/src/app/core/experiments/mooclet-helper.service.ts
@@ -12,6 +12,7 @@ import {
 import { ExperimentVM, TS_CONFIGURABLE_OVERVIEW_PARAM_LABELS } from './store/experiments.model';
 import { environment } from '../../../environments/environment';
 import { BullettedListKeyValueFormat } from '../../shared-standalone-component-lib/components/common-section-card-overview-details/common-section-card-overview-details.component';
+import { CommonFormHelpersService } from '../../shared/services/common-form-helpers.service';
 
 // ============================================================================
 // Pure Functions (exported for use in selectors and other pure contexts)
@@ -232,22 +233,30 @@ export class MoocletExperimentHelperService {
     const defaults = this.getTSConfigurableDefaults();
 
     return {
-      batch_size: [Validators.required, Validators.min(defaults.batch_size), Validators.max(DEFAULT_MAX_NUMBER_INPUT)],
+      batch_size: [
+        Validators.required,
+        Validators.min(defaults.batch_size),
+        Validators.max(DEFAULT_MAX_NUMBER_INPUT),
+        CommonFormHelpersService.integerValidator(),
+      ],
       uniform_threshold: [
         Validators.required,
         Validators.min(defaults.uniform_threshold),
         Validators.max(DEFAULT_MAX_NUMBER_INPUT),
+        CommonFormHelpersService.integerValidator(),
       ],
       tspostdiff_thresh: [Validators.required, Validators.min(defaults.tspostdiff_thresh), Validators.max(1.0)],
       prior_success: [
         Validators.required,
         Validators.min(defaults.prior.success),
         Validators.max(DEFAULT_MAX_NUMBER_INPUT),
+        CommonFormHelpersService.integerValidator(),
       ],
       prior_failure: [
         Validators.required,
         Validators.min(defaults.prior.failure),
         Validators.max(DEFAULT_MAX_NUMBER_INPUT),
+        CommonFormHelpersService.integerValidator(),
       ],
     };
   }

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/modals/upsert-experiment-modal/ts-configurable-policy-parameters-form/ts-configurable-policy-parameters-form.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/modals/upsert-experiment-modal/ts-configurable-policy-parameters-form/ts-configurable-policy-parameters-form.component.html
@@ -24,6 +24,9 @@
       <mat-error *ngIf="policyForm.get('prior_success')?.hasError('max')">
         {{ 'home.new-experiment.design.ts-configurable-policy.general.max-error.text' | translate }}
       </mat-error>
+      <mat-error *ngIf="policyForm.get('prior_success')?.hasError('integer')">
+        {{ 'home.new-experiment.design.ts-configurable-policy.general.integer-error.text' | translate }}
+      </mat-error>
     </mat-form-field>
 
     <mat-form-field appearance="outline" subscriptSizing="dynamic">
@@ -39,6 +42,9 @@
       }}</mat-error>
       <mat-error *ngIf="policyForm.get('prior_failure')?.hasError('max')">
         {{ 'home.new-experiment.design.ts-configurable-policy.general.max-error.text' | translate }}
+      </mat-error>
+      <mat-error *ngIf="policyForm.get('prior_failure')?.hasError('integer')">
+        {{ 'home.new-experiment.design.ts-configurable-policy.general.integer-error.text' | translate }}
       </mat-error>
     </mat-form-field>
 
@@ -56,6 +62,9 @@
       <mat-error *ngIf="policyForm.get('batch_size')?.hasError('max')">
         {{ 'home.new-experiment.design.ts-configurable-policy.general.max-error.text' | translate }}
       </mat-error>
+      <mat-error *ngIf="policyForm.get('batch_size')?.hasError('integer')">
+        {{ 'home.new-experiment.design.ts-configurable-policy.general.integer-error.text' | translate }}
+      </mat-error>
     </mat-form-field>
 
     <mat-form-field appearance="outline" subscriptSizing="dynamic">
@@ -71,6 +80,9 @@
       </mat-error>
       <mat-error *ngIf="policyForm.get('uniform_threshold')?.hasError('max')">
         {{ 'home.new-experiment.design.ts-configurable-policy.general.max-error.text' | translate }}
+      </mat-error>
+      <mat-error *ngIf="policyForm.get('uniform_threshold')?.hasError('integer')">
+        {{ 'home.new-experiment.design.ts-configurable-policy.general.integer-error.text' | translate }}
       </mat-error>
     </mat-form-field>
 

--- a/frontend/projects/upgrade/src/app/shared/services/common-form-helpers.service.ts
+++ b/frontend/projects/upgrade/src/app/shared/services/common-form-helpers.service.ts
@@ -58,4 +58,21 @@ export class CommonFormHelpersService {
     control?.setValidators(validators);
     control?.updateValueAndValidity({ emitEvent: false });
   }
+
+  /**
+   * Custom validator to ensure the value is an integer.
+   * Returns an error if the value is not a whole number.
+   */
+  public static integerValidator(): ValidatorFn {
+    return (control) => {
+      if (!control.value) {
+        return null; // Don't validate empty values, this clobbers the 'required' validator
+      }
+      const value = Number(control.value);
+      if (isNaN(value) || !Number.isInteger(value)) {
+        return { integer: { value: control.value } };
+      }
+      return null;
+    };
+  }
 }

--- a/frontend/projects/upgrade/src/assets/i18n/en.json
+++ b/frontend/projects/upgrade/src/assets/i18n/en.json
@@ -203,6 +203,7 @@
   "home.new-experiment.design.ts-configurable-policy.tspostdiff-thresh.min-error.text": "TS Post Diff threshold must be 0.0 or higher.",
   "home.new-experiment.design.ts-configurable-policy.tspostdiff-thresh.max-error.text": "TS Post Diff threshold must be 1.0 or lower.",
   "home.new-experiment.design.ts-configurable-policy.general.max-error.text": "Please enter a value less than 1,000,000.",
+  "home.new-experiment.design.ts-configurable-policy.general.integer-error.text": "Please enter a whole number (integer) value.",
   "home.new-experiment.metrics.text": "Metrics",
   "home.new-experiment.metrics.metric.placeholder.text": "Metric",
   "home.new-experiment.metrics.key.placeholder.text": "Key",


### PR DESCRIPTION
crazily even though native html5 can enforce integers on its own, angular somehow makes it not work. This works fine though.