### PR TITLE
Prevent showing all metrics when experiment context has no defined metrics

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/modals/upsert-metric-modal/upsert-metric-modal.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/modals/upsert-metric-modal/upsert-metric-modal.component.ts
@@ -772,14 +772,15 @@ export class UpsertMetricModalComponent implements OnInit, OnDestroy {
       filteredMetrics = metrics.filter((metric) => metric.children && metric.children.length > 0);
     }
 
-    // Then, apply context filtering if context is available
-    if (this.currentContext?.length) {
-      filteredMetrics = filteredMetrics.filter(
-        (metric) => metric.context && this.currentContext?.some((ctx) => metric.context.includes(ctx))
-      );
+    // Context is required - if not available, return empty array
+    if (!this.currentContext?.length) {
+      return [];
     }
 
-    return filteredMetrics;
+    // Apply context filtering
+    return filteredMetrics.filter(
+      (metric) => metric.context && this.currentContext?.some((ctx) => metric.context.includes(ctx))
+    );
   }
 
   private populateGlobalMetricOptions(metrics: MetricNode[]): void {

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/modals/upsert-metric-modal/upsert-metric-modal.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/modals/upsert-metric-modal/upsert-metric-modal.component.ts
@@ -761,7 +761,7 @@ export class UpsertMetricModalComponent implements OnInit, OnDestroy {
   }
 
   private filterMetricsByAssignmentContext(metrics: MetricNode[]): MetricNode[] {
-    if (!metrics?.length) {
+    if (!metrics?.length || !this.currentContext?.length) {
       return [];
     }
 
@@ -770,11 +770,6 @@ export class UpsertMetricModalComponent implements OnInit, OnDestroy {
 
     if (this.currentAssignmentUnit === ASSIGNMENT_UNIT.WITHIN_SUBJECTS) {
       filteredMetrics = metrics.filter((metric) => metric.children && metric.children.length > 0);
-    }
-
-    // Context is required - if not available, return empty array
-    if (!this.currentContext?.length) {
-      return [];
     }
 
     // Apply context filtering

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/modals/upsert-metric-modal/upsert-metric-modal.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/modals/upsert-metric-modal/upsert-metric-modal.component.ts
@@ -765,21 +765,21 @@ export class UpsertMetricModalComponent implements OnInit, OnDestroy {
       return [];
     }
 
+    // First, filter by assignment unit type
+    let filteredMetrics = metrics;
+
     if (this.currentAssignmentUnit === ASSIGNMENT_UNIT.WITHIN_SUBJECTS) {
-      const withinSubjectsMetrics = metrics.filter((metric) => metric.children && metric.children.length > 0);
-      return withinSubjectsMetrics.length > 0 ? withinSubjectsMetrics : metrics;
+      filteredMetrics = metrics.filter((metric) => metric.children && metric.children.length > 0);
     }
 
-    if (this.currentAssignmentUnit && this.currentContext?.length) {
-      const contextFilteredMetrics = metrics.filter(
+    // Then, apply context filtering if context is available
+    if (this.currentContext?.length) {
+      filteredMetrics = filteredMetrics.filter(
         (metric) => metric.context && this.currentContext?.some((ctx) => metric.context.includes(ctx))
       );
-      if (contextFilteredMetrics.length > 0) {
-        return contextFilteredMetrics;
-      }
     }
 
-    return metrics;
+    return filteredMetrics;
   }
 
   private populateGlobalMetricOptions(metrics: MetricNode[]): void {


### PR DESCRIPTION
Resolves #2921

Changes:

Modified `filterMetricsByAssignmentContext()` to enforce strict context-based filtering:
- Returns empty array when context has no matching metrics (instead of showing all metrics)
- Returns empty array when context information is missing/loading (instead of showing all metrics)  
- Applies context filtering to both regular and within-subjects experiments