### PR TITLE
up to 500 entities

### DIFF
--- a/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
+++ b/backend/packages/Upgrade/src/api/controllers/ExperimentController.ts
@@ -38,6 +38,7 @@ import { SegmentInputValidator } from '../controllers/validators/SegmentInputVal
 import { ExperimentSegmentExclusion } from '../models/ExperimentSegmentExclusion';
 import { IdValidator } from '../controllers/validators/ExperimentUserValidator';
 import { Segment } from '../models/Segment';
+import { CacheService } from '../services/CacheService';
 
 interface ExperimentPaginationInfo extends PaginationResponse {
   nodes: Experiment[];
@@ -656,7 +657,8 @@ export class ExperimentController {
     public experimentService: ExperimentService,
     public experimentAssignmentService: ExperimentAssignmentService,
     public moocletExperimentService: MoocletExperimentService,
-    public importExportService: ImportExportService
+    public importExportService: ImportExportService,
+    public cacheService: CacheService
   ) {}
 
   /**
@@ -689,6 +691,49 @@ export class ExperimentController {
   @Get('/names')
   public findName(@Req() request: AppRequest): Promise<Array<Pick<Experiment, 'id' | 'name'>>> {
     return this.experimentService.findAllName(request.logger);
+  }
+
+  // Add this temporary debugging endpoint
+  @Get('/cache')
+  async debugCache(): Promise<any> {
+    const prefixes = {
+      experiments: 'validExperiments-',
+      segments: 'segments-',
+      marks: 'markExperiments-',
+      featureFlags: 'featureFlags-',
+    };
+
+    // Get all keys from cache
+    const allKeys = (await (this.cacheService as any).memoryCache?.store?.keys()) || [];
+
+    // Build summary for each prefix
+    const summary = {};
+
+    for (const [name, prefix] of Object.entries(prefixes)) {
+      const keys = allKeys.filter((key: string) => key.startsWith(prefix));
+      const data = await Promise.all(
+        keys.map(async (key: string) => {
+          const cachedData = await this.cacheService.getCache(key);
+          return {
+            key,
+            data: cachedData,
+          };
+        })
+      );
+
+      summary[name] = {
+        prefix,
+        count: keys.length,
+        keys,
+        data,
+      };
+    }
+
+    return {
+      totalKeysInCache: allKeys.length,
+      allKeys,
+      summary,
+    };
   }
 
   /**

--- a/backend/packages/Upgrade/src/api/services/CacheService.ts
+++ b/backend/packages/Upgrade/src/api/services/CacheService.ts
@@ -17,7 +17,7 @@ export class CacheService {
 
   private async initializeMemoryCache() {
     this.memoryCache = await caching('memory', {
-      max: 100,
+      max: 500,
       ttl: this.ttl * 1000 /*milliseconds*/,
     });
   }


### PR DESCRIPTION
this ups the "max" number of stored keys in cache from 100 to 500, because we have been creating more segments in the new style of experiments and segments.

this also adds an endpoint called `GET /experiments/cache` that will return a summary of and all data currently cached for that ECS task at the moment the call was made so we don't have to be in the dark about what is going on with the cache manager.

in my testing in staging i tried to make a realistic simulation to try and capture what is cached, and it is clear 100 isn't enough for how segments are cached, I was seeing around 150 at times, so 500 should be fine, i doubt we even have that many individual segments total, and those make up most of the cache keys.