### PR TITLE
disable the weights editing and display n/a for mooclet experiments c…

### DIFF
--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-conditions-section-card/experiment-conditions-section-card.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-conditions-section-card/experiment-conditions-section-card.component.html
@@ -34,6 +34,7 @@ vm.experiment.context[0];
     [showActions]="canShowActions"
     [actionsDisabled]="vm.restriction.isDisabled"
     [actionsTooltip]="restrictionTooltip"
+    [isMoocletExperiment]="isMoocletExperiment(vm.experiment)"
     (rowAction)="onRowAction($event, vm.experiment.id, appContext)"
     (editWeights)="onEditWeights($event, vm.experiment)"
   ></app-experiment-conditions-table>

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-conditions-section-card/experiment-conditions-section-card.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-conditions-section-card/experiment-conditions-section-card.component.ts
@@ -25,6 +25,7 @@ import { ConditionWeightUpdate } from '../../../../modals/edit-condition-weights
 import { ConditionHelperService } from '../../../../../../../core/experiments/condition-helper.service';
 import { selectConditionWeightsValid } from '../../../../../../../core/experiments/store/experiments.selectors';
 import { Store } from '@ngrx/store';
+import { MoocletExperimentHelperService } from '../../../../../../../core/experiments/mooclet-helper.service';
 
 @Component({
   selector: 'app-experiment-conditions-section-card',
@@ -59,7 +60,8 @@ export class ExperimentConditionsSectionCardComponent implements OnInit {
     private readonly authService: AuthService,
     private readonly dialogService: DialogService,
     private readonly conditionHelperService: ConditionHelperService,
-    private readonly store: Store
+    private readonly store: Store,
+    private readonly moocletHelperService: MoocletExperimentHelperService
   ) {}
 
   ngOnInit() {
@@ -74,6 +76,10 @@ export class ExperimentConditionsSectionCardComponent implements OnInit {
         restriction,
       }))
     );
+  }
+
+  isMoocletExperiment(experiment: Experiment) {
+    return this.moocletHelperService.isMoocletAlgorithm(experiment?.assignmentAlgorithm);
   }
 
   onAddConditionClick(appContext: string, experimentId: string): void {

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-conditions-section-card/experiment-conditions-table/experiment-conditions-table.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-conditions-section-card/experiment-conditions-table/experiment-conditions-table.component.html
@@ -18,10 +18,24 @@
 
     <!-- Weight Column -->
     <ng-container matColumnDef="weight">
-      <th mat-header-cell *matHeaderCellDef class="weight-column ft-14-600">
+      <th
+        mat-header-cell
+        *matHeaderCellDef
+        class="weight-column ft-14-600"
+        [matTooltip]="'experiments.details.conditions.weight-adaptive-tooltip.text' | translate"
+        [matTooltipDisabled]="!isMoocletExperiment"
+        matTooltipPosition="above"
+      >
         {{ CONDITION_TRANSLATION_KEYS.WEIGHT | translate }}
       </th>
-      <td mat-cell *matCellDef="let condition" class="weight-column ft-14-400">
+      <td
+        mat-cell
+        *matCellDef="let condition"
+        class="weight-column ft-14-400"
+        [matTooltip]="'experiments.details.conditions.weight-adaptive-tooltip.text' | translate"
+        [matTooltipDisabled]="!isMoocletExperiment"
+        matTooltipPosition="above"
+      >
         {{ isMoocletExperiment ? 'N/A' : condition.assignmentWeight }}
       </td>
     </ng-container>

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-conditions-section-card/experiment-conditions-table/experiment-conditions-table.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-conditions-section-card/experiment-conditions-table/experiment-conditions-table.component.html
@@ -21,7 +21,9 @@
       <th mat-header-cell *matHeaderCellDef class="weight-column ft-14-600">
         {{ CONDITION_TRANSLATION_KEYS.WEIGHT | translate }}
       </th>
-      <td mat-cell *matCellDef="let condition" class="weight-column ft-14-400">{{ condition.assignmentWeight }}</td>
+      <td mat-cell *matCellDef="let condition" class="weight-column ft-14-400">
+        {{ isMoocletExperiment ? 'N/A' : condition.assignmentWeight }}
+      </td>
     </ng-container>
 
     <!-- Weight Edit Column -->
@@ -29,7 +31,7 @@
       <th mat-header-cell *matHeaderCellDef class="weight-edit-column ft-14-600 dense-2">
         <div
           class="button-wrapper"
-          *ngIf="showActions"
+          *ngIf="showActions && !isMoocletExperiment"
           [matTooltip]="
             (actionsDisabled ? actionsTooltip : 'experiments.details.conditions.weight-disabled-tooltip.text')
               | translate

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-conditions-section-card/experiment-conditions-table/experiment-conditions-table.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-conditions-section-card/experiment-conditions-table/experiment-conditions-table.component.ts
@@ -36,6 +36,7 @@ export class ExperimentConditionsTableComponent {
   @Input() showActions?: boolean = false;
   @Input() actionsDisabled?: boolean = false;
   @Input() actionsTooltip?: string = '';
+  @Input() isMoocletExperiment = false;
   @Output() rowAction = new EventEmitter<ExperimentConditionRowActionEvent>();
   @Output() editWeights = new EventEmitter<ExperimentCondition[]>();
 

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-condition-table/enrollment-condition-expandable-row/enrollment-condition-expandable-row.component.html
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-condition-table/enrollment-condition-expandable-row/enrollment-condition-expandable-row.component.html
@@ -7,6 +7,9 @@
         style="justify-content: left; padding-left: 16px"
         class="ft-14-600"
         *matHeaderCellDef
+        [matTooltip]="'experiments.details.conditions.weight-adaptive-tooltip.text' | translate"
+        [matTooltipDisabled]="!isMoocletExperiment(experiment)"
+        matTooltipPosition="above"
       >
         {{ key.includes('Icon') ? '' : columnHeaders[key] }}
       </mat-header-cell>
@@ -16,9 +19,12 @@
         style="justify-content: left"
         class="ft-14-400"
         *matCellDef="let element; let i = dataIndex"
+        [matTooltip]="'experiments.details.conditions.weight-adaptive-tooltip.text' | translate"
+        [matTooltipDisabled]="!isMoocletExperiment(experiment)"
+        matTooltipPosition="above"
       >
         <!-- Special handling for weight column when experiment has moocletPolicyParameters -->
-        <span *ngIf="key === 'weight' && experiment?.moocletPolicyParameters; else regularCell">N/A</span>
+        <span *ngIf="key === 'weight' && isMoocletExperiment(experiment); else regularCell">N/A</span>
 
         <ng-template #regularCell>
           <span *ngIf="!key.includes('Icon'); else icon" style="padding-left: -5px">{{ element.data[key] }}</span>

--- a/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-condition-table/enrollment-condition-expandable-row/enrollment-condition-expandable-row.component.ts
+++ b/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-condition-table/enrollment-condition-expandable-row/enrollment-condition-expandable-row.component.ts
@@ -6,7 +6,8 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatTableModule } from '@angular/material/table';
 import { CommonModule } from '@angular/common';
 import { EnrollmentPointPartitionTableComponent } from '../enrollment-point-partition-table/enrollment-point-partition-table.component';
-
+import { MoocletExperimentHelperService } from '../../../../../../../../../core/experiments/mooclet-helper.service';
+import { MatTooltipModule } from '@angular/material/tooltip';
 @Component({
   selector: 'app-enrollment-condition-expandable-row',
   templateUrl: './enrollment-condition-expandable-row.component.html',
@@ -17,6 +18,7 @@ import { EnrollmentPointPartitionTableComponent } from '../enrollment-point-part
     CommonModule,
     MatTableModule,
     MatIconModule,
+    MatTooltipModule,
     forwardRef(() => EnrollmentPointPartitionTableComponent),
   ],
 })
@@ -29,7 +31,8 @@ export class EnrollmentConditionExpandableRowComponent implements OnDestroy {
   expandedId = '';
   columnHeaders = {};
   translateSub: Subscription;
-  constructor(private translate: TranslateService) {
+
+  constructor(private translate: TranslateService, private moocletHelperService: MoocletExperimentHelperService) {
     this.translateSub = this.translate
       .get([
         'global.condition.text',
@@ -49,6 +52,10 @@ export class EnrollmentConditionExpandableRowComponent implements OnDestroy {
           experimentId: arrayValues['home.view-experiment-global.experiment-target.text'],
         };
       });
+  }
+
+  isMoocletExperiment(experiment: ExperimentVM): boolean {
+    return this.moocletHelperService.isMoocletAlgorithm(experiment?.assignmentAlgorithm);
   }
 
   toggleExpandableSymbol(id: string): void {

--- a/frontend/projects/upgrade/src/assets/i18n/en.json
+++ b/frontend/projects/upgrade/src/assets/i18n/en.json
@@ -486,6 +486,7 @@
   "experiments.details.conditions.payload.specific-to-decision-point.text": "Specific to Decision Point",
   "experiments.details.conditions.weight.text": "Weight (%)",
   "experiments.details.conditions.weight-disabled-tooltip.text": "Add at least one condition to edit weights",
+  "experiments.details.conditions.weight-adaptive-tooltip.text": "Adaptive experiments do not have static weights. Initial weights can be configured via the adaptive algorithm parameters. See GitBook documentation.",
   "experiments.details.conditions.description.text": "Description",
   "experiments.details.conditions.actions.text": "Actions",
   "experiments.details.conditions.card.no-data-row.text": "No conditions defined. Simple experiments require conditions.",


### PR DESCRIPTION
adds N/A for weights in the conditions sections card (was already there for the condition enrollments data tab)

adds a tooltip in both places we show condition weights when N/A because mooclet

<img width="1241" height="322" alt="image" src="https://github.com/user-attachments/assets/afa795f9-a6ab-45c1-b552-2e48b33cfb5f" />

<img width="1259" height="381" alt="image" src="https://github.com/user-attachments/assets/b3084230-d24d-4028-af85-0e6cf45f5b1d" />


<img width="1190" height="362" alt="image" src="https://github.com/user-attachments/assets/9a06278b-295f-4632-975d-7d170380304e" />
