### PR TITLE
Fix/normalize experiment shapes for audit log diffs

### DIFF
--- a/packages/backend/src/api/services/ExperimentService.ts
+++ b/packages/backend/src/api/services/ExperimentService.ts
@@ -1101,6 +1101,9 @@ export class ExperimentService {
         delete oldExperimentClone.updatedAt;
         delete oldExperimentClone.createdAt;
         delete oldExperimentClone.queries; // TODO: Remove comment if we want to consider queries in diff
+        // Segments are managed via separate actions and not part of this update operation
+        delete (oldExperimentClone as any).experimentSegmentInclusion;
+        delete (oldExperimentClone as any).experimentSegmentExclusion;
 
         // Sort based on createdAt to make correct diff
         oldExperimentClone.partitions.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
@@ -1117,7 +1120,12 @@ export class ExperimentService {
           delete condition.updatedAt;
           delete condition.createdAt;
           delete (condition as any).experimentId;
+          delete (condition as any).conditionPayloads;
+          delete (condition as any).levelCombinationElements;
         });
+
+        // Ensure this formatting has happened
+        const formattedOldClone = this.formattingPayload(oldExperimentClone);
 
         // removing unwanted params for diff
         const newExperimentClone = JSON.parse(JSON.stringify(updatedExperiment));
@@ -1142,12 +1150,32 @@ export class ExperimentService {
           delete condition.createdAt;
           delete (condition as any).experimentId;
         });
+
+        // Strip timestamps from conditionPayload items and their nested relation objects
+        [formattedOldClone, newExperimentClone].forEach((clone) => {
+          (clone.conditionPayloads || []).forEach((cp: any) => {
+            delete cp.updatedAt;
+            delete cp.createdAt;
+            delete cp.versionNumber;
+            if (cp.parentCondition) {
+              delete cp.parentCondition.updatedAt;
+              delete cp.parentCondition.createdAt;
+              delete cp.parentCondition.versionNumber;
+            }
+            if (cp.decisionPoint) {
+              delete cp.decisionPoint.updatedAt;
+              delete cp.decisionPoint.createdAt;
+              delete cp.decisionPoint.versionNumber;
+            }
+          });
+        });
+
         logger.info({ message: 'Updated experiment:', details: updatedExperiment });
         // add AuditLogs here
         const updateAuditLog: AuditLogData = {
           experimentId: experiment.id,
           experimentName: experiment.name,
-          diff: diffString(oldExperimentClone, newExperimentClone),
+          diff: diffString(formattedOldClone, newExperimentClone),
         };
 
         await this.experimentAuditLogRepository.saveRawJson(LOG_TYPE.EXPERIMENT_UPDATED, updateAuditLog, user);

--- a/packages/backend/src/api/services/ExperimentService.ts
+++ b/packages/backend/src/api/services/ExperimentService.ts
@@ -1100,7 +1100,6 @@ export class ExperimentService {
         delete oldExperimentClone.versionNumber;
         delete oldExperimentClone.updatedAt;
         delete oldExperimentClone.createdAt;
-        delete oldExperimentClone.queries; // TODO: Remove comment if we want to consider queries in diff
         // Segments are managed via separate actions and not part of this update operation
         delete (oldExperimentClone as any).experimentSegmentInclusion;
         delete (oldExperimentClone as any).experimentSegmentExclusion;
@@ -1123,6 +1122,13 @@ export class ExperimentService {
           delete (condition as any).conditionPayloads;
           delete (condition as any).levelCombinationElements;
         });
+        (oldExperimentClone.queries || []).map((query: any) => {
+          delete query.versionNumber;
+          delete query.updatedAt;
+          delete query.createdAt;
+          delete query.experiment;
+          delete query.archivedStats;
+        });
 
         // Ensure this formatting has happened
         const formattedOldClone = this.formattingPayload(oldExperimentClone);
@@ -1132,8 +1138,6 @@ export class ExperimentService {
         delete newExperimentClone.versionNumber;
         delete newExperimentClone.updatedAt;
         delete newExperimentClone.createdAt;
-        delete newExperimentClone.queries;
-
         // Sort based on createdAt to make correct diff
         newExperimentClone.partitions.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
         newExperimentClone.conditions.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
@@ -1149,6 +1153,13 @@ export class ExperimentService {
           delete condition.updatedAt;
           delete condition.createdAt;
           delete (condition as any).experimentId;
+        });
+        (newExperimentClone.queries || []).map((query: any) => {
+          delete query.versionNumber;
+          delete query.updatedAt;
+          delete query.createdAt;
+          delete query.experiment;
+          delete query.archivedStats;
         });
 
         // Strip timestamps from conditionPayload items and their nested relation objects
@@ -2180,12 +2191,12 @@ export class ExperimentService {
 
       // update list AuditLogs here
       const updateAuditLog: AuditLogData = {
-        flagId: experiment.id,
-        flagName: experiment.name,
+        experimentId: experiment.id,
+        experimentName: experiment.name,
         list: listData,
       };
 
-      await this.experimentAuditLogRepository.saveRawJson(LOG_TYPE.FEATURE_FLAG_UPDATED, updateAuditLog, currentUser);
+      await this.experimentAuditLogRepository.saveRawJson(LOG_TYPE.EXPERIMENT_UPDATED, updateAuditLog, currentUser);
 
       return existingRecord;
     });

--- a/packages/frontend/projects/upgrade/src/app/core/experiments/experiments.data.service.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/experiments/experiments.data.service.ts
@@ -51,7 +51,13 @@ export class ExperimentDataService {
 
   updateExperiment(experiment: Experiment) {
     const url = `${API_ENDPOINTS.updateExperiments}/${experiment.id}`;
-    return this.http.put<Experiment>(url, { ...experiment });
+    return this.http.put<Experiment>(url, { ...this.stripVMProperties(experiment) });
+  }
+
+  private stripVMProperties(experiment: Experiment): Experiment {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { stat, weightingMethod, ...experimentData } = experiment as any;
+    return experimentData;
   }
 
   updateExperimentState(experimentId: string, experimentStateInfo: ExperimentStateInfo) {

--- a/packages/frontend/projects/upgrade/src/app/core/experiments/experiments.service.spec.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/experiments/experiments.service.spec.ts
@@ -302,7 +302,6 @@ describe('ExperimentService', () => {
 
       service.updateExperiment(experiment);
 
-      expect(experiment.stat).toBeUndefined();
       expect(mockStore.dispatch).toHaveBeenCalledWith(
         actionUpsertExperiment({
           experiment,

--- a/packages/frontend/projects/upgrade/src/app/core/experiments/experiments.service.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/experiments/experiments.service.ts
@@ -137,9 +137,11 @@ export class ExperimentService {
   }
 
   updateExperiment(experiment: ExperimentVM) {
-    delete experiment.stat;
     this.store$.dispatch(
-      experimentAction.actionUpsertExperiment({ experiment, actionType: UpsertExperimentType.UPDATE_EXPERIMENT })
+      experimentAction.actionUpsertExperiment({
+        experiment,
+        actionType: UpsertExperimentType.UPDATE_EXPERIMENT,
+      })
     );
   }
 

--- a/packages/frontend/projects/upgrade/src/app/core/experiments/store/experiments.effects.spec.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/experiments/store/experiments.effects.spec.ts
@@ -78,6 +78,7 @@ describe('ExperimentEffects', () => {
   let commonModalEventsService: any;
   let mockEnvironment: Environment;
   let commonExportHelpersService: any;
+  let experimentService: any;
 
   beforeEach(() => {
     actions$ = new ActionsSubject();
@@ -99,6 +100,9 @@ describe('ExperimentEffects', () => {
     commonModalEventsService = {
       forceCloseModal: jest.fn(),
       emitCloseModalEvent: jest.fn(),
+    };
+    experimentService = {
+      stripExperimentVMProperties: jest.fn(),
     };
     service = new ExperimentEffects(
       actions$,

--- a/packages/frontend/projects/upgrade/src/app/core/experiments/store/experiments.effects.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/experiments/store/experiments.effects.ts
@@ -133,7 +133,10 @@ export class ExperimentEffects {
   UpsertExperiment$ = createEffect(() =>
     this.actions$.pipe(
       ofType(experimentAction.actionUpsertExperiment),
-      map((action) => ({ experiment: action.experiment, actionType: action.actionType })),
+      map((action) => ({
+        experiment: action.experiment,
+        actionType: action.actionType,
+      })),
       filter(({ experiment, actionType }) => !!experiment && !!actionType),
       withLatestFrom(this.store$.pipe(select(selectExperimentStats))),
       switchMap(([{ experiment, actionType }, experimentStats]) => {

--- a/packages/frontend/projects/upgrade/src/app/core/logs/audit-log-diff.helper.spec.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/logs/audit-log-diff.helper.spec.ts
@@ -1,0 +1,331 @@
+import { AuditLogDiffHelperService, DiffRow } from './audit-log-diff.helper';
+
+describe('AuditLogDiffHelperService', () => {
+  let service: AuditLogDiffHelperService;
+
+  beforeEach(() => {
+    service = new AuditLogDiffHelperService();
+  });
+
+  // ─── hasDiff ────────────────────────────────────────────────────────────────
+
+  describe('#hasDiff', () => {
+    const testCases = [
+      {
+        whenCondition: 'logData has a top-level diff property',
+        logData: { diff: '-old\n+new' },
+        expected: true,
+      },
+      {
+        whenCondition: 'logData has a list-scoped diff property',
+        logData: { list: { diff: '-old\n+new' } },
+        expected: true,
+      },
+      {
+        whenCondition: 'logData has neither diff nor list.diff',
+        logData: { experimentId: 'abc' },
+        expected: false,
+      },
+      {
+        whenCondition: 'logData is null',
+        logData: null,
+        expected: false,
+      },
+      {
+        whenCondition: 'logData is undefined',
+        logData: undefined,
+        expected: false,
+      },
+    ];
+
+    testCases.forEach(({ whenCondition, logData, expected }) => {
+      it(`WHEN ${whenCondition}, THEN hasDiff returns ${expected}`, () => {
+        expect(service.hasDiff(logData)).toBe(expected);
+      });
+    });
+  });
+
+  // ─── getDiffContent ──────────────────────────────────────────────────────────
+
+  describe('#getDiffContent', () => {
+    const testCases = [
+      {
+        whenCondition: 'logData has a top-level diff',
+        logData: { diff: '-old\n+new' },
+        expected: '-old\n+new',
+      },
+      {
+        whenCondition: 'logData has a list-scoped diff',
+        logData: { list: { diff: '-listOld\n+listNew' } },
+        expected: '-listOld\n+listNew',
+      },
+      {
+        whenCondition: 'logData has both top-level and list-scoped diffs',
+        logData: { diff: '-top', list: { diff: '-list' } },
+        expected: '-list',
+        note: 'list-scoped diff takes precedence',
+      },
+      {
+        whenCondition: 'logData has no diff',
+        logData: { experimentId: 'abc' },
+        expected: '',
+      },
+      {
+        whenCondition: 'logData is null',
+        logData: null,
+        expected: '',
+      },
+    ];
+
+    testCases.forEach(({ whenCondition, logData, expected, note }) => {
+      const label = note
+        ? `WHEN ${whenCondition}, THEN "${expected}" (${note})`
+        : `WHEN ${whenCondition}, THEN "${expected}"`;
+      it(label, () => {
+        expect(service.getDiffContent(logData)).toBe(expected);
+      });
+    });
+  });
+
+  // ─── parseDiff ───────────────────────────────────────────────────────────────
+
+  describe('#parseDiff', () => {
+    describe('basic line types', () => {
+      it('WHEN the diff has a removed line, THEN it appears on the left side as "removed"', () => {
+        const raw = '-old value';
+        const rows = service.parseDiff(raw);
+
+        expect(rows).toEqual<DiffRow[]>([
+          {
+            leftLineNum: 1,
+            rightLineNum: undefined,
+            leftContent: 'old value',
+            rightContent: '',
+            leftType: 'removed',
+            rightType: 'empty',
+          },
+        ]);
+      });
+
+      it('WHEN the diff has an added line, THEN it appears on the right side as "added"', () => {
+        const raw = '+new value';
+        const rows = service.parseDiff(raw);
+
+        expect(rows).toEqual<DiffRow[]>([
+          {
+            leftLineNum: undefined,
+            rightLineNum: 1,
+            leftContent: '',
+            rightContent: 'new value',
+            leftType: 'empty',
+            rightType: 'added',
+          },
+        ]);
+      });
+
+      it('WHEN the diff has a context line with a leading space, THEN it appears on both sides as "context"', () => {
+        const raw = ' unchanged line';
+        const rows = service.parseDiff(raw);
+
+        expect(rows).toEqual<DiffRow[]>([
+          {
+            leftLineNum: 1,
+            rightLineNum: 1,
+            leftContent: 'unchanged line',
+            rightContent: 'unchanged line',
+            leftType: 'context',
+            rightType: 'context',
+          },
+        ]);
+      });
+
+      it('WHEN the diff has a blank line, THEN it is skipped and produces no row', () => {
+        const raw = ' context\n\n context2';
+        const rows = service.parseDiff(raw);
+
+        expect(rows).toHaveLength(2);
+      });
+    });
+
+    describe('pairing removed and added lines', () => {
+      it('WHEN a single removed line is followed by a single added line, THEN they are paired into one row', () => {
+        const raw = '-old value\n+new value';
+        const rows = service.parseDiff(raw);
+
+        expect(rows).toEqual<DiffRow[]>([
+          {
+            leftLineNum: 1,
+            rightLineNum: 1,
+            leftContent: 'old value',
+            rightContent: 'new value',
+            leftType: 'removed',
+            rightType: 'added',
+          },
+        ]);
+      });
+
+      it('WHEN two removed lines are followed by two added lines, THEN each pair is aligned in its own row', () => {
+        const raw = '-line A\n-line B\n+line X\n+line Y';
+        const rows = service.parseDiff(raw);
+
+        expect(rows).toEqual<DiffRow[]>([
+          {
+            leftLineNum: 1,
+            rightLineNum: 1,
+            leftContent: 'line A',
+            rightContent: 'line X',
+            leftType: 'removed',
+            rightType: 'added',
+          },
+          {
+            leftLineNum: 2,
+            rightLineNum: 2,
+            leftContent: 'line B',
+            rightContent: 'line Y',
+            leftType: 'removed',
+            rightType: 'added',
+          },
+        ]);
+      });
+
+      it('WHEN there are more removed lines than added lines, THEN extra removed lines are padded with empty right cells', () => {
+        const raw = '-line A\n-line B\n+line X';
+        const rows = service.parseDiff(raw);
+
+        expect(rows).toEqual<DiffRow[]>([
+          {
+            leftLineNum: 1,
+            rightLineNum: 1,
+            leftContent: 'line A',
+            rightContent: 'line X',
+            leftType: 'removed',
+            rightType: 'added',
+          },
+          {
+            leftLineNum: 2,
+            rightLineNum: undefined,
+            leftContent: 'line B',
+            rightContent: '',
+            leftType: 'removed',
+            rightType: 'empty',
+          },
+        ]);
+      });
+
+      it('WHEN there are more added lines than removed lines, THEN extra added lines are padded with empty left cells', () => {
+        const raw = '-line A\n+line X\n+line Y';
+        const rows = service.parseDiff(raw);
+
+        expect(rows).toEqual<DiffRow[]>([
+          {
+            leftLineNum: 1,
+            rightLineNum: 1,
+            leftContent: 'line A',
+            rightContent: 'line X',
+            leftType: 'removed',
+            rightType: 'added',
+          },
+          {
+            leftLineNum: undefined,
+            rightLineNum: 2,
+            leftContent: '',
+            rightContent: 'line Y',
+            leftType: 'empty',
+            rightType: 'added',
+          },
+        ]);
+      });
+    });
+
+    describe('mixed diffs with context lines', () => {
+      it('WHEN a change is surrounded by context lines, THEN each section is correctly classified', () => {
+        const raw = ' context before\n-old\n+new\n context after';
+        const rows = service.parseDiff(raw);
+
+        expect(rows).toEqual<DiffRow[]>([
+          {
+            leftLineNum: 1,
+            rightLineNum: 1,
+            leftContent: 'context before',
+            rightContent: 'context before',
+            leftType: 'context',
+            rightType: 'context',
+          },
+          {
+            leftLineNum: 2,
+            rightLineNum: 2,
+            leftContent: 'old',
+            rightContent: 'new',
+            leftType: 'removed',
+            rightType: 'added',
+          },
+          {
+            leftLineNum: 3,
+            rightLineNum: 3,
+            leftContent: 'context after',
+            rightContent: 'context after',
+            leftType: 'context',
+            rightType: 'context',
+          },
+        ]);
+      });
+
+      it('WHEN there are two separate change blocks separated by context, THEN each block is paired independently', () => {
+        const raw = '-block1 old\n+block1 new\n context line\n-block2 old\n+block2 new';
+        const rows = service.parseDiff(raw);
+
+        expect(rows).toHaveLength(4);
+        expect(rows[0]).toMatchObject({ leftType: 'removed', rightType: 'added', leftContent: 'block1 old' });
+        expect(rows[1]).toMatchObject({ leftType: 'context', leftContent: 'context line' });
+        expect(rows[2]).toMatchObject({ leftType: 'removed', rightType: 'added', leftContent: 'block2 old' });
+      });
+
+      it('WHEN the diff ends with a pending change block (no trailing context), THEN the buffer is flushed and all rows are included', () => {
+        const raw = ' context\n-trailing old\n+trailing new';
+        const rows = service.parseDiff(raw);
+
+        expect(rows).toHaveLength(2);
+        expect(rows[1]).toMatchObject({ leftType: 'removed', rightType: 'added', leftContent: 'trailing old' });
+      });
+    });
+
+    describe('line number tracking', () => {
+      it('WHEN the diff has context and change lines, THEN line numbers increment correctly on each side', () => {
+        const raw = ' ctx\n-removed\n+added\n ctx2';
+        const rows = service.parseDiff(raw);
+
+        expect(rows[0].leftLineNum).toBe(1); // context
+        expect(rows[0].rightLineNum).toBe(1);
+        expect(rows[1].leftLineNum).toBe(2); // removed/added pair
+        expect(rows[1].rightLineNum).toBe(2);
+        expect(rows[2].leftLineNum).toBe(3); // context
+        expect(rows[2].rightLineNum).toBe(3);
+      });
+    });
+
+    describe('ANSI color code handling', () => {
+      it('WHEN the diff contains ANSI color codes (as produced by json-diff), THEN they are stripped before parsing', () => {
+        const raw = '\x1b[31m-old value\x1b[0m\n\x1b[32m+new value\x1b[0m';
+        const rows = service.parseDiff(raw);
+
+        expect(rows).toHaveLength(1);
+        expect(rows[0].leftContent).toBe('old value');
+        expect(rows[0].rightContent).toBe('new value');
+      });
+    });
+
+    describe('edge cases', () => {
+      it('WHEN the diff string is empty, THEN parseDiff returns an empty array', () => {
+        expect(service.parseDiff('')).toEqual([]);
+      });
+
+      it('WHEN the diff has only context lines, THEN all lines appear as context rows', () => {
+        const raw = ' line one\n line two';
+        const rows = service.parseDiff(raw);
+
+        expect(rows).toHaveLength(2);
+        expect(rows.every((r) => r.leftType === 'context')).toBe(true);
+      });
+    });
+  });
+});

--- a/packages/frontend/projects/upgrade/src/app/core/logs/audit-log-diff.helper.spec.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/logs/audit-log-diff.helper.spec.ts
@@ -274,7 +274,7 @@ describe('AuditLogDiffHelperService', () => {
         const raw = '-block1 old\n+block1 new\n context line\n-block2 old\n+block2 new';
         const rows = service.parseDiff(raw);
 
-        expect(rows).toHaveLength(4);
+        expect(rows).toHaveLength(3);
         expect(rows[0]).toMatchObject({ leftType: 'removed', rightType: 'added', leftContent: 'block1 old' });
         expect(rows[1]).toMatchObject({ leftType: 'context', leftContent: 'context line' });
         expect(rows[2]).toMatchObject({ leftType: 'removed', rightType: 'added', leftContent: 'block2 old' });

--- a/packages/frontend/projects/upgrade/src/app/core/logs/audit-log-diff.helper.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/logs/audit-log-diff.helper.ts
@@ -1,0 +1,140 @@
+import { Injectable } from '@angular/core';
+
+/**
+ * A single row in a side-by-side diff display.
+ *
+ * Each row represents either a paired change (one removed line alongside one added line),
+ * a context line shared by both sides, or a padding row on one side when the block sizes
+ * don't match.
+ */
+export interface DiffRow {
+  leftLineNum?: number;
+  rightLineNum?: number;
+  leftContent?: string;
+  rightContent?: string;
+  /** `'removed'` for a deleted line, `'context'` for unchanged, `'empty'` for padding. */
+  leftType?: 'removed' | 'context' | 'empty';
+  /** `'added'` for a new line, `'context'` for unchanged, `'empty'` for padding. */
+  rightType?: 'added' | 'context' | 'empty';
+}
+
+interface DiffLineBuffer {
+  removed: { lineNum: number; content: string }[];
+  added: { lineNum: number; content: string }[];
+}
+
+/**
+ * Provides pure utility methods for parsing and extracting audit log diffs.
+ *
+ * The backend generates diffs using `json-diff`'s `diffString()`, which produces
+ * a unified diff format with ANSI color codes:
+ * - Lines prefixed with `-` are removed lines
+ * - Lines prefixed with `+` are added lines
+ * - Lines prefixed with a space (or no special prefix) are context lines
+ *
+ * No hunk headers (`@@`) are produced by `diffString`, so this service does not
+ * need to handle them.
+ */
+@Injectable({ providedIn: 'root' })
+export class AuditLogDiffHelperService {
+  /**
+   * Returns `true` if the given audit log data payload contains a diff string.
+   *
+   * Handles both top-level diffs (`logData.diff`) and list-scoped diffs
+   * (`logData.list.diff`), as produced by feature flag segment updates.
+   */
+  hasDiff(logData: unknown): boolean {
+    const data = logData as Record<string, any>;
+    return !!(data?.['diff'] || data?.['list']?.['diff']);
+  }
+
+  /**
+   * Extracts the raw diff string from an audit log data payload.
+   *
+   * List-scoped diffs (`logData.list.diff`) take precedence over top-level diffs
+   * (`logData.diff`) to match how feature flag segment list changes are stored.
+   * Returns an empty string if no diff is present.
+   */
+  getDiffContent(logData: unknown): string {
+    const data = logData as Record<string, any>;
+    return data?.['list']?.['diff'] || data?.['diff'] || '';
+  }
+
+  /**
+   * Converts a raw unified diff string into structured {@link DiffRow} objects
+   * for side-by-side display.
+   *
+   * ANSI color codes are stripped before parsing. Consecutive blocks of removed
+   * and added lines are paired together so they align horizontally. When a block
+   * has more removed lines than added lines (or vice versa), the shorter side is
+   * padded with empty cells.
+   *
+   * @param raw - A raw diff string as produced by `json-diff`'s `diffString()`.
+   * @returns An ordered array of `DiffRow` objects ready for rendering.
+   */
+  parseDiff(raw: string): DiffRow[] {
+    const lines = this.stripAnsi(raw).split('\n');
+    const rows: DiffRow[] = [];
+    let leftNum = 1;
+    let rightNum = 1;
+    let buffer: DiffLineBuffer = { removed: [], added: [] };
+
+    for (const line of lines) {
+      if (line.startsWith('-')) {
+        buffer.removed.push({ lineNum: leftNum++, content: line.slice(1) });
+      } else if (line.startsWith('+')) {
+        buffer.added.push({ lineNum: rightNum++, content: line.slice(1) });
+      } else {
+        rows.push(...this.flushBuffer(buffer));
+        buffer = { removed: [], added: [] };
+
+        const content = line.startsWith(' ') ? line.slice(1) : line;
+        if (content !== '') {
+          rows.push({
+            leftLineNum: leftNum++,
+            rightLineNum: rightNum++,
+            leftContent: content,
+            rightContent: content,
+            leftType: 'context',
+            rightType: 'context',
+          });
+        }
+      }
+    }
+
+    rows.push(...this.flushBuffer(buffer));
+    return rows;
+  }
+
+  /**
+   * Pairs buffered removed and added lines into aligned {@link DiffRow} objects.
+   *
+   * Lines are matched by position within their respective block. If one side has
+   * more lines than the other, the shorter side is padded with `'empty'` rows.
+   */
+  private flushBuffer(buffer: DiffLineBuffer): DiffRow[] {
+    const maxLen = Math.max(buffer.removed.length, buffer.added.length);
+    const rows: DiffRow[] = [];
+
+    for (let i = 0; i < maxLen; i++) {
+      const removed = buffer.removed[i];
+      const added = buffer.added[i];
+      rows.push({
+        leftLineNum: removed?.lineNum,
+        rightLineNum: added?.lineNum,
+        leftContent: removed?.content ?? '',
+        rightContent: added?.content ?? '',
+        leftType: removed ? 'removed' : 'empty',
+        rightType: added ? 'added' : 'empty',
+      });
+    }
+
+    return rows;
+  }
+
+  /** Strips ANSI terminal color/style escape codes from a string. */
+  private stripAnsi(str: string): string {
+    // eslint-disable-next-line no-control-regex
+    return str.replace(/\x1b\[[0-9;]*m/g, '');
+  }
+}

--- a/packages/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-audit-log-timeline/common-audit-log-diff-display/common-audit-log-diff-display.component.html
+++ b/packages/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-audit-log-timeline/common-audit-log-diff-display/common-audit-log-diff-display.component.html
@@ -7,6 +7,53 @@
       </mat-panel-title>
     </mat-expansion-panel-header>
 
-    <pre><div class="ft-14-400 diff-container" [id]="'diff-' + logId">{{ renderDiff() }}</div></pre>
+    @if (hasDiff) {
+    <div class="diff-table-wrapper">
+      <table class="diff-table ft-12-400">
+        <colgroup>
+          <col class="col-linenum" />
+          <col class="col-content" />
+          <col class="col-linenum" />
+          <col class="col-content" />
+        </colgroup>
+        <tbody>
+          @for (row of diffRows; track $index) {
+          <tr class="diff-row">
+            <td class="linenum-cell" [class.removed]="row.leftType === 'removed'">
+              {{ row.leftType !== 'empty' ? row.leftLineNum : '' }}
+            </td>
+            <td
+              class="content-cell"
+              [class.removed]="row.leftType === 'removed'"
+              [class.empty]="row.leftType === 'empty'"
+            >
+              @if (row.leftType === 'removed') {
+              <span class="diff-marker">-</span>
+              } @else {
+              <span class="diff-marker"> </span>
+              }
+              <span class="diff-content">{{ row.leftContent }}</span>
+            </td>
+            <td class="linenum-cell" [class.added]="row.rightType === 'added'">
+              {{ row.rightType !== 'empty' ? row.rightLineNum : '' }}
+            </td>
+            <td
+              class="content-cell"
+              [class.added]="row.rightType === 'added'"
+              [class.empty]="row.rightType === 'empty'"
+            >
+              @if (row.rightType === 'added') {
+              <span class="diff-marker">+</span>
+              } @else {
+              <span class="diff-marker"> </span>
+              }
+              <span class="diff-content">{{ row.rightContent }}</span>
+            </td>
+          </tr>
+          }
+        </tbody>
+      </table>
+    </div>
+    }
   </mat-expansion-panel>
 </mat-accordion>

--- a/packages/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-audit-log-timeline/common-audit-log-diff-display/common-audit-log-diff-display.component.html
+++ b/packages/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-audit-log-timeline/common-audit-log-diff-display/common-audit-log-diff-display.component.html
@@ -1,3 +1,4 @@
+@if (wrapInAccordion) {
 <mat-accordion class="accordion">
   <mat-expansion-panel hideToggle="true">
     <mat-expansion-panel-header class="expansion-header" expandedHeight="*" collapsedHeight="*">
@@ -8,52 +9,55 @@
     </mat-expansion-panel-header>
 
     @if (hasDiff) {
-    <div class="diff-table-wrapper">
-      <table class="diff-table ft-12-400">
-        <colgroup>
-          <col class="col-linenum" />
-          <col class="col-content" />
-          <col class="col-linenum" />
-          <col class="col-content" />
-        </colgroup>
-        <tbody>
-          @for (row of diffRows; track $index) {
-          <tr class="diff-row">
-            <td class="linenum-cell" [class.removed]="row.leftType === 'removed'">
-              {{ row.leftType !== 'empty' ? row.leftLineNum : '' }}
-            </td>
-            <td
-              class="content-cell"
-              [class.removed]="row.leftType === 'removed'"
-              [class.empty]="row.leftType === 'empty'"
-            >
-              @if (row.leftType === 'removed') {
-              <span class="diff-marker">-</span>
-              } @else {
-              <span class="diff-marker"> </span>
-              }
-              <span class="diff-content">{{ row.leftContent }}</span>
-            </td>
-            <td class="linenum-cell" [class.added]="row.rightType === 'added'">
-              {{ row.rightType !== 'empty' ? row.rightLineNum : '' }}
-            </td>
-            <td
-              class="content-cell"
-              [class.added]="row.rightType === 'added'"
-              [class.empty]="row.rightType === 'empty'"
-            >
-              @if (row.rightType === 'added') {
-              <span class="diff-marker">+</span>
-              } @else {
-              <span class="diff-marker"> </span>
-              }
-              <span class="diff-content">{{ row.rightContent }}</span>
-            </td>
-          </tr>
-          }
-        </tbody>
-      </table>
-    </div>
+    <ng-container *ngTemplateOutlet="diffTable"></ng-container>
     }
   </mat-expansion-panel>
 </mat-accordion>
+} @else { @if (hasDiff) {
+<ng-container *ngTemplateOutlet="diffTable"></ng-container>
+} }
+
+<ng-template #diffTable>
+  <div class="diff-table-wrapper">
+    <table class="diff-table ft-12-400">
+      <colgroup>
+        <col class="col-linenum" />
+        <col class="col-content" />
+        <col class="col-linenum" />
+        <col class="col-content" />
+      </colgroup>
+      <tbody>
+        @for (row of diffRows; track $index) {
+        <tr class="diff-row">
+          <td class="linenum-cell" [class.removed]="row.leftType === 'removed'">
+            {{ row.leftType !== 'empty' ? row.leftLineNum : '' }}
+          </td>
+          <td
+            class="content-cell"
+            [class.removed]="row.leftType === 'removed'"
+            [class.empty]="row.leftType === 'empty'"
+          >
+            @if (row.leftType === 'removed') {
+            <span class="diff-marker">-</span>
+            } @else {
+            <span class="diff-marker"> </span>
+            }
+            <span class="diff-content">{{ row.leftContent }}</span>
+          </td>
+          <td class="linenum-cell" [class.added]="row.rightType === 'added'">
+            {{ row.rightType !== 'empty' ? row.rightLineNum : '' }}
+          </td>
+          <td class="content-cell" [class.added]="row.rightType === 'added'" [class.empty]="row.rightType === 'empty'">
+            @if (row.rightType === 'added') {
+            <span class="diff-marker">+</span>
+            } @else {
+            <span class="diff-marker"> </span>
+            }
+            <span class="diff-content">{{ row.rightContent }}</span>
+          </td>
+        </tr>
+        }
+      </tbody>
+    </table>
+  </div>
+</ng-template>

--- a/packages/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-audit-log-timeline/common-audit-log-diff-display/common-audit-log-diff-display.component.scss
+++ b/packages/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-audit-log-timeline/common-audit-log-diff-display/common-audit-log-diff-display.component.scss
@@ -1,6 +1,5 @@
 .accordion {
   width: 100%;
-  // margin-top: 8px;
 }
 
 .expansion-header {
@@ -24,26 +23,88 @@
   cursor: pointer;
 }
 
-.diff-container {
-  background-color: var(--background-secondary);
-  padding: 16px;
+.diff-table-wrapper {
+  max-height: 500px;
+  overflow: auto;
+  border: 1px solid var(--border-color, #e0e0e0);
   border-radius: 4px;
   font-family: 'Courier New', monospace;
-  font-size: 14px;
-  overflow-x: auto;
-  white-space: pre-wrap;
-  word-wrap: break-word;
-  max-height: 500px;
-  overflow-y: auto;
+  font-size: 12px;
+}
 
-  ::ng-deep {
-    .ansi-color {
-      font-weight: normal;
-    }
+.diff-table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+
+  .col-linenum {
+    width: 48px;
+  }
+
+  .col-content {
+    width: calc(50% - 48px);
   }
 }
 
-pre {
-  margin: 0;
-  padding: 0;
+.diff-row {
+  &:hover td {
+    filter: brightness(0.97);
+  }
+}
+
+.linenum-cell {
+  text-align: right;
+  padding: 1px 6px;
+  user-select: none;
+  color: var(--text-hint, #999);
+  background-color: var(--background-secondary, #f5f5f5);
+  border-right: 1px solid var(--border-color, #e0e0e0);
+  min-width: 36px;
+  white-space: nowrap;
+
+  &.removed {
+    background-color: var(--diff-removed-linenum-bg, #ffd7d5);
+    color: var(--diff-removed-linenum-text, #c0392b);
+  }
+
+  &.added {
+    background-color: var(--diff-added-linenum-bg, #ccffd8);
+    color: var(--diff-added-linenum-text, #27ae60);
+  }
+}
+
+.content-cell {
+  padding: 1px 8px;
+  white-space: pre-wrap;
+  word-break: break-all;
+  vertical-align: top;
+
+  &.removed {
+    background-color: var(--diff-removed-bg, #fff0f0);
+  }
+
+  &.added {
+    background-color: var(--diff-added-bg, #f0fff4);
+  }
+
+  &.empty {
+    background-color: var(--diff-empty-bg, #fafafa);
+  }
+
+  .diff-marker {
+    display: inline-block;
+    width: 12px;
+    font-weight: 600;
+    user-select: none;
+    color: inherit;
+  }
+
+  .diff-content {
+    color: var(--text-primary);
+  }
+}
+
+// Left/right column divider
+.diff-table tr td:nth-child(3) {
+  border-left: 2px solid var(--border-color, #e0e0e0);
 }

--- a/packages/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-audit-log-timeline/common-audit-log-diff-display/common-audit-log-diff-display.component.ts
+++ b/packages/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-audit-log-timeline/common-audit-log-diff-display/common-audit-log-diff-display.component.ts
@@ -1,4 +1,5 @@
 import { Component, ChangeDetectionStrategy, Input, OnChanges } from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { TranslateModule } from '@ngx-translate/core';
 import { AuditLogDiffHelperService, DiffRow } from '../../../../core/logs/audit-log-diff.helper';
@@ -15,13 +16,14 @@ export type { DiffRow };
   styleUrls: ['./common-audit-log-diff-display.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
-  imports: [MatExpansionModule, TranslateModule],
+  imports: [NgTemplateOutlet, MatExpansionModule, TranslateModule],
 })
 export class CommonAuditLogDiffDisplayComponent implements OnChanges {
   @Input() logId: string;
   @Input() logData: any;
   @Input() logType: string;
   @Input() actionMessage: string;
+  @Input() wrapInAccordion = true;
 
   constructor(private diffHelper: AuditLogDiffHelperService) {}
 

--- a/packages/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-audit-log-timeline/common-audit-log-diff-display/common-audit-log-diff-display.component.ts
+++ b/packages/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-audit-log-timeline/common-audit-log-diff-display/common-audit-log-diff-display.component.ts
@@ -1,8 +1,9 @@
-import { Component, ChangeDetectionStrategy, Input, AfterViewInit } from '@angular/core';
-
+import { Component, ChangeDetectionStrategy, Input, OnChanges } from '@angular/core';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { TranslateModule } from '@ngx-translate/core';
-import Convert from 'ansi-to-html';
+import { AuditLogDiffHelperService, DiffRow } from '../../../../core/logs/audit-log-diff.helper';
+
+export type { DiffRow };
 
 /**
  * Generic component for displaying diffs in audit logs.
@@ -16,38 +17,23 @@ import Convert from 'ansi-to-html';
   standalone: true,
   imports: [MatExpansionModule, TranslateModule],
 })
-export class CommonAuditLogDiffDisplayComponent implements AfterViewInit {
+export class CommonAuditLogDiffDisplayComponent implements OnChanges {
   @Input() logId: string;
   @Input() logData: any;
   @Input() logType: string;
   @Input() actionMessage: string;
 
-  ngAfterViewInit(): void {
-    // Convert ANSI-formatted diff to HTML after view is initialized
-    if (this.hasDiff) {
-      setTimeout(() => {
-        this.renderDiff();
-      }, 0);
-    }
-  }
+  constructor(private diffHelper: AuditLogDiffHelperService) {}
+
+  diffRows: DiffRow[] = [];
 
   get hasDiff(): boolean {
-    return !!(this.logData?.diff || this.logData?.list?.diff);
+    return this.diffHelper.hasDiff(this.logData);
   }
 
-  get diffContent(): string {
-    return this.logData?.list?.diff || this.logData?.diff || '';
-  }
-
-  renderDiff(): void {
-    const convert = new Convert();
-    let convertedToHtml = convert.toHtml(this.diffContent);
-    convertedToHtml = convertedToHtml.split('color:#FFF').join('color: grey');
-
-    const diffNode = document.getElementById(`diff-${this.logId}`);
-    if (diffNode) {
-      const html = new DOMParser().parseFromString(convertedToHtml, 'text/html');
-      diffNode.innerHTML = html.body.innerHTML;
+  ngOnChanges(): void {
+    if (this.diffHelper.hasDiff(this.logData)) {
+      this.diffRows = this.diffHelper.parseDiff(this.diffHelper.getDiffContent(this.logData));
     }
   }
 }

--- a/packages/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-audit-log-timeline/common-audit-log-timeline.component.html
+++ b/packages/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-audit-log-timeline/common-audit-log-timeline.component.html
@@ -122,6 +122,13 @@
                         ></span>
                       </mat-panel-title>
                     </mat-expansion-panel-header>
+                    <common-audit-log-diff-display
+                      [logId]="log.id"
+                      [logData]="log.data"
+                      [logType]="log.type"
+                      [actionMessage]="getLogTypeMessage(log.type) | translate"
+                      [wrapInAccordion]="false"
+                    ></common-audit-log-diff-display>
                   </mat-expansion-panel>
                 </mat-accordion>
               </div>

--- a/packages/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-audit-log-timeline/common-audit-log-timeline.component.scss
+++ b/packages/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-audit-log-timeline/common-audit-log-timeline.component.scss
@@ -188,6 +188,12 @@ $timeline-background-color: #eaf0f8;
       }
     }
   }
+
+  .view-diff {
+    margin-left: 20px;
+    color: var(--blue);
+    cursor: pointer;
+  }
 }
 
 ::ng-deep .mat-expansion-panel:not([class*='mat-elevation-z']) {
@@ -205,4 +211,8 @@ $timeline-background-color: #eaf0f8;
 
 ::ng-deep .mat-content.mat-content-hide-toggle {
   margin-right: 0 !important;
+}
+
+::ng-deep .mat-expansion-panel-body {
+  padding: 24px 24px 0 0 !important;
 }


### PR DESCRIPTION
backend: "normalizes" the difference between old and new experiment objects when creating a diff for audit logs so we see only the data we care about changing in the update log diffs.

frontend: turns the diff into a side-by-side comparison

this diff-creating business is really ugly stuff in the backend, and this adds to it, but the root cause is much deeper and I'm not getting into that right now.