### PR TITLE
log mooclet assignment errors but do not throw, treat as default

### DIFF
--- a/packages/backend/src/api/services/ExperimentAssignmentService.ts
+++ b/packages/backend/src/api/services/ExperimentAssignmentService.ts
@@ -2000,7 +2000,7 @@ export class ExperimentAssignmentService {
         message: 'Error getting condition from Mooclet proxy; experiment will return no condition for this user',
         experimentId: experiment.id,
         userId,
-        err,
+        error: err,
       });
       return undefined;
     }

--- a/packages/backend/src/api/services/ExperimentAssignmentService.ts
+++ b/packages/backend/src/api/services/ExperimentAssignmentService.ts
@@ -1993,7 +1993,17 @@ export class ExperimentAssignmentService {
   private async getConditionFromMoocletProxy(experiment: Experiment, user: ExperimentUser, logger: UpgradeLogger) {
     const userId = user.id;
 
-    return await this.moocletExperimentService.getConditionFromMoocletProxy(experiment, userId, logger);
+    try {
+      return await this.moocletExperimentService.getConditionFromMoocletProxy(experiment, userId, logger);
+    } catch (err) {
+      logger.error({
+        message: 'Error getting condition from Mooclet proxy; experiment will return no condition for this user',
+        experimentId: experiment.id,
+        userId,
+        err,
+      });
+      return undefined;
+    }
   }
 
   private assignRandom(

--- a/packages/backend/src/api/services/MoocletDataService.ts
+++ b/packages/backend/src/api/services/MoocletDataService.ts
@@ -345,8 +345,6 @@ export class MoocletDataService {
     logger: UpgradeLogger
   ): Promise<any> {
     const { method, url, body } = requestParams;
-    let jsonResponse = '';
-
     if (method && url) {
       const headers: HeadersInit = {
         Authorization: this.apiToken,
@@ -366,20 +364,30 @@ export class MoocletDataService {
         };
 
         const res = await axios.request(options);
-
-        if (res?.status?.toString().startsWith('2')) {
-          jsonResponse = res.data;
-          return jsonResponse;
-        } else {
-          logger.error({ message: 'Non-2xx response from Mooclets API', url, method, status: res?.status });
-          throw new MoocletError(`Mooclet server returned non-2xx status: ${res?.status}`);
-        }
+        return res.data;
       } catch (err) {
         if (err instanceof MoocletError) {
           throw err;
         }
-        logger.error({ message: 'Error fetching data from Mooclets API', url, method });
-        throw new MoocletError('Failed to communicate with Mooclet server');
+        if (axios.isAxiosError(err)) {
+          logger.error({
+            message: 'Error fetching data from Mooclets API',
+            url,
+            method,
+            status: err.response?.status,
+            responseBody: err.response?.data,
+            error: err,
+          });
+          throw new MoocletError(`Mooclet server returned non-2xx status: ${err.response?.status}`);
+        } else {
+          logger.error({
+            message: 'Error fetching data from Mooclets API',
+            url,
+            method,
+            error: err,
+          });
+          throw new MoocletError('Failed to communicate with Mooclet server');
+        }
       }
     }
   }

--- a/packages/backend/src/api/services/MoocletDataService.ts
+++ b/packages/backend/src/api/services/MoocletDataService.ts
@@ -371,11 +371,13 @@ export class MoocletDataService {
           jsonResponse = res.data;
           return jsonResponse;
         } else {
-          return {
-            error: res,
-          };
+          logger.error({ message: 'Non-2xx response from Mooclets API', url, method, status: res?.status });
+          throw new MoocletError(`Mooclet server returned non-2xx status: ${res?.status}`);
         }
       } catch (err) {
+        if (err instanceof MoocletError) {
+          throw err;
+        }
         logger.error({ message: 'Error fetching data from Mooclets API', url, method });
         throw new MoocletError('Failed to communicate with Mooclet server');
       }

--- a/packages/backend/src/api/services/MoocletExperimentService.ts
+++ b/packages/backend/src/api/services/MoocletExperimentService.ts
@@ -1303,6 +1303,15 @@ export class MoocletExperimentService extends ExperimentService {
     logger: UpgradeLogger
   ): Promise<ExperimentCondition> {
     const moocletExperimentRef = await this.getMoocletExperimentRefByUpgradeExperimentId(experiment.id);
+
+    if (!moocletExperimentRef) {
+      logger.error({
+        message: 'MoocletExperimentRef not found for experiment',
+        experimentId: experiment.id,
+      });
+      throw new MoocletError(`MoocletExperimentRef not found for experiment id ${experiment.id}`);
+    }
+
     const versionResponse = await this.moocletDataService.getVersionForNewLearner(
       moocletExperimentRef.moocletId,
       userId,

--- a/packages/backend/src/api/services/MoocletExperimentService.ts
+++ b/packages/backend/src/api/services/MoocletExperimentService.ts
@@ -1305,10 +1305,6 @@ export class MoocletExperimentService extends ExperimentService {
     const moocletExperimentRef = await this.getMoocletExperimentRefByUpgradeExperimentId(experiment.id);
 
     if (!moocletExperimentRef) {
-      logger.error({
-        message: 'MoocletExperimentRef not found for experiment',
-        experimentId: experiment.id,
-      });
       throw new MoocletError(`MoocletExperimentRef not found for experiment id ${experiment.id}`);
     }
 

--- a/packages/backend/test/unit/services/ExperimentAssignmentService.test.ts
+++ b/packages/backend/test/unit/services/ExperimentAssignmentService.test.ts
@@ -1729,4 +1729,17 @@ describe('Experiment Assignment Service Test', () => {
       });
     });
   });
+
+  it('[getConditionFromMoocletProxy] should return undefined and log error when mooclet proxy throws', async () => {
+    const userDoc = { id: 'user123', group: {}, workingGroup: {} };
+    const exp = structuredClone(simpleIndividualAssignmentExperiment);
+    const mockError = new Error('Mooclet proxy error');
+
+    moocletExperimentServiceMock.getConditionFromMoocletProxy.rejects(mockError);
+
+    const result = await (testedModule as any).getConditionFromMoocletProxy(exp, userDoc, loggerMock);
+
+    expect(result).toBeUndefined();
+    sinon.assert.calledOnce(loggerMock.error);
+  });
 });

--- a/packages/backend/test/unit/services/MoocletDataService.test.ts
+++ b/packages/backend/test/unit/services/MoocletDataService.test.ts
@@ -249,8 +249,8 @@ describe('#MoocletDataService', () => {
     const mockPolicyParameters: MoocletTSConfigurablePolicyParametersDTO = {
       assignmentAlgorithm: ASSIGNMENT_ALGORITHM.MOOCLET_TS_CONFIGURABLE,
       prior: {
-        failure: 1,
-        success: 1,
+        1: { failure: 1, success: 1 },
+        2: { failure: 1, success: 1 },
       },
       batch_size: 1,
       max_rating: 1,
@@ -429,12 +429,16 @@ describe('#MoocletDataService', () => {
         body: { ...mockRequest },
       };
 
-      const mockErrorResponse = {
-        status: 400,
-        data: { error: 'Bad Request' },
-      };
+      const mockAxiosError = Object.assign(new Error('Request failed with status code 400'), {
+        response: {
+          status: 400,
+          data: { error: 'Bad Request' },
+        },
+        isAxiosError: true,
+      });
 
-      (axios.request as jest.Mock).mockResolvedValue(mockErrorResponse);
+      (axios.request as jest.Mock).mockRejectedValue(mockAxiosError);
+      (axios as any).isAxiosError.mockReturnValueOnce(true);
 
       await expect(moocletDataService.fetchExternalMoocletsData(mockRequestParams, logger)).rejects.toThrow(
         'Mooclet server returned non-2xx status: 400'

--- a/packages/backend/test/unit/services/MoocletDataService.test.ts
+++ b/packages/backend/test/unit/services/MoocletDataService.test.ts
@@ -421,7 +421,7 @@ describe('#MoocletDataService', () => {
       expect(response).toEqual(mockResponse.data);
     });
 
-    it('should return an error object when the request fails with a non-2xx status', async () => {
+    it('should throw a MoocletError when the request fails with a non-2xx status', async () => {
       const mockRequestParams: MoocletProxyRequestParams = {
         method: 'POST',
         url: 'https://api.example.com/mooclet',
@@ -436,8 +436,9 @@ describe('#MoocletDataService', () => {
 
       (axios.request as jest.Mock).mockResolvedValue(mockErrorResponse);
 
-      const response = await moocletDataService.fetchExternalMoocletsData(mockRequestParams, logger);
-      expect(response).toEqual({ error: mockErrorResponse });
+      await expect(moocletDataService.fetchExternalMoocletsData(mockRequestParams, logger)).rejects.toThrow(
+        'Mooclet server returned non-2xx status: 400'
+      );
     });
 
     it('should handle and log errors when the request fails', async () => {

--- a/packages/backend/test/unit/services/MoocletExperimentService.test.ts
+++ b/packages/backend/test/unit/services/MoocletExperimentService.test.ts
@@ -1491,6 +1491,14 @@ describe('#MoocletExperimentService', () => {
       );
     });
 
+    it('should throw MoocletError if moocletExperimentRef is not found', async () => {
+      jest.spyOn(moocletExperimentService, 'getMoocletExperimentRefByUpgradeExperimentId').mockResolvedValue(undefined);
+
+      await expect(
+        moocletExperimentService.getConditionFromMoocletProxy(mockExperiment, mockUserId, logger)
+      ).rejects.toThrow(`MoocletExperimentRef not found for experiment id ${mockExperiment.id}`);
+    });
+
     it('should throw error if version not found in maps', async () => {
       const mockVersionResponse = { id: 999, name: 'unknown' };
 


### PR DESCRIPTION
https://github.com/CarnegieLearningWeb/UpGrade/issues/3056

This adds logic to properly log a clear error but not throw it if the mooclet server is unreachable, or if there data corruption finding mooclet-related resources.

This patches up a couple of spots to ensure that we will treat this error consistently and return "undefined" for this decision point, leaving it out of the /assign return response.

To test the error, create an experiment and then delete the condition maps / experiment refs and try to /assign for a user, with at least one other eligible experiment running that should return a valid assignment. That should error currently in the release branch, but on this branch it will return valid experiments, and an error should be seen in the logs.

