### PR TITLE
make target optional in decision points

### DIFF
--- a/clientlibs/java/src/main/java/org/upgradeplatform/client/ExperimentClient.java
+++ b/clientlibs/java/src/main/java/org/upgradeplatform/client/ExperimentClient.java
@@ -336,8 +336,8 @@ public class ExperimentClient implements AutoCloseable {
 			List<ExperimentsResponse> experiments) {
 		return experiments.stream()
 				.filter(t -> t.getSite().equalsIgnoreCase(site) &&
-						(isStringNull(target) ? isStringNull(t.getTarget().toString())
-								: t.getTarget().toString().equalsIgnoreCase(target)))
+						(isStringNull(target) ? t.getTarget() == null
+								: t.getTarget() != null && t.getTarget().toString().equalsIgnoreCase(target)))
 				.findFirst()
 				.map(ExperimentClient::copyExperimentResponse)
 				.orElse(new ExperimentsResponse());
@@ -346,8 +346,8 @@ public class ExperimentClient implements AutoCloseable {
 	private void rotateConditions(String site, String target) {
 		if (this.allExperiments != null) {
 			ExperimentsResponse result = this.allExperiments.stream().filter(t -> t.getSite().equalsIgnoreCase(site) &&
-					(isStringNull(target) ? isStringNull(t.getTarget().toString())
-							: t.getTarget().toString().equalsIgnoreCase(target)))
+					(isStringNull(target) ? t.getTarget() == null
+							: t.getTarget() != null && t.getTarget().toString().equalsIgnoreCase(target)))
 					.findFirst().orElse(null);
 			if (result != null) {
 				Condition[] rotatedCondition = Arrays.copyOf(result.getAssignedCondition(),
@@ -362,7 +362,9 @@ public class ExperimentClient implements AutoCloseable {
 	}
 
 	private static ExperimentsResponse copyExperimentResponse(ExperimentsResponse experimentsResponse) {
-		ExperimentsResponse resultCondition = new ExperimentsResponse(experimentsResponse.getTarget().toString(),
+		String targetString = experimentsResponse.getTarget() != null ? experimentsResponse.getTarget().toString()
+				: null;
+		ExperimentsResponse resultCondition = new ExperimentsResponse(targetString,
 				experimentsResponse.getSite(), experimentsResponse.getExperimentType(),
 				Arrays.copyOf(experimentsResponse.getAssignedCondition(),
 						experimentsResponse.getAssignedCondition().length),

--- a/clientlibs/js/docs/README.md
+++ b/clientlibs/js/docs/README.md
@@ -358,7 +358,7 @@ const allExperimentConditionsResponse: IExperimentAssignment5[] = await upgradeC
 | `site` | `string` | `undefined` |
 | `condition` | `string` | `null` |
 | `status` | `MARKED_DECISION_POINT_STATUS` | `undefined` |
-| `target?` | `string` | `undefined` |
+| `target?` | `string` | `null` |
 | `clientError?` | `string` | `undefined` |
 
 #### Returns

--- a/clientlibs/js/docs/README.md
+++ b/clientlibs/js/docs/README.md
@@ -358,7 +358,7 @@ const allExperimentConditionsResponse: IExperimentAssignment5[] = await upgradeC
 | `site` | `string` | `undefined` |
 | `condition` | `string` | `null` |
 | `status` | `MARKED_DECISION_POINT_STATUS` | `undefined` |
-| `target?` | `string` | `null` |
+| `target?` | `string` | `undefined` |
 | `clientError?` | `string` | `undefined` |
 
 #### Returns

--- a/clientlibs/js/src/ApiService/ApiService.ts
+++ b/clientlibs/js/src/ApiService/ApiService.ts
@@ -323,7 +323,7 @@ export default class ApiService {
     rewardValue: 'SUCCESS' | 'FAILURE';
     experimentId?: string;
     context?: string;
-    decisionPoint?: { site: string; target: string };
+    decisionPoint?: { site: string; target: string | null };
   }): Promise<UpGradeClientInterfaces.ISendRewardResponse> {
     const requestBody: UpGradeClientRequests.ISendRewardRequestBody = {
       rewardValue: params.rewardValue,

--- a/clientlibs/js/src/Assignment/Assignment.ts
+++ b/clientlibs/js/src/Assignment/Assignment.ts
@@ -10,7 +10,7 @@ import ApiService from '../ApiService/ApiService';
 
 export default class Assignment {
   private _site: string;
-  private _target: string;
+  private _target: string | null;
   private _conditionCode: string;
   private _payloadType: PAYLOAD_TYPE;
   private _payloadValue: string | null;

--- a/clientlibs/js/src/DataService/DataService.ts
+++ b/clientlibs/js/src/DataService/DataService.ts
@@ -52,7 +52,7 @@ export class DataService {
     return assignment;
   }
 
-  public findExperimentAssignmentBySiteAndTarget(site: string, target: string): IExperimentAssignmentv5 {
+  public findExperimentAssignmentBySiteAndTarget(site: string, target: string | null): IExperimentAssignmentv5 {
     const assignment = this.experimentAssignmentData.find(
       (assignment) => assignment.site === site && assignment.target === target
     );

--- a/clientlibs/js/src/UpGradeClient/UpGradeClient.types.ts
+++ b/clientlibs/js/src/UpGradeClient/UpGradeClient.types.ts
@@ -2,7 +2,7 @@ import { MARKED_DECISION_POINT_STATUS } from 'upgrade_types';
 
 export interface IMarkDecisionPointParams {
   site: string;
-  target: string;
+  target: string | null;
   condition: string;
   status: MARKED_DECISION_POINT_STATUS;
   uniquifier?: string;

--- a/clientlibs/js/src/UpGradeClient/UpgradeClient.ts
+++ b/clientlibs/js/src/UpGradeClient/UpgradeClient.ts
@@ -310,7 +310,7 @@ export default class UpgradeClient {
     await this.getAllExperimentConditions();
 
     if (this.dataService.getExperimentAssignmentData()) {
-      const experimentAssignment = this.dataService.findExperimentAssignmentBySiteAndTarget(site, target);
+      const experimentAssignment = this.dataService.findExperimentAssignmentBySiteAndTarget(site, target || null);
 
       const assignment = new Assignment(experimentAssignment, this.apiService);
 

--- a/clientlibs/js/src/UpGradeClient/UpgradeClient.ts
+++ b/clientlibs/js/src/UpGradeClient/UpgradeClient.ts
@@ -306,7 +306,7 @@ export default class UpgradeClient {
    * ```
    */
 
-  async getDecisionPointAssignment(site: string, target?: string): Promise<Assignment> {
+  async getDecisionPointAssignment(site: string, target?: string | null): Promise<Assignment> {
     await this.getAllExperimentConditions();
 
     if (this.dataService.getExperimentAssignmentData()) {
@@ -370,7 +370,7 @@ export default class UpgradeClient {
 
   async markDecisionPoint(
     site: string,
-    target: string,
+    target: string | null,
     condition: string | null = null,
     status: MARKED_DECISION_POINT_STATUS,
     uniquifier?: string,
@@ -632,7 +632,7 @@ export default class UpgradeClient {
     rewardValue: 'SUCCESS' | 'FAILURE';
     experimentId?: string;
     context?: string;
-    decisionPoint?: { site: string; target: string };
+    decisionPoint?: { site: string; target: string | null };
   }): Promise<UpGradeClientInterfaces.ISendRewardResponse> {
     return await this.apiService.sendReward(params);
   }

--- a/clientlibs/js/src/types/Interfaces.ts
+++ b/clientlibs/js/src/types/Interfaces.ts
@@ -35,7 +35,7 @@ export namespace UpGradeClientInterfaces {
 
   export interface IMarkDecisionPointParams {
     site: string;
-    target: string;
+    target: string | null;
     condition: string;
     status: MARKED_DECISION_POINT_STATUS;
     uniquifier?: string;
@@ -52,7 +52,7 @@ export namespace UpGradeClientInterfaces {
   export interface IMarkDecisionPoint {
     id: string;
     site: string;
-    target: string;
+    target: string | null;
     userId: string;
     experimentId: string;
   }
@@ -95,7 +95,7 @@ export namespace UpGradeClientInterfaces {
       context?: string;
       decisionPoint?: {
         site: string;
-        target: string;
+        target: string | null;
       };
     };
     reward: {

--- a/clientlibs/js/src/types/requests.ts
+++ b/clientlibs/js/src/types/requests.ts
@@ -38,7 +38,7 @@ export namespace UpGradeClientRequests {
     status: MARKED_DECISION_POINT_STATUS;
     data: {
       site: string;
-      target: string;
+      target: string | null;
       assignedCondition: { conditionCode: string; experimentId?: string };
     };
     uniquifier?: string;
@@ -51,7 +51,7 @@ export namespace UpGradeClientRequests {
     context?: string;
     decisionPoint?: {
       site: string;
-      target: string;
+      target: string | null;
     };
   }
 }

--- a/packages/backend/src/api/controllers/ExperimentClientController.v5.ts
+++ b/packages/backend/src/api/controllers/ExperimentClientController.v5.ts
@@ -481,7 +481,7 @@ export class ExperimentClientController {
       experiment.data.assignedCondition?.conditionCode ?? null,
       request.logger,
       experiment.data.assignedCondition?.experimentId ?? null,
-      experiment.data.target,
+      experiment.data.target ?? null,
       experiment.uniquifier ? experiment.uniquifier : null,
       experiment.clientError ? experiment.clientError : null
     );

--- a/packages/backend/src/api/controllers/ExperimentClientController.v6.ts
+++ b/packages/backend/src/api/controllers/ExperimentClientController.v6.ts
@@ -451,7 +451,7 @@ export class ExperimentClientController {
       experiment.data.assignedCondition?.conditionCode ?? null,
       request.logger,
       experiment.data.assignedCondition?.experimentId ?? null,
-      experiment.data.target,
+      experiment.data.target ?? null,
       experiment.uniquifier ? experiment.uniquifier : null,
       experiment.clientError ? experiment.clientError : null
     );

--- a/packages/backend/src/api/controllers/ExperimentClientController.v6.ts
+++ b/packages/backend/src/api/controllers/ExperimentClientController.v6.ts
@@ -492,7 +492,6 @@ export class ExperimentClientController {
    *                type: object
    *                required:
    *                  - site
-   *                  - target
    *                  - condition
    *                properties:
    *                  site:

--- a/packages/backend/src/api/controllers/validators/MarkExperimentValidator.v5.ts
+++ b/packages/backend/src/api/controllers/validators/MarkExperimentValidator.v5.ts
@@ -23,7 +23,7 @@ class Data {
 
   @IsString()
   @IsOptional()
-  target: string;
+  target?: string | null;
 
   @IsOptional()
   @ValidateNested()

--- a/packages/backend/src/api/controllers/validators/MarkExperimentValidator.v5.ts
+++ b/packages/backend/src/api/controllers/validators/MarkExperimentValidator.v5.ts
@@ -22,6 +22,7 @@ class Data {
   site: string;
 
   @IsString()
+  @IsOptional()
   target: string;
 
   @IsOptional()

--- a/packages/backend/src/api/controllers/validators/MarkExperimentValidator.v6.ts
+++ b/packages/backend/src/api/controllers/validators/MarkExperimentValidator.v6.ts
@@ -23,7 +23,7 @@ class Data {
 
   @IsString()
   @IsOptional()
-  target: string;
+  target?: string | null;
 
   @IsOptional()
   @ValidateNested()

--- a/packages/backend/src/api/controllers/validators/MarkExperimentValidator.v6.ts
+++ b/packages/backend/src/api/controllers/validators/MarkExperimentValidator.v6.ts
@@ -22,6 +22,7 @@ class Data {
   site: string;
 
   @IsString()
+  @IsOptional()
   target: string;
 
   @IsOptional()

--- a/packages/backend/src/api/services/ExperimentAssignmentService.ts
+++ b/packages/backend/src/api/services/ExperimentAssignmentService.ts
@@ -127,7 +127,7 @@ export class ExperimentAssignmentService {
     public moocletExperimentService: MoocletExperimentService
   ) {}
 
-  private async getCachedExperiments(site: string, target: string): Promise<[DecisionPoint[], Experiment[]]> {
+  private async getCachedExperiments(site: string, target: string | null): Promise<[DecisionPoint[], Experiment[]]> {
     const cacheKey = CACHE_PREFIX.MARK_KEY_PREFIX + '-' + site + '-' + target;
     const dpExperiments = await this.cacheService.wrap(cacheKey, () =>
       this.decisionPointRepository.find({
@@ -156,7 +156,7 @@ export class ExperimentAssignmentService {
     condition: string | null,
     logger: UpgradeLogger,
     experimentId: string,
-    target?: string,
+    target: string | null,
     uniquifier?: string,
     clientError?: string
   ): Promise<Omit<MonitoredDecisionPoint, 'createdAt | updatedAt | versionNumber'>> {

--- a/packages/backend/test/integration/Experiment/markExperimentPoint/NullTargetDecisionPoint.ts
+++ b/packages/backend/test/integration/Experiment/markExperimentPoint/NullTargetDecisionPoint.ts
@@ -84,7 +84,6 @@ export async function NullTargetAllDecisionPoints(): Promise<void> {
   expect(assignments.length).toEqual(experimentObject.partitions.length);
   assignments.forEach((assignment) => {
     expect(assignment.target).toBeNull();
-    expect(assignment.site).toEqual('CurriculumSequence');
     expect(assignment.assignedCondition.length).toBeGreaterThan(0);
   });
 

--- a/packages/backend/test/integration/Experiment/markExperimentPoint/NullTargetDecisionPoint.ts
+++ b/packages/backend/test/integration/Experiment/markExperimentPoint/NullTargetDecisionPoint.ts
@@ -1,0 +1,102 @@
+import { Container } from 'typedi';
+import { ExperimentService } from '../../../../src/api/services/ExperimentService';
+import { UserService } from '../../../../src/api/services/UserService';
+import { systemUser } from '../../mockData/user/index';
+import { experimentUsers } from '../../mockData/experimentUsers';
+import { EXPERIMENT_STATE } from 'upgrade_types';
+import { getAllExperimentCondition, markExperimentPoint, checkMarkExperimentPointForUser } from '../../utils';
+import { UpgradeLogger } from '../../../../src/lib/logger/UpgradeLogger';
+import { individualAssignmentExperiment, allNullTargetPartitionsExperiment } from '../../mockData/experiment/index';
+
+/**
+ * Verifies that an experiment with a mix of null-target and non-null-target decision points:
+ * - stores the null-target partition correctly (target IS NULL in DB)
+ * - includes the null-target partition in getAllExperimentConditions results
+ * - accepts markExperimentPoint calls with no target and records the monitored point
+ */
+export async function NullTargetMixedDecisionPoint(): Promise<void> {
+  const experimentService = Container.get<ExperimentService>(ExperimentService);
+  const userService = Container.get<UserService>(UserService);
+
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
+
+  // individualAssignmentExperiment has W1, W2 (non-null target) and NP (null target) partitions
+  const experimentObject = individualAssignmentExperiment;
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  const experiments = await experimentService.find(new UpgradeLogger());
+
+  // The null-target (NP) partition should be stored with target IS NULL
+  const nullTargetPartition = experiments[0].partitions.find((p) => !p.target);
+  expect(nullTargetPartition).toBeDefined();
+  expect(nullTargetPartition.site).toEqual('CurriculumSequence');
+  expect(nullTargetPartition.target).toBeNull();
+
+  const experimentId = experiments[0].id;
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.RUNNING, user, new UpgradeLogger());
+
+  // getAllExperimentConditions should include the null-target DP as a separate assignment entry
+  const assignments = await getAllExperimentCondition(experimentUsers[0].id, new UpgradeLogger());
+  const nullTargetAssignment = assignments.find((a) => a.target == null && a.site === 'CurriculumSequence');
+  expect(nullTargetAssignment).toBeDefined();
+  expect(nullTargetAssignment.assignedCondition).toBeDefined();
+  expect(nullTargetAssignment.assignedCondition.length).toBeGreaterThan(0);
+
+  // markExperimentPoint with undefined target should record a monitored point with null target
+  const condition = experimentObject.conditions[0].conditionCode;
+  const markedPoint = await markExperimentPoint(
+    experimentUsers[0].id,
+    undefined,
+    'CurriculumSequence',
+    condition,
+    experimentId,
+    new UpgradeLogger()
+  );
+  checkMarkExperimentPointForUser(markedPoint, experimentUsers[0].id, null, 'CurriculumSequence');
+}
+
+/**
+ * Verifies that an experiment where ALL decision points have null target works end-to-end:
+ * - all partitions are stored with target IS NULL
+ * - getAllExperimentConditions returns only null-target assignment entries
+ * - markExperimentPoint with no target records the monitored point correctly
+ */
+export async function NullTargetAllDecisionPoints(): Promise<void> {
+  const experimentService = Container.get<ExperimentService>(ExperimentService);
+  const userService = Container.get<UserService>(UserService);
+
+  const user = await userService.upsertUser(systemUser as any, new UpgradeLogger());
+
+  const experimentObject = allNullTargetPartitionsExperiment;
+  await experimentService.create(experimentObject as any, user, new UpgradeLogger());
+  const experiments = await experimentService.find(new UpgradeLogger());
+
+  // Every partition should have null target
+  expect(experiments[0].partitions.length).toBeGreaterThan(0);
+  experiments[0].partitions.forEach((p) => {
+    expect(p.target).toBeNull();
+  });
+
+  const experimentId = experiments[0].id;
+  await experimentService.updateState(experimentId, EXPERIMENT_STATE.RUNNING, user, new UpgradeLogger());
+
+  // getAllExperimentConditions should return an entry per null-target partition
+  const assignments = await getAllExperimentCondition(experimentUsers[0].id, new UpgradeLogger());
+  expect(assignments.length).toEqual(experimentObject.partitions.length);
+  assignments.forEach((assignment) => {
+    expect(assignment.target).toBeNull();
+    expect(assignment.site).toEqual('CurriculumSequence');
+    expect(assignment.assignedCondition.length).toBeGreaterThan(0);
+  });
+
+  // markExperimentPoint with undefined target should work and record null target
+  const condition = experimentObject.conditions[0].conditionCode;
+  const markedPoint = await markExperimentPoint(
+    experimentUsers[0].id,
+    undefined,
+    'CurriculumSequence',
+    condition,
+    experimentId,
+    new UpgradeLogger()
+  );
+  checkMarkExperimentPointForUser(markedPoint, experimentUsers[0].id, null, 'CurriculumSequence');
+}

--- a/packages/backend/test/integration/Experiment/markExperimentPoint/index.ts
+++ b/packages/backend/test/integration/Experiment/markExperimentPoint/index.ts
@@ -3,6 +3,7 @@ import { experimentUsers } from '../../mockData/experimentUsers/index';
 import { ExperimentUserService } from '../../../../src/api/services/ExperimentUserService';
 import { CheckService } from '../../../../src/api/services/CheckService';
 import TestCase1 from './NoExperiment';
+import { NullTargetMixedDecisionPoint, NullTargetAllDecisionPoints } from './NullTargetDecisionPoint';
 import { UpgradeLogger } from '../../../../src/lib/logger/UpgradeLogger';
 
 const initialChecks = async () => {
@@ -42,4 +43,14 @@ const initialChecks = async () => {
 export const NoExperiment = async () => {
   await initialChecks();
   await TestCase1();
+};
+
+export const NullTargetMixed = async () => {
+  await initialChecks();
+  await NullTargetMixedDecisionPoint();
+};
+
+export const NullTargetAll = async () => {
+  await initialChecks();
+  await NullTargetAllDecisionPoints();
 };

--- a/packages/backend/test/integration/UserNotDefined/index.ts
+++ b/packages/backend/test/integration/UserNotDefined/index.ts
@@ -47,6 +47,7 @@ export const UserNotDefined = async () => {
       MARKED_DECISION_POINT_STATUS.CONDITION_APPLIED,
       null,
       new UpgradeLogger(),
+      null,
       null
     )
   ).rejects.toThrow();

--- a/packages/backend/test/integration/index.test.ts
+++ b/packages/backend/test/integration/index.test.ts
@@ -33,7 +33,7 @@ import {
 import { MainAuditLog } from './Experiment/auditLogs';
 import { NoPartitionPoint } from './Experiment/onlyExperimentPoint';
 // import { StatsGroupExperiment } from './ExperimentStats';
-import { NoExperiment } from './Experiment/markExperimentPoint';
+import { NoExperiment, NullTargetMixed, NullTargetAll } from './Experiment/markExperimentPoint';
 import {
   NoPreviewUser,
   PreviewAssignments,
@@ -163,6 +163,14 @@ describe('Integration Tests', () => {
 
   test('Mark Experiment before experiment is created', () => {
     return NoExperiment();
+  });
+
+  test('Mark Experiment point with null target in mixed-target experiment', () => {
+    return NullTargetMixed();
+  });
+
+  test('Mark Experiment point when all decision points have null target', () => {
+    return NullTargetAll();
   });
 
   test('No Group for Experiment', () => {

--- a/packages/backend/test/integration/mockData/experiment/index.ts
+++ b/packages/backend/test/integration/mockData/experiment/index.ts
@@ -480,6 +480,34 @@ export const individualExperimentWithMetric = clone({
   ],
 });
 
+export const allNullTargetPartitionsExperiment = clone({
+  ...getExperiment(),
+  consistencyRule: CONSISTENCY_RULE.INDIVIDUAL,
+  assignmentUnit: ASSIGNMENT_UNIT.INDIVIDUAL,
+  postExperimentRule: POST_EXPERIMENT_RULE.CONTINUE,
+  state: EXPERIMENT_STATE.INACTIVE,
+  logging: false,
+  type: EXPERIMENT_TYPE.SIMPLE,
+  partitions: [
+    {
+      id: 'd2702d3c-5e04-41a7-8766-1da8a95b71a1',
+      site: 'CurriculumSequence',
+      description: 'No Target Decision Point 1',
+      twoCharacterId: 'N1',
+      excludeIfReached: false,
+      order: 1,
+    },
+    {
+      id: 'd2702d3c-5e04-41a7-8766-1da8a95b71a2',
+      site: 'CurriculumSequence',
+      description: 'No Target Decision Point 2',
+      twoCharacterId: 'N2',
+      excludeIfReached: false,
+      order: 2,
+    },
+  ],
+});
+
 export const scheduleJobStartExperiment = clone({ ...getExperiment(), state: EXPERIMENT_STATE.SCHEDULED });
 
 export const scheduleJobEndExperiment = clone({

--- a/packages/backend/test/integration/mockData/experiment/index.ts
+++ b/packages/backend/test/integration/mockData/experiment/index.ts
@@ -499,7 +499,7 @@ export const allNullTargetPartitionsExperiment = clone({
     },
     {
       id: 'd2702d3c-5e04-41a7-8766-1da8a95b71a2',
-      site: 'CurriculumSequence',
+      site: 'CurriculumSequence2',
       description: 'No Target Decision Point 2',
       twoCharacterId: 'N2',
       excludeIfReached: false,

--- a/packages/backend/test/integration/utils/index.ts
+++ b/packages/backend/test/integration/utils/index.ts
@@ -100,7 +100,7 @@ export async function getAllExperimentCondition(
 
 export async function markExperimentPoint(
   userId: string,
-  target: string | undefined,
+  target: string | null,
   site: string,
   condition: string | null,
   experimentId: string,

--- a/packages/backend/test/integration/utils/index.ts
+++ b/packages/backend/test/integration/utils/index.ts
@@ -51,7 +51,7 @@ export function checkExperimentAssignedIsNotDefault(
 export function checkMarkExperimentPointForUser(
   markedDecisionPoint: MonitoredDecisionPoint[],
   userId: string,
-  target: string,
+  target: string | null | undefined,
   site: string,
   markExperimentPointLogLength?: number
 ): void {
@@ -60,7 +60,7 @@ export function checkMarkExperimentPointForUser(
       expect.arrayContaining([
         expect.objectContaining({
           site: site,
-          target: target,
+          target: target ?? null,
           user: expect.objectContaining({
             id: userId,
           }),
@@ -100,7 +100,7 @@ export async function getAllExperimentCondition(
 
 export async function markExperimentPoint(
   userId: string,
-  target: string,
+  target: string | undefined,
   site: string,
   condition: string | null,
   experimentId: string,

--- a/packages/backend/test/unit/services/ExperimentAssignmentService.test.ts
+++ b/packages/backend/test/unit/services/ExperimentAssignmentService.test.ts
@@ -1755,10 +1755,10 @@ describe('Experiment Assignment Service Test', () => {
       const context = 'context';
       const userDoc = { id: 'user123', group: { schoolId: ['school1'] }, workingGroup: {} };
       const exp = structuredClone(simpleIndividualAssignmentExperiment);
-      // Add a second null-target partition at the same site
+      // Add a second null-target partition with a different site so each decision point remains uniquely addressable
       exp.partitions = [
-        { ...exp.partitions[0], id: 'dp-null-1', target: null, twoCharacterId: 'N1', order: 1 },
-        { ...exp.partitions[0], id: 'dp-null-2', target: null, twoCharacterId: 'N2', order: 2 },
+        { ...exp.partitions[0], id: 'dp-null-1', site: 'site-null-1', target: null, twoCharacterId: 'N1', order: 1 },
+        { ...exp.partitions[0], id: 'dp-null-2', site: 'site-null-2', target: null, twoCharacterId: 'N2', order: 2 },
       ];
 
       const experimentUserServiceMock = { getOriginalUserDoc: sandbox.stub().resolves(userDoc) };

--- a/packages/backend/test/unit/services/ExperimentAssignmentService.test.ts
+++ b/packages/backend/test/unit/services/ExperimentAssignmentService.test.ts
@@ -1774,7 +1774,7 @@ describe('Experiment Assignment Service Test', () => {
       });
     });
 
-    it('[markExperimentPoint] should save monitored point with null target when target is undefined and no experiment is running', async () => {
+    it('[markExperimentPoint] should save monitored point with null target when target is null and no experiment is running', async () => {
       const userId = 'testUser';
       const site = 'testSite';
       const condition = 'testCondition';

--- a/packages/backend/test/unit/services/ExperimentAssignmentService.test.ts
+++ b/packages/backend/test/unit/services/ExperimentAssignmentService.test.ts
@@ -1828,13 +1828,10 @@ describe('Experiment Assignment Service Test', () => {
         condition,
         loggerMock,
         undefined, // no experimentId
-        undefined  // null target
+        undefined // null target
       );
 
-      sinon.assert.calledWith(
-        loggerMock.info,
-        sinon.match({ message: sinon.match(`Target: undefined`) })
-      );
+      sinon.assert.calledWith(loggerMock.info, sinon.match({ message: sinon.match(`Target: undefined`) }));
     });
   });
 });

--- a/packages/backend/test/unit/services/ExperimentAssignmentService.test.ts
+++ b/packages/backend/test/unit/services/ExperimentAssignmentService.test.ts
@@ -1800,7 +1800,12 @@ describe('Experiment Assignment Service Test', () => {
         undefined, // no experimentId
         undefined // null target
       );
-      expect(result).toMatchObject({ site, condition });
+
+      sinon.assert.calledWith(
+        monitoredDecisionPointRepositoryMock.saveRawJson,
+        sinon.match({ site, condition, target: null })
+      );
+      expect(result).toMatchObject({ site, condition, target: null });
     });
 
     it('[markExperimentPoint] should accept undefined target and log correctly (no running experiment)', async () => {

--- a/packages/backend/test/unit/services/ExperimentAssignmentService.test.ts
+++ b/packages/backend/test/unit/services/ExperimentAssignmentService.test.ts
@@ -933,7 +933,7 @@ describe('Experiment Assignment Service Test', () => {
 
     const monitoredDocument = {
       site: site,
-      target: target,
+      target: null,
       condition: condition,
       user: {
         id: userId,
@@ -975,14 +975,14 @@ describe('Experiment Assignment Service Test', () => {
       condition,
       loggerMock,
       undefined,
-      undefined,
+      null,
       undefined,
       clientError
     );
     expect(result).toMatchObject({
       condition: condition,
       site: site,
-      target: target,
+      target: null,
     });
     sinon.assert.calledOnce(loggerMock.error);
   });
@@ -1798,7 +1798,7 @@ describe('Experiment Assignment Service Test', () => {
         condition,
         loggerMock,
         undefined, // no experimentId
-        undefined // null target
+        null // null target
       );
 
       sinon.assert.calledWith(
@@ -1833,10 +1833,10 @@ describe('Experiment Assignment Service Test', () => {
         condition,
         loggerMock,
         undefined, // no experimentId
-        undefined // null target
+        null // null target
       );
 
-      sinon.assert.calledWith(loggerMock.info, sinon.match({ message: sinon.match(`Target: undefined`) }));
+      sinon.assert.calledWith(loggerMock.info, sinon.match({ message: sinon.match(`Target: null`) }));
     });
   });
 });

--- a/packages/backend/test/unit/services/ExperimentAssignmentService.test.ts
+++ b/packages/backend/test/unit/services/ExperimentAssignmentService.test.ts
@@ -1729,4 +1729,112 @@ describe('Experiment Assignment Service Test', () => {
       });
     });
   });
+
+  describe('null target decision points', () => {
+    it('[getAllExperimentConditions] should return assignment with null target for an experiment with a null-target partition', async () => {
+      const context = 'context';
+      const userDoc = { id: 'user123', group: { schoolId: ['school1'] }, workingGroup: {} };
+      const exp = structuredClone(simpleIndividualAssignmentExperiment);
+      // Override the partition target to null
+      exp.partitions[0] = { ...exp.partitions[0], target: null };
+
+      const experimentUserServiceMock = { getOriginalUserDoc: sandbox.stub().resolves(userDoc) };
+      testedModule.cacheService.wrap = sandbox.stub().resolves([exp]);
+      testedModule.experimentService.getCachedValidExperiments = sandbox.stub().resolves([exp]);
+      testedModule.experimentUserService = experimentUserServiceMock;
+
+      const result = await testedModule.getAllExperimentConditions(userDoc, context, loggerMock);
+      expect(result.length).toEqual(1);
+      expect(result[0].site).toEqual(exp.partitions[0].site);
+      expect(result[0].target).toBeNull();
+      expect(result[0].assignedCondition).toBeDefined();
+      expect(result[0].assignedCondition.length).toBeGreaterThan(0);
+    });
+
+    it('[getAllExperimentConditions] should return assignments for all partitions when all targets are null', async () => {
+      const context = 'context';
+      const userDoc = { id: 'user123', group: { schoolId: ['school1'] }, workingGroup: {} };
+      const exp = structuredClone(simpleIndividualAssignmentExperiment);
+      // Add a second null-target partition at the same site
+      exp.partitions = [
+        { ...exp.partitions[0], id: 'dp-null-1', target: null, twoCharacterId: 'N1', order: 1 },
+        { ...exp.partitions[0], id: 'dp-null-2', target: null, twoCharacterId: 'N2', order: 2 },
+      ];
+
+      const experimentUserServiceMock = { getOriginalUserDoc: sandbox.stub().resolves(userDoc) };
+      testedModule.cacheService.wrap = sandbox.stub().resolves([exp]);
+      testedModule.experimentService.getCachedValidExperiments = sandbox.stub().resolves([exp]);
+      testedModule.experimentUserService = experimentUserServiceMock;
+
+      const result = await testedModule.getAllExperimentConditions(userDoc, context, loggerMock);
+      expect(result.length).toEqual(2);
+      result.forEach((assignment) => {
+        expect(assignment.target).toBeNull();
+        expect(assignment.assignedCondition.length).toBeGreaterThan(0);
+      });
+    });
+
+    it('[markExperimentPoint] should save monitored point with null target when target is undefined and no experiment is running', async () => {
+      const userId = 'testUser';
+      const site = 'testSite';
+      const condition = 'testCondition';
+
+      const monitoredDocument = { site, target: null, condition, user: { id: userId } };
+      const monitoredDecisionPointRepositoryMock = {
+        saveRawJson: sandbox.stub().callsFake((args) => args),
+        findOne: sandbox.stub().resolves(monitoredDocument),
+      };
+
+      testedModule.cacheService.wrap = sandbox.stub().resolves([]);
+      testedModule.monitoredDecisionPointRepository = monitoredDecisionPointRepositoryMock;
+      testedModule.experimentService.getPayloadAndFactorialObject = sandbox
+        .stub()
+        .resolves([{ payloadFound: conditionPayloadRepositoryMock, factorialObject: factorRepositoryMock }]);
+
+      const result = await testedModule.markExperimentPoint(
+        { id: userId },
+        site,
+        MARKED_DECISION_POINT_STATUS.CONDITION_APPLIED,
+        condition,
+        loggerMock,
+        undefined, // no experimentId
+        undefined // null target
+      );
+      expect(result).toMatchObject({ site, condition });
+    });
+
+    it('[markExperimentPoint] should accept undefined target and log correctly (no running experiment)', async () => {
+      // Verifies that passing undefined target does not crash and logs the null target in the info message
+      const userId = 'testUser';
+      const site = 'testSite';
+      const condition = 'testCondition';
+
+      const monitoredDocument = { site, target: null, condition, user: { id: userId } };
+      const monitoredDecisionPointRepositoryMock = {
+        saveRawJson: sandbox.stub().callsFake((args) => args),
+        findOne: sandbox.stub().resolves(monitoredDocument),
+      };
+
+      testedModule.cacheService.wrap = sandbox.stub().resolves([]);
+      testedModule.monitoredDecisionPointRepository = monitoredDecisionPointRepositoryMock;
+      testedModule.experimentService.getPayloadAndFactorialObject = sandbox
+        .stub()
+        .resolves([{ payloadFound: conditionPayloadRepositoryMock, factorialObject: factorRepositoryMock }]);
+
+      await testedModule.markExperimentPoint(
+        { id: userId },
+        site,
+        MARKED_DECISION_POINT_STATUS.CONDITION_APPLIED,
+        condition,
+        loggerMock,
+        undefined, // no experimentId
+        undefined  // null target
+      );
+
+      sinon.assert.calledWith(
+        loggerMock.info,
+        sinon.match({ message: sinon.match(`Target: undefined`) })
+      );
+    });
+  });
 });

--- a/packages/frontend/projects/upgrade/src/app/core/experiments/store/experiments.model.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/experiments/store/experiments.model.ts
@@ -199,7 +199,7 @@ export interface LevelCombinationElement {
 export interface ExperimentDecisionPoint {
   id: string;
   site: string;
-  target?: string;
+  target?: string | null;
   description: string;
   twoCharacterId: string;
   order: number;

--- a/packages/frontend/projects/upgrade/src/app/core/experiments/store/experiments.model.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/experiments/store/experiments.model.ts
@@ -395,7 +395,7 @@ export interface ExperimentFormData {
 
 export interface DecisionPointFormData {
   site: string;
-  target?: string;
+  target?: string | null;
   excludeIfReached: boolean;
 }
 

--- a/packages/frontend/projects/upgrade/src/app/core/experiments/store/experiments.model.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/experiments/store/experiments.model.ts
@@ -199,7 +199,7 @@ export interface LevelCombinationElement {
 export interface ExperimentDecisionPoint {
   id: string;
   site: string;
-  target: string;
+  target?: string;
   description: string;
   twoCharacterId: string;
   order: number;
@@ -395,7 +395,7 @@ export interface ExperimentFormData {
 
 export interface DecisionPointFormData {
   site: string;
-  target: string;
+  target?: string;
   excludeIfReached: boolean;
 }
 

--- a/packages/frontend/projects/upgrade/src/app/features/dashboard/experiments/modals/upsert-decision-point-modal/upsert-decision-point-modal.component.html
+++ b/packages/frontend/projects/upgrade/src/app/features/dashboard/experiments/modals/upsert-decision-point-modal/upsert-decision-point-modal.component.html
@@ -30,6 +30,9 @@
       </mat-hint>
     </mat-form-field>
 
+    @if (!showTargetField) {
+    <button mat-button type="button" class="ft-14-400" (click)="onAddTargetClicked()">+ Add Target (optional)</button>
+    } @if (showTargetField) {
     <mat-form-field appearance="outline">
       <mat-label class="ft-14-400">Target</mat-label>
       <input
@@ -52,8 +55,7 @@
         <app-common-learn-more-link learnMoreLinkKey="glossary.decisionPoint"></app-common-learn-more-link>
       </mat-hint>
     </mat-form-field>
-
-    @if (decisionPointForm.get('target')?.hasError('duplicateDecisionPoint')) {
+    } @if (decisionPointForm.get('target')?.hasError('duplicateDecisionPoint')) {
     <div class="duplicate-error-message ft-12-400">
       {{ 'experiments.upsert-decision-point-modal.decision-point-warning.text' | translate }}
     </div>

--- a/packages/frontend/projects/upgrade/src/app/features/dashboard/experiments/modals/upsert-decision-point-modal/upsert-decision-point-modal.component.ts
+++ b/packages/frontend/projects/upgrade/src/app/features/dashboard/experiments/modals/upsert-decision-point-modal/upsert-decision-point-modal.component.ts
@@ -118,6 +118,7 @@ export class UpsertDecisionPointModalComponent implements OnInit, OnDestroy {
 
     if (this.showTargetField) {
       this.decisionPointForm.get('target').addValidators(Validators.required);
+      this.decisionPointForm.get('target').updateValueAndValidity();
     }
 
     this.initialFormValues$.next(this.decisionPointForm.value);
@@ -181,7 +182,7 @@ export class UpsertDecisionPointModalComponent implements OnInit, OnDestroy {
     }
 
     const site = siteControl.value?.trim() || '';
-    const target = targetControl.value?.trim() || '';
+    const target = targetControl.value?.trim() || null;
 
     // Don't validate if site is empty (required validator will handle that)
     if (!site) {
@@ -204,7 +205,7 @@ export class UpsertDecisionPointModalComponent implements OnInit, OnDestroy {
     // Check if this decision point already exists
     const isDuplicate = currentExperiment.partitions.some((decisionPoint) => {
       const isSameSite = decisionPoint.site?.trim() === site;
-      const isSameTarget = (decisionPoint.target?.trim() || '') === target;
+      const isSameTarget = (decisionPoint.target?.trim() || null) === target;
 
       // For edit action, exclude the current decision point being edited
       if (this.config.params.action === UPSERT_EXPERIMENT_ACTION.EDIT) {
@@ -212,7 +213,7 @@ export class UpsertDecisionPointModalComponent implements OnInit, OnDestroy {
         if (sourceDecisionPoint) {
           const isCurrentDecisionPoint =
             decisionPoint.site?.trim() === sourceDecisionPoint.site?.trim() &&
-            decisionPoint.target?.trim() === sourceDecisionPoint.target?.trim();
+            (decisionPoint.target?.trim() || null) === (sourceDecisionPoint.target?.trim() || null);
 
           // Skip validation if it's the same decision point being edited
           if (isCurrentDecisionPoint) {

--- a/packages/frontend/projects/upgrade/src/app/features/dashboard/experiments/modals/upsert-decision-point-modal/upsert-decision-point-modal.component.ts
+++ b/packages/frontend/projects/upgrade/src/app/features/dashboard/experiments/modals/upsert-decision-point-modal/upsert-decision-point-modal.component.ts
@@ -68,6 +68,7 @@ export class UpsertDecisionPointModalComponent implements OnInit, OnDestroy {
 
   decisionPointForm: FormGroup;
   currentContext: string;
+  showTargetField = false;
 
   constructor(
     @Inject(MAT_DIALOG_DATA)
@@ -109,11 +110,15 @@ export class UpsertDecisionPointModalComponent implements OnInit, OnDestroy {
     this.decisionPointForm = this.formBuilder.group(
       {
         site: [initialValues.site, [Validators.required]],
-        target: [initialValues.target, [Validators.required]],
+        target: [initialValues.target],
         excludeIfReached: [initialValues.excludeIfReached],
       },
       options
     );
+
+    if (this.showTargetField) {
+      this.decisionPointForm.get('target').addValidators(Validators.required);
+    }
 
     this.initialFormValues$.next(this.decisionPointForm.value);
   }
@@ -127,7 +132,17 @@ export class UpsertDecisionPointModalComponent implements OnInit, OnDestroy {
       action === UPSERT_EXPERIMENT_ACTION.EDIT && sourceDecisionPoint?.target ? sourceDecisionPoint.target : '';
     const excludeIfReached = sourceDecisionPoint?.excludeIfReached || false;
 
+    if (action === UPSERT_EXPERIMENT_ACTION.EDIT && sourceDecisionPoint?.target) {
+      this.showTargetField = true;
+    }
+
     return { site, target, excludeIfReached };
+  }
+
+  onAddTargetClicked(): void {
+    this.showTargetField = true;
+    this.decisionPointForm.get('target').addValidators(Validators.required);
+    this.decisionPointForm.get('target').updateValueAndValidity();
   }
 
   setupAutocompleteFilters(): void {
@@ -168,9 +183,8 @@ export class UpsertDecisionPointModalComponent implements OnInit, OnDestroy {
     const site = siteControl.value?.trim() || '';
     const target = targetControl.value?.trim() || '';
 
-    // Don't validate if either field is empty (required validator will handle that)
-    if (!site || !target) {
-      // Clear any existing duplicate errors when fields are empty
+    // Don't validate if site is empty (required validator will handle that)
+    if (!site) {
       this.clearDuplicateError(siteControl);
       this.clearDuplicateError(targetControl);
       return null;
@@ -190,7 +204,7 @@ export class UpsertDecisionPointModalComponent implements OnInit, OnDestroy {
     // Check if this decision point already exists
     const isDuplicate = currentExperiment.partitions.some((decisionPoint) => {
       const isSameSite = decisionPoint.site?.trim() === site;
-      const isSameTarget = decisionPoint.target?.trim() === target;
+      const isSameTarget = (decisionPoint.target?.trim() || '') === target;
 
       // For edit action, exclude the current decision point being edited
       if (this.config.params.action === UPSERT_EXPERIMENT_ACTION.EDIT) {
@@ -272,12 +286,12 @@ export class UpsertDecisionPointModalComponent implements OnInit, OnDestroy {
     const formData = this.decisionPointForm.value;
     const decisionPointData: DecisionPointFormData = {
       site: formData.site?.trim() || '',
-      target: formData.target?.trim() || '',
+      target: formData.target?.trim() || null,
       excludeIfReached: formData.excludeIfReached,
     };
 
-    // Validate trimmed values are not empty
-    if (!decisionPointData.site || !decisionPointData.target) {
+    // Validate site is not empty
+    if (!decisionPointData.site) {
       CommonFormHelpersService.triggerTouchedToDisplayErrors(this.decisionPointForm);
       return;
     }

--- a/packages/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-decision-points-section-card/experiment-decision-points-table/experiment-decision-points-table.component.ts
+++ b/packages/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-decision-points-section-card/experiment-decision-points-table/experiment-decision-points-table.component.ts
@@ -40,7 +40,10 @@ export class ExperimentDecisionPointsTableComponent {
   @Input() actionsTooltip?: string = '';
   @Output() rowAction = new EventEmitter<ExperimentDecisionPointRowActionEvent>();
 
-  displayedColumns: string[] = ['site', 'target', 'excludeIfReached', 'actions'];
+  get displayedColumns(): string[] {
+    const hasTarget = this.decisionPoints?.some((dp) => dp.target);
+    return hasTarget ? ['site', 'target', 'excludeIfReached', 'actions'] : ['site', 'excludeIfReached', 'actions'];
+  }
 
   DECISION_POINT_TRANSLATION_KEYS = {
     SITE: 'experiments.details.decision-points.site.text',

--- a/packages/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-condition-table/enrollment-condition-expandable-row/enrollment-condition-expandable-row.component.ts
+++ b/packages/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-condition-table/enrollment-condition-expandable-row/enrollment-condition-expandable-row.component.ts
@@ -40,7 +40,6 @@ export class EnrollmentConditionExpandableRowComponent implements OnDestroy {
         'home.view-experiment.global.users-enrolled.text',
         'home.view-experiment.global.group-enrolled.text',
         'home.view-experiment-global.experiment-site.text',
-        'home.view-experiment-global.experiment-target.text',
       ])
       .subscribe((arrayValues) => {
         this.columnHeaders = {
@@ -49,7 +48,6 @@ export class EnrollmentConditionExpandableRowComponent implements OnDestroy {
           userEnrolled: arrayValues['home.view-experiment.global.users-enrolled.text'],
           groupEnrolled: arrayValues['home.view-experiment.global.group-enrolled.text'],
           experimentPoint: arrayValues['home.view-experiment-global.experiment-site.text'],
-          experimentId: arrayValues['home.view-experiment-global.experiment-target.text'],
         };
       });
   }

--- a/packages/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-condition-table/enrollment-condition-table.component.ts
+++ b/packages/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-condition-table/enrollment-condition-table.component.ts
@@ -55,7 +55,6 @@ export class EnrollmentConditionTableComponent implements OnChanges, OnInit, OnD
           condition.partitions.forEach((partition) => {
             const partitionObj: EnrollmentByConditionOrPartitionData = {
               experimentPoint: this.getPartitionData(partition.id, 'site'),
-              experimentId: this.getPartitionData(partition.id, 'target') || '',
               userEnrolled: partition.users,
               groupEnrolled: partition.groups,
             };

--- a/packages/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-condition-table/enrollment-point-partition-table/enrollment-point-partition-table.component.ts
+++ b/packages/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-enrollment-data-section-card/enrollment-condition-table/enrollment-point-partition-table/enrollment-point-partition-table.component.ts
@@ -12,7 +12,7 @@ import { EnrollmentConditionExpandableRowComponent } from '../enrollment-conditi
 export class EnrollmentPointPartitionTableComponent implements OnChanges {
   @Input() partitionData: any[];
   @Input() experiment: ExperimentVM;
-  commonColumns = ['expandIcon', 'experimentPoint', 'experimentId', 'userEnrolled'];
+  commonColumns = ['expandIcon', 'experimentPoint', 'userEnrolled'];
   displayedColumns: string[] = [];
 
   ngOnChanges() {

--- a/packages/types/src/Experiment/interfaces.ts
+++ b/packages/types/src/Experiment/interfaces.ts
@@ -52,7 +52,7 @@ export interface IExperimentEnrollmentDetailStats {
 
 export interface IExperimentAssignmentv5 {
   site: string;
-  target: string;
+  target: string | null;
   assignedCondition: AssignedCondition[];
   assignedFactor?: Record<string, { level: string; payload: IPayload }>[];
   experimentType: EXPERIMENT_TYPE;


### PR DESCRIPTION
make 'target' an optional addition in the decision point modal; add backend tests to verify NULL targets