### PR TITLE
use working group instead of group for in/exclusions

### DIFF
--- a/packages/backend/src/api/services/ExperimentAssignmentService.ts
+++ b/packages/backend/src/api/services/ExperimentAssignmentService.ts
@@ -2223,11 +2223,9 @@ export class ExperimentAssignmentService {
     const explicitGroupExclusionFilteredData: { groupId: string; type: string; id: string }[] = [];
 
     const userGroups = [];
-    if (experimentUser.group) {
-      Object.keys(experimentUser.group).forEach((type) => {
-        experimentUser.group[type].forEach((groupId) => {
-          userGroups.push({ type, groupId });
-        });
+    if (experimentUser.workingGroup) {
+      Object.keys(experimentUser.workingGroup).forEach((type) => {
+        userGroups.push({ type, groupId: experimentUser.workingGroup[type] });
       });
     }
 

--- a/packages/backend/test/unit/services/ExperimentAssignmentService.test.ts
+++ b/packages/backend/test/unit/services/ExperimentAssignmentService.test.ts
@@ -558,14 +558,26 @@ describe('Experiment Assignment Service Test', () => {
     expect(includedExperiment).toEqual([exp]);
   });
 
-  it('[experimentLevelExclusionInclusion] should return an exclusion reason if a user or userGroup is on exclusion list', async () => {
-    const userDoc = { id: 'user2', group: { teacher: ['teacher1'] }, workingGroup: {} };
+  it('[experimentLevelExclusionInclusion] should return an exclusion reason if a user workingGroup is on exclusion list', async () => {
+    const userDoc = { id: 'user2', group: { teacher: ['teacher1'] }, workingGroup: { teacher: 'teacher1' } };
     const exp = structuredClone(simpleIndividualAssignmentExperiment);
     const [includedExperiment, exclusionReason] = await testedModule.experimentLevelExclusionInclusion([exp], userDoc);
     expect(exclusionReason.length).toEqual(1);
     expect(exclusionReason[0].matchedGroup).toEqual(true);
     expect(exclusionReason[0].reason).toEqual('group');
     expect(includedExperiment).toEqual([]);
+  });
+
+  it('[experimentLevelExclusionInclusion] should not return an exclusion reason if a user workingGroup is not on exclusion list', async () => {
+    const userDoc = {
+      id: 'user2',
+      group: { teacher: ['teacher1', 'teacher2'] },
+      workingGroup: { teacher: 'teacher2' },
+    };
+    const exp = structuredClone(simpleIndividualAssignmentExperiment);
+    const [includedExperiment, exclusionReason] = await testedModule.experimentLevelExclusionInclusion([exp], userDoc);
+    expect(exclusionReason.length).toEqual(0);
+    expect(includedExperiment).toEqual([exp]);
   });
 
   it('[createExperimentPool] should return empty pool of experiments for no active experiments', async () => {


### PR DESCRIPTION
For inclusion/exclusion logic, consider only a user's working group to determine whether to include or exclude them from experiments and feature flags.