### PR TITLE
no infinite errors when pagination fetch fails

### DIFF
--- a/packages/frontend/projects/upgrade/src/app/core/experiments/experiments.service.spec.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/experiments/experiments.service.spec.ts
@@ -13,6 +13,7 @@ import {
   EXPERIMENT_SORT_KEY,
   EXPERIMENT_STATE,
   POST_EXPERIMENT_RULE,
+  SegmentNew,
   UpsertExperimentType,
 } from './store/experiments.model';
 import * as ExperimentSelectors from './store/experiments.selectors';
@@ -41,7 +42,6 @@ import {
   SEGMENT_STATUS,
   SEGMENT_TYPE,
 } from 'upgrade_types';
-import { SegmentNew } from './store/experiments.model';
 import { Segment } from '../segments/store/segments.model';
 
 const MockStateStore$ = new BehaviorSubject({});
@@ -169,40 +169,25 @@ describe('ExperimentService', () => {
   });
 
   describe('#haveInitialExperimentsLoaded', () => {
-    describe('should return true if experiments are not loading and experiment data exists, and false otherwise', () => {
+    describe('should return the value of hasInitialExperimentsDataLoaded selector', () => {
       const testCases = [
         {
-          whenCondition: 'is NOT in loadingstate AND has experiments',
+          whenCondition: 'initial experiments data has loaded',
           expectedValue: true,
-          isLoading: false,
-          experiments: mockExperimentsList,
+          hasInitialDataLoaded: true,
         },
         {
-          whenCondition: 'is NOT loading AND has NO experiments',
-          expectedValue: true,
-          isLoading: false,
-          experiments: [],
-        },
-        {
-          whenCondition: 'is loading AND has NO experiments',
+          whenCondition: 'initial experiments data has not loaded',
           expectedValue: false,
-          isLoading: true,
-          experiments: [],
-        },
-        {
-          whenCondition: 'is loading AND has experiments',
-          expectedValue: true,
-          isLoading: true,
-          experiments: mockExperimentsList,
+          hasInitialDataLoaded: false,
         },
       ];
 
       testCases.forEach((testCase) => {
-        const { whenCondition, expectedValue, isLoading, experiments } = testCase;
+        const { whenCondition, expectedValue, hasInitialDataLoaded } = testCase;
 
         it(`WHEN ${whenCondition}, THEN ${expectedValue}:`, fakeAsync(() => {
-          ExperimentSelectors.selectIsLoadingExperiment.setResult(isLoading);
-          ExperimentSelectors.selectAllExperiment.setResult(experiments);
+          ExperimentSelectors.selectHasInitialExperimentsDataLoaded.setResult(hasInitialDataLoaded);
 
           service.haveInitialExperimentsLoaded().subscribe((val) => {
             tick(0);
@@ -344,7 +329,7 @@ describe('ExperimentService', () => {
     testCases.forEach((testCase) => {
       const { whenCondition, expectedValue, experiment, experimentId } = testCase;
 
-      it(`WHEN ${whenCondition}, THEN ${expectedValue}:`, fakeAsync(() => {
+      it(`WHEN ${whenCondition}`, fakeAsync(() => {
         ExperimentSelectors.selectExperimentById.setResult(experiment);
 
         service.selectExperimentById(experimentId).subscribe((val) => {

--- a/packages/frontend/projects/upgrade/src/app/core/experiments/experiments.service.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/experiments/experiments.service.ts
@@ -21,6 +21,7 @@ import {
 import { Store, select } from '@ngrx/store';
 import {
   selectAllExperiment,
+  selectHasInitialExperimentsDataLoaded,
   selectIsLoadingExperiment,
   selectSelectedExperiment,
   selectExperimentOverviewDetails,
@@ -65,7 +66,7 @@ import { selectCurrentUserEmail } from '../auth/store/auth.selectors';
 
 @Injectable()
 export class ExperimentService {
-  constructor(private store$: Store<AppState>, private localStorageService: LocalStorageService) {}
+  constructor(private readonly store$: Store<AppState>, private readonly localStorageService: LocalStorageService) {}
 
   experiments$: Observable<Experiment[]> = this.store$.pipe(select(selectAllExperiment));
   currentUserEmailAddress$ = this.store$.pipe(select(selectCurrentUserEmail));
@@ -103,9 +104,7 @@ export class ExperimentService {
     this.store$.pipe(select(selectSectionCardRestriction(cardType)));
 
   haveInitialExperimentsLoaded() {
-    return combineLatest([this.store$.pipe(select(selectIsLoadingExperiment)), this.experiments$]).pipe(
-      map(([isLoading, experiments]) => !isLoading || !!experiments.length)
-    );
+    return this.store$.pipe(select(selectHasInitialExperimentsDataLoaded));
   }
 
   isAllExperimentsFetched() {

--- a/packages/frontend/projects/upgrade/src/app/core/experiments/store/experiments.model.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/experiments/store/experiments.model.ts
@@ -609,6 +609,7 @@ export interface ExperimentState {
   // List page data - plain array preserves backend sort order
   experiments: ExperimentVM[];
   isLoadingExperiment: boolean;
+  hasInitialExperimentsDataLoaded: boolean;
   isLoadingExperimentDetailStats: boolean;
   isLoadingExperimentExport: boolean;
   skipExperiment: number;

--- a/packages/frontend/projects/upgrade/src/app/core/experiments/store/experiments.reducer.spec.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/experiments/store/experiments.reducer.spec.ts
@@ -102,6 +102,7 @@ describe('ExperimentsReducer', () => {
       totalExperiments: 1,
       skipExperiment: 1,
       isLoadingExperiment: false,
+      hasInitialExperimentsDataLoaded: true,
     });
   });
 

--- a/packages/frontend/projects/upgrade/src/app/core/experiments/store/experiments.reducer.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/experiments/store/experiments.reducer.ts
@@ -1,10 +1,4 @@
-import {
-  ExperimentState,
-  EXPERIMENT_SEARCH_KEY,
-  SORT_AS_DIRECTION,
-  EXPERIMENT_SORT_KEY,
-  ExperimentVM,
-} from './experiments.model';
+import { ExperimentState, EXPERIMENT_SEARCH_KEY, SORT_AS_DIRECTION, EXPERIMENT_SORT_KEY } from './experiments.model';
 import { createReducer, on, Action } from '@ngrx/store';
 import * as experimentsAction from './experiments.actions';
 
@@ -12,6 +6,7 @@ export const initialState: ExperimentState = {
   // List page state
   experiments: [],
   isLoadingExperiment: false,
+  hasInitialExperimentsDataLoaded: false,
   isLoadingExperimentDetailStats: false,
   isLoadingExperimentExport: false,
   skipExperiment: 0,
@@ -54,6 +49,7 @@ const reducer = createReducer(
       totalExperiments,
       skipExperiment: fromStarting ? experiments.length : state.skipExperiment + experiments.length,
       isLoadingExperiment: false,
+      hasInitialExperimentsDataLoaded: true,
     };
   }),
   on(
@@ -100,7 +96,7 @@ const reducer = createReducer(
     isLoadingExperiment: true,
     // if we don't have a totalExperiments count yet (no paginated call with > 1 has occured yet),
     // set it to 1 because we are loading at least one experiment so that nav to root page will not show empty template
-    totalExperiments: !state.totalExperiments ? 1 : state.totalExperiments,
+    totalExperiments: state.totalExperiments ? state.totalExperiments : 1,
   })),
   on(experimentsAction.actionGetExperimentByIdSuccess, (state, { experiment }) => {
     // Upsert experiment: update if exists, add if not (for direct navigation)

--- a/packages/frontend/projects/upgrade/src/app/core/experiments/store/experiments.selectors.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/experiments/store/experiments.selectors.ts
@@ -42,6 +42,11 @@ export const selectAllExperiment = createSelector(
 
 export const selectIsLoadingExperiment = createSelector(selectExperimentState, (state) => state.isLoadingExperiment);
 
+export const selectHasInitialExperimentsDataLoaded = createSelector(
+  selectExperimentState,
+  (state) => state.hasInitialExperimentsDataLoaded
+);
+
 export const selectIsLoadingExperimentDetailStats = createSelector(
   selectExperimentState,
   (state) => state.isLoadingExperimentDetailStats

--- a/packages/frontend/projects/upgrade/src/app/core/local-storage/local-storage.service.spec.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/local-storage/local-storage.service.spec.ts
@@ -46,6 +46,7 @@ describe('LocalStorageService', () => {
       isLoadingImportExperiment: false,
       rewardsSummaries: {},
       isLoadingRewardsSummary: false,
+      hasInitialExperimentsDataLoaded: false,
     };
     const expectedStateWithDefaults: ExperimentState = {
       experiments: [],
@@ -73,6 +74,7 @@ describe('LocalStorageService', () => {
       isLoadingImportExperiment: false,
       rewardsSummaries: {},
       isLoadingRewardsSummary: false,
+      hasInitialExperimentsDataLoaded: false,
     };
 
     const testCases = [

--- a/packages/frontend/projects/upgrade/src/app/core/local-storage/local-storage.service.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/local-storage/local-storage.service.ts
@@ -58,6 +58,7 @@ export class LocalStorageService {
       isLoadingImportExperiment: false,
       isLoadingRewardsSummary: false,
       rewardsSummaries: {},
+      hasInitialExperimentsDataLoaded: false,
     };
 
     const featureFlagState: FeatureFlagState = {
@@ -86,6 +87,7 @@ export class LocalStorageService {
     const segmentState: SegmentState = {
       segments: [],
       isLoadingSegments: false,
+      hasInitialSegmentsDataLoaded: false,
       allExperimentSegmentsInclusion: null,
       allExperimentSegmentsExclusion: null,
       allFeatureFlagSegmentsInclusion: null,

--- a/packages/frontend/projects/upgrade/src/app/core/segments/segments.service.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/segments/segments.service.ts
@@ -3,6 +3,7 @@ import { Store, select } from '@ngrx/store';
 import { AppState } from '../core.state';
 import * as SegmentsActions from './store/segments.actions';
 import {
+  selectHasInitialSegmentsDataLoaded,
   selectIsLoadingSegments,
   selectAllSegments,
   selectSelectedSegment,
@@ -50,9 +51,9 @@ import { actionFetchContextMetaData } from '../experiments/store/experiments.act
 @Injectable({ providedIn: 'root' })
 export class SegmentsService {
   constructor(
-    private store$: Store<AppState>,
-    private segmentsDataService: SegmentsDataService,
-    private localStorageService: LocalStorageService
+    private readonly store$: Store<AppState>,
+    private readonly segmentsDataService: SegmentsDataService,
+    private readonly localStorageService: LocalStorageService
   ) {}
 
   isLoadingSegments$ = this.store$.pipe(select(selectIsLoadingSegments));
@@ -102,7 +103,7 @@ export class SegmentsService {
       select(selectContextMetaData),
       map((contextMetaData) => {
         const groupTypes = contextMetaData?.contextMetadata?.[appContext]?.GROUP_TYPES ?? [];
-        const groupTypeSelectOptions = CommonTextHelpersService.formatGroupTypes(groupTypes as string[]);
+        const groupTypeSelectOptions = CommonTextHelpersService.formatGroupTypes(groupTypes);
 
         return [
           { value: LIST_OPTION_TYPE.SEGMENT, viewValue: LIST_OPTION_TYPE.SEGMENT },
@@ -134,9 +135,7 @@ export class SegmentsService {
   }
 
   isInitialSegmentsLoading() {
-    return combineLatest(this.store$.pipe(select(selectIsLoadingSegments)), this.allSegments$).pipe(
-      map(([isLoading, segments]) => !isLoading || !!segments.length)
-    );
+    return this.store$.pipe(select(selectHasInitialSegmentsDataLoaded));
   }
 
   fetchSegmentsPaginated(fromStarting?: boolean) {

--- a/packages/frontend/projects/upgrade/src/app/core/segments/store/segments.model.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/segments/store/segments.model.ts
@@ -231,6 +231,7 @@ export interface SegmentState {
   // List page data - plain array preserves backend sort order
   segments: Segment[];
   isLoadingSegments: boolean;
+  hasInitialSegmentsDataLoaded: boolean;
   isLoadingUpsertSegment: boolean;
   // TODO: remove any
   allExperimentSegmentsInclusion: any;

--- a/packages/frontend/projects/upgrade/src/app/core/segments/store/segments.reducer.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/segments/store/segments.reducer.ts
@@ -5,13 +5,13 @@ import {
   SEGMENT_SEARCH_KEY,
   SORT_AS_DIRECTION,
   SEGMENT_SORT_KEY,
-  SEGMENT_TYPE,
 } from '../../../../../../../../types/src/Experiment/enums';
 
 export const initialState: SegmentState = {
   // List page data - plain array preserves backend sort order
   segments: [],
   isLoadingSegments: false,
+  hasInitialSegmentsDataLoaded: false,
   allExperimentSegmentsInclusion: null,
   allExperimentSegmentsExclusion: null,
   allFeatureFlagSegmentsInclusion: null,
@@ -61,11 +61,21 @@ const reducer = createReducer(
       if (fromStarting) {
         // when going fromStarting (on any fetch other than fetch more on scroll)
         newState.skipSegments = segments.length;
-        return { ...newState, segments: [...segments], isLoadingSegments: false };
+        return {
+          ...newState,
+          segments: [...segments],
+          isLoadingSegments: false,
+          hasInitialSegmentsDataLoaded: true,
+        };
       } else {
         // when fetching more
         newState.skipSegments = state.skipSegments + segments.length;
-        return { ...newState, segments: [...state.segments, ...segments], isLoadingSegments: false };
+        return {
+          ...newState,
+          segments: [...state.segments, ...segments],
+          isLoadingSegments: false,
+          hasInitialSegmentsDataLoaded: true,
+        };
       }
     }
   ),
@@ -83,7 +93,7 @@ const reducer = createReducer(
     SegmentsActions.actionAddSegmentSuccess,
     (state) => ({ ...state, isLoadingSegments: false })
   ),
-  on(SegmentsActions.actionUpsertSegmentSuccess, (state, { segment }) => ({
+  on(SegmentsActions.actionUpsertSegmentSuccess, (state) => ({
     ...state,
     isLoadingSegments: false,
   })),

--- a/packages/frontend/projects/upgrade/src/app/core/segments/store/segments.selectors.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/segments/store/segments.selectors.ts
@@ -24,6 +24,11 @@ export const selectGlobalSegments = createSelector(selectGlobalSegmentsState, (s
 
 export const selectIsLoadingSegments = createSelector(selectSegmentsState, (state) => state.isLoadingSegments);
 
+export const selectHasInitialSegmentsDataLoaded = createSelector(
+  selectSegmentsState,
+  (state) => state.hasInitialSegmentsDataLoaded
+);
+
 export const isLoadingUpsertSegment = createSelector(selectSegmentsState, (state) => state.isLoadingUpsertSegment);
 
 export const selectIsLoadingGlobalSegments = createSelector(


### PR DESCRIPTION
Implements the same guard against infinite fetch errors on pagination for segments and experiments that is already in place for feature flags.