### PR TITLE
feature flag optimizations part one

### DIFF
--- a/packages/backend/src/api/repositories/FeatureFlagExposureRepository.ts
+++ b/packages/backend/src/api/repositories/FeatureFlagExposureRepository.ts
@@ -6,6 +6,15 @@ import { getDateVariables } from './utils/dateQuery';
 
 @EntityRepository(FeatureFlagExposure)
 export class FeatureFlagExposureRepository extends Repository<FeatureFlagExposure> {
+  public async recordExposureIfNotExists(flagIds: string[], experimentUserId: string): Promise<void> {
+    await this.createQueryBuilder()
+      .insert()
+      .into(FeatureFlagExposure)
+      .values(flagIds.map((featureFlagId) => ({ featureFlagId, experimentUserId })))
+      .orIgnore()
+      .execute();
+  }
+
   public async getExposuresByDateRange(flagId: string, dateRange: DATE_RANGE, clientOffset: number) {
     const { whereDate, selectRange } = getDateVariables(dateRange, clientOffset, 'feature_flag_exposure');
     const query = this.createQueryBuilder('feature_flag_exposure')

--- a/packages/backend/src/api/services/FeatureFlagService.ts
+++ b/packages/backend/src/api/services/FeatureFlagService.ts
@@ -110,7 +110,7 @@ export class FeatureFlagService {
           includedFeatureFlags.map((flag) => flag.id),
           experimentUserDoc.id
         )
-.catch((err) => logger.error({ message: 'Error saving FF exposures', err }));
+        .catch((err) => logger.error({ message: 'Error saving FF exposures', err }));
     }
 
     return includedFeatureFlags.map((flags) => flags.key);

--- a/packages/backend/src/api/services/FeatureFlagService.ts
+++ b/packages/backend/src/api/services/FeatureFlagService.ts
@@ -110,7 +110,7 @@ export class FeatureFlagService {
           includedFeatureFlags.map((flag) => flag.id),
           experimentUserDoc.id
         )
-        .catch((err) => logger.error({ message: `Error saving FF exposures: ${err}` }));
+.catch((err) => logger.error({ message: 'Error saving FF exposures', err }));
     }
 
     return includedFeatureFlags.map((flags) => flags.key);

--- a/packages/backend/src/api/services/FeatureFlagService.ts
+++ b/packages/backend/src/api/services/FeatureFlagService.ts
@@ -1,7 +1,6 @@
 import { Service } from 'typedi';
 import { FeatureFlag } from '../models/FeatureFlag';
 import { Segment } from '../models/Segment';
-import { FeatureFlagExposure } from '../models/FeatureFlagExposure';
 import { FeatureFlagSegmentInclusion } from '../models/FeatureFlagSegmentInclusion';
 import { FeatureFlagSegmentExclusion } from '../models/FeatureFlagSegmentExclusion';
 import { FeatureFlagRepository } from '../repositories/FeatureFlagRepository';
@@ -102,34 +101,16 @@ export class FeatureFlagService {
 
     const filteredFeatureFlags = await this.getCachedFlagsFromContext(context);
 
-    const [isUserExcluded, isGroupExcluded] = await this.experimentAssignmentService.checkUserOrGroupIsGloballyExcluded(
-      experimentUserDoc,
-      context
-    );
-
-    if (isUserExcluded || isGroupExcluded) {
-      return [];
-    }
-
     const includedFeatureFlags = await this.featureFlagLevelInclusionExclusion(filteredFeatureFlags, experimentUserDoc);
 
     // save exposures in db
-    try {
-      await this.dataSource.transaction(async (transactionalEntityManager) => {
-        const exposureRepo = transactionalEntityManager.getRepository(FeatureFlagExposure);
-        const exposuresToSave = includedFeatureFlags.map((flag) => ({
-          featureFlag: flag,
-          experimentUserId: experimentUserDoc.id,
-        }));
-        if (exposuresToSave.length > 0) {
-          // fire and forget, we don't need to wait on this, return flag asap to user
-          exposureRepo.save(exposuresToSave);
-        }
-      });
-    } catch (err) {
-      const error = new Error(`Error in saving feature flag exposure records ${err}`);
-      (error as any).type = SERVER_ERROR.QUERY_FAILED;
-      logger.error(error);
+    if (includedFeatureFlags.length > 0) {
+      this.featureFlagExposureRepository
+        .recordExposureIfNotExists(
+          includedFeatureFlags.map((flag) => flag.id),
+          experimentUserDoc.id
+        )
+        .catch((err) => logger.error({ message: `Error saving FF exposures: ${err}` }));
     }
 
     return includedFeatureFlags.map((flags) => flags.key);
@@ -882,13 +863,19 @@ export class FeatureFlagService {
     experimentUser: ExperimentUser
   ): Promise<FeatureFlag[]> {
     const segmentObjMap = {};
+    const getEnabledSegmentIds = (list: FeatureFlagSegmentExclusion[] | FeatureFlagSegmentInclusion[]) => {
+      return list.filter((item) => item.enabled).map((item) => item.segment.id);
+    };
+
     featureFlags.forEach((flag) => {
-      const includeIds = flag.featureFlagSegmentInclusion
-        .filter((inclusion) => inclusion.enabled)
-        .map((segmentInclusion) => segmentInclusion.segment.id);
-      const excludeIds = flag.featureFlagSegmentExclusion
-        .filter((exclusion) => exclusion.enabled)
-        .map((segmentExclusion) => segmentExclusion.segment.id);
+      const excludeIds = getEnabledSegmentIds(flag.featureFlagSegmentExclusion);
+      let includeIds = [];
+
+      // this should be fixed upstream also so featureFlagSegmentInclusion is always an empty array already,
+      // but this will at least catch it here also if something was missed so that we aren't caching or running logic on irrelevant segments
+      if (flag.filterMode !== FILTER_MODE.INCLUDE_ALL) {
+        includeIds = getEnabledSegmentIds(flag.featureFlagSegmentInclusion);
+      }
 
       segmentObjMap[flag.id] = {
         segmentIdsQueue: [...includeIds, ...excludeIds],

--- a/packages/backend/test/integration/FeatureFlags/FeatureFlagInclusionExclusion.ts
+++ b/packages/backend/test/integration/FeatureFlags/FeatureFlagInclusionExclusion.ts
@@ -112,6 +112,11 @@ export default async function FeatureFlagInclusionExclusionLogic(): Promise<void
   expect(keysAssign.length).toEqual(0);
 
   // Check the number of exposures
-  const paginatedFind = await featureFlagService.findPaginated(0, 5, new UpgradeLogger());
+  // getKeys fire-and-forgets the exposure insert, so poll until the writes land in the DB
+  let paginatedFind = await featureFlagService.findPaginated(0, 5, new UpgradeLogger());
+  for (let i = 0; i < 10 && (paginatedFind[0][0] as any).featureFlagExposures < 2; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    paginatedFind = await featureFlagService.findPaginated(0, 5, new UpgradeLogger());
+  }
   expect(paginatedFind[0][0].featureFlagExposures).toEqual(2);
 }

--- a/packages/backend/test/unit/repositories/FeatureFlagExposureRepository.test.ts
+++ b/packages/backend/test/unit/repositories/FeatureFlagExposureRepository.test.ts
@@ -1,0 +1,68 @@
+import { DataSource } from 'typeorm';
+import { FeatureFlagExposureRepository } from '../../../src/api/repositories/FeatureFlagExposureRepository';
+import { FeatureFlagExposure } from '../../../src/api/models/FeatureFlagExposure';
+import { Container } from '../../../src/typeorm-typedi-extensions';
+import { initializeMocks } from '../mockdata/mockRepo';
+
+let mock;
+let dataSource: DataSource;
+let repo: FeatureFlagExposureRepository;
+
+const result = {
+  identifiers: [],
+  generatedMaps: [],
+  raw: [],
+};
+
+beforeAll(() => {
+  dataSource = new DataSource({
+    type: 'postgres',
+    database: 'postgres',
+    entities: [FeatureFlagExposureRepository],
+    synchronize: true,
+  });
+  Container.setDataSource('default', dataSource);
+});
+
+beforeEach(() => {
+  repo = Container.getCustomRepository(FeatureFlagExposureRepository);
+  const commonMockData = initializeMocks(result);
+  repo.createQueryBuilder = commonMockData.createQueryBuilder;
+  mock = commonMockData.mocks;
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('FeatureFlagExposureRepository Testing', () => {
+  describe('recordExposureIfNotExists', () => {
+    it('should insert all flagId/userId pairs using orIgnore for duplicate handling', async () => {
+      const flagIds = ['flag-id-1', 'flag-id-2'];
+      const userId = 'user-id-1';
+
+      await repo.recordExposureIfNotExists(flagIds, userId);
+
+      expect(repo.createQueryBuilder).toHaveBeenCalledTimes(1);
+      expect(mock.insert).toHaveBeenCalledTimes(1);
+      expect(mock.into).toHaveBeenCalledWith(FeatureFlagExposure);
+      expect(mock.values).toHaveBeenCalledWith([
+        { featureFlagId: 'flag-id-1', experimentUserId: 'user-id-1' },
+        { featureFlagId: 'flag-id-2', experimentUserId: 'user-id-1' },
+      ]);
+      expect(mock.orIgnore).toHaveBeenCalledTimes(1);
+      expect(mock.execute).toHaveBeenCalledTimes(1);
+    });
+
+    it('should work for a single flag', async () => {
+      const flagIds = ['flag-id-1'];
+      const userId = 'user-id-1';
+
+      await repo.recordExposureIfNotExists(flagIds, userId);
+
+      expect(mock.values).toHaveBeenCalledWith([{ featureFlagId: 'flag-id-1', experimentUserId: 'user-id-1' }]);
+      expect(mock.orIgnore).toHaveBeenCalledTimes(1);
+      expect(mock.execute).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/backend/test/unit/services/FeatureFlagService.test.ts
+++ b/packages/backend/test/unit/services/FeatureFlagService.test.ts
@@ -30,6 +30,8 @@ import { FeatureFlagListValidator } from '../../../src/api/controllers/validator
 import { SegmentService } from '../../../src/api/services/SegmentService';
 import { FeatureFlagSegmentExclusionRepository } from '../../../src/api/repositories/FeatureFlagSegmentExclusionRepository';
 import { FeatureFlagSegmentInclusionRepository } from '../../../src/api/repositories/FeatureFlagSegmentInclusionRepository';
+import { FeatureFlagExposureRepository } from '../../../src/api/repositories/FeatureFlagExposureRepository';
+import { FeatureFlagSegmentInclusion } from '../../../src/api/models/FeatureFlagSegmentInclusion';
 import { User } from '../../../src/api/models/User';
 import { ExperimentAuditLogRepository } from '../../../src/api/repositories/ExperimentAuditLogRepository';
 import { CacheService } from '../../../src/api/services/CacheService';
@@ -77,6 +79,26 @@ describe('Feature Flag Service Testing', () => {
   mockFlag4.tags = [];
   mockFlag4.featureFlagSegmentInclusion = [];
   mockFlag4.featureFlagSegmentExclusion = [];
+
+  const inclusionSegmentForExcludeAll = { id: 'seg-include-for-exclude-all' } as any;
+  const excludeAllFlagWithInclusion = new FeatureFlag();
+  excludeAllFlagWithInclusion.id = 'exclude-all-flag-id';
+  excludeAllFlagWithInclusion.key = 'exclude-all-key';
+  excludeAllFlagWithInclusion.filterMode = FILTER_MODE.EXCLUDE_ALL;
+  excludeAllFlagWithInclusion.featureFlagSegmentInclusion = [
+    { enabled: true, segment: inclusionSegmentForExcludeAll } as FeatureFlagSegmentInclusion,
+  ];
+  excludeAllFlagWithInclusion.featureFlagSegmentExclusion = [];
+
+  const inclusionSegmentForIncludeAll = { id: 'seg-include-for-include-all' } as any;
+  const includeAllFlagWithInclusion = new FeatureFlag();
+  includeAllFlagWithInclusion.id = 'include-all-flag-id';
+  includeAllFlagWithInclusion.key = 'include-all-key';
+  includeAllFlagWithInclusion.filterMode = FILTER_MODE.INCLUDE_ALL;
+  includeAllFlagWithInclusion.featureFlagSegmentInclusion = [
+    { enabled: true, segment: inclusionSegmentForIncludeAll } as FeatureFlagSegmentInclusion,
+  ];
+  includeAllFlagWithInclusion.featureFlagSegmentExclusion = [];
 
   const mockSegment = {
     name: 'name',
@@ -241,6 +263,12 @@ describe('Feature Flag Service Testing', () => {
               getMany: jest.fn().mockResolvedValue([]),
               getOne: jest.fn().mockResolvedValue(null),
             })),
+          },
+        },
+        {
+          provide: getRepositoryToken(FeatureFlagExposureRepository),
+          useValue: {
+            recordExposureIfNotExists: jest.fn().mockResolvedValue(undefined),
           },
         },
         {
@@ -535,5 +563,123 @@ describe('Feature Flag Service Testing', () => {
     await service.clearCachedFlagsForContext('test');
 
     expect(service.cacheService.delCache).toHaveBeenCalled();
+  });
+
+  describe('getKeys - global exclusion removed', () => {
+    it('should not call checkUserOrGroupIsGloballyExcluded', async () => {
+      const userDoc = { id: 'user123', group: {}, workingGroup: {} } as any;
+      const experimentAssignmentService = module.get<ExperimentAssignmentService>(ExperimentAssignmentService);
+
+      flagRepo.getFlagsFromContext = jest.fn().mockResolvedValue([]);
+      service.cacheService.wrap = jest.fn().mockResolvedValue([mockFlag1]);
+
+      await service.getKeys(userDoc, 'context1', logger);
+
+      expect(experimentAssignmentService.checkUserOrGroupIsGloballyExcluded).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getKeys - exposure recording', () => {
+    it('should call recordExposureIfNotExists with included flag ids and user id', async () => {
+      const userDoc = { id: 'user123', group: {}, workingGroup: {} } as any;
+      const exposureRepo = module.get(getRepositoryToken(FeatureFlagExposureRepository)) as any;
+      const experimentAssignmentService = module.get<ExperimentAssignmentService>(ExperimentAssignmentService);
+
+      flagRepo.getFlagsFromContext = jest.fn().mockResolvedValue([]);
+      service.cacheService.wrap = jest.fn().mockResolvedValue([mockFlag1]);
+      (experimentAssignmentService.inclusionExclusionLogic as jest.Mock).mockResolvedValue([[mockFlag1.id], []]);
+
+      await service.getKeys(userDoc, 'context1', logger);
+
+      expect(exposureRepo.recordExposureIfNotExists).toHaveBeenCalledWith([mockFlag1.id], userDoc.id);
+    });
+
+    it('should not call recordExposureIfNotExists when no flags are included', async () => {
+      const userDoc = { id: 'user123', group: {}, workingGroup: {} } as any;
+      const exposureRepo = module.get(getRepositoryToken(FeatureFlagExposureRepository)) as any;
+      const experimentAssignmentService = module.get<ExperimentAssignmentService>(ExperimentAssignmentService);
+
+      flagRepo.getFlagsFromContext = jest.fn().mockResolvedValue([]);
+      service.cacheService.wrap = jest.fn().mockResolvedValue([mockFlag1]);
+      (experimentAssignmentService.inclusionExclusionLogic as jest.Mock).mockResolvedValue([[], []]);
+
+      await service.getKeys(userDoc, 'context1', logger);
+
+      expect(exposureRepo.recordExposureIfNotExists).not.toHaveBeenCalled();
+    });
+
+    it('should not use dataSource.transaction for exposure recording', async () => {
+      const userDoc = { id: 'user123', group: {}, workingGroup: {} } as any;
+      const experimentAssignmentService = module.get<ExperimentAssignmentService>(ExperimentAssignmentService);
+
+      flagRepo.getFlagsFromContext = jest.fn().mockResolvedValue([]);
+      service.cacheService.wrap = jest.fn().mockResolvedValue([mockFlag1]);
+      (experimentAssignmentService.inclusionExclusionLogic as jest.Mock).mockResolvedValue([[mockFlag1.id], []]);
+
+      await service.getKeys(userDoc, 'context1', logger);
+
+      expect(dataSource.transaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('featureFlagLevelInclusionExclusion - filterMode segment handling', () => {
+    it('EXCLUDE_ALL: passes enabled inclusion segment IDs to resolveSegmentsForEntities', async () => {
+      const userDoc = { id: 'user123', group: {}, workingGroup: {} } as any;
+      const experimentAssignmentService = module.get<ExperimentAssignmentService>(ExperimentAssignmentService);
+      const resolveSegmentsSpy = experimentAssignmentService.resolveSegmentsForEntities as jest.Mock;
+
+      flagRepo.getFlagsFromContext = jest.fn().mockResolvedValue([]);
+      service.cacheService.wrap = jest.fn().mockResolvedValue([excludeAllFlagWithInclusion]);
+      resolveSegmentsSpy.mockResolvedValue([{}, {}]);
+
+      await service.getKeys(userDoc, 'context1', logger);
+
+      expect(resolveSegmentsSpy).toHaveBeenCalledTimes(1);
+      const segmentObjMap = resolveSegmentsSpy.mock.calls[0][0];
+      expect(segmentObjMap[excludeAllFlagWithInclusion.id].currentIncludedSegmentIds).toEqual([
+        inclusionSegmentForExcludeAll.id,
+      ]);
+    });
+
+    it('INCLUDE_ALL: does not pass inclusion segment IDs to resolveSegmentsForEntities', async () => {
+      const userDoc = { id: 'user123', group: {}, workingGroup: {} } as any;
+      const experimentAssignmentService = module.get<ExperimentAssignmentService>(ExperimentAssignmentService);
+      const resolveSegmentsSpy = experimentAssignmentService.resolveSegmentsForEntities as jest.Mock;
+
+      flagRepo.getFlagsFromContext = jest.fn().mockResolvedValue([]);
+      service.cacheService.wrap = jest.fn().mockResolvedValue([includeAllFlagWithInclusion]);
+      resolveSegmentsSpy.mockResolvedValue([{}, {}]);
+
+      await service.getKeys(userDoc, 'context1', logger);
+
+      expect(resolveSegmentsSpy).toHaveBeenCalledTimes(1);
+      const segmentObjMap = resolveSegmentsSpy.mock.calls[0][0];
+      expect(segmentObjMap[includeAllFlagWithInclusion.id].currentIncludedSegmentIds).toEqual([]);
+    });
+
+    it('should exclude disabled inclusion segments regardless of filterMode', async () => {
+      const userDoc = { id: 'user123', group: {}, workingGroup: {} } as any;
+      const experimentAssignmentService = module.get<ExperimentAssignmentService>(ExperimentAssignmentService);
+      const resolveSegmentsSpy = experimentAssignmentService.resolveSegmentsForEntities as jest.Mock;
+
+      const flagWithDisabledInclusion = new FeatureFlag();
+      flagWithDisabledInclusion.id = 'flag-disabled-inclusion';
+      flagWithDisabledInclusion.key = 'flag-disabled-key';
+      flagWithDisabledInclusion.filterMode = FILTER_MODE.EXCLUDE_ALL;
+      flagWithDisabledInclusion.featureFlagSegmentInclusion = [
+        { enabled: false, segment: { id: 'disabled-seg-id' } } as FeatureFlagSegmentInclusion,
+      ];
+      flagWithDisabledInclusion.featureFlagSegmentExclusion = [];
+
+      flagRepo.getFlagsFromContext = jest.fn().mockResolvedValue([]);
+      service.cacheService.wrap = jest.fn().mockResolvedValue([flagWithDisabledInclusion]);
+      resolveSegmentsSpy.mockResolvedValue([{}, {}]);
+
+      await service.getKeys(userDoc, 'context1', logger);
+
+      expect(resolveSegmentsSpy).toHaveBeenCalledTimes(1);
+      const segmentObjMap = resolveSegmentsSpy.mock.calls[0][0];
+      expect(segmentObjMap[flagWithDisabledInclusion.id].currentIncludedSegmentIds).toEqual([]);
+    });
   });
 });


### PR DESCRIPTION
handles 1a, 1b, and 4 from the research spike plan that claude and I spun up #3143 

- Removes global exclude logic from `getKeys()` (if we can't do that, then we'll need to cache the global exclude lists, because it isn't happening currently so gets called every time... not a problem current as `clc` and `mathia-student-ui` don't have global exclude lists currently, but if someone added a big one today, it would cause problems)

- Guards against include-list data being used in segment lookups when INCLUDE_ALL (this is one part of a two part fix in another pr)

- Fixes issues in exposure save: 
  - wasn't actually fire-and-forget because the transaction is awaited
  - was doing a full SELECT on every call with `.save` because of how typeorm treats full object as param vs an id, however:
  - ignore on conflict makes that work the way we'd actually want, which is to do a blind insert and bail if it exists without erroring
  
