### PR TITLE
global exclude caching, refactor cache service for simplified error-handling

### DIFF
--- a/packages/backend/src/api/controllers/ExperimentController.ts
+++ b/packages/backend/src/api/controllers/ExperimentController.ts
@@ -31,7 +31,13 @@ import { env } from '../../env';
 import { Response } from 'express';
 import { NotFoundException } from '@nestjs/common/exceptions';
 import { ExperimentIdValidator } from '../DTO/ExperimentDTO';
-import { IImportError, LIST_FILTER_MODE, SERVER_ERROR, SUPPORTED_MOOCLET_ALGORITHMS } from 'upgrade_types';
+import {
+  CACHE_PREFIX,
+  IImportError,
+  LIST_FILTER_MODE,
+  SERVER_ERROR,
+  SUPPORTED_MOOCLET_ALGORITHMS,
+} from 'upgrade_types';
 import { ImportExportService } from '../services/ImportExportService';
 import { ExperimentSegmentInclusion } from '../models/ExperimentSegmentInclusion';
 import { SegmentInputValidator } from './validators/SegmentInputValidator';
@@ -1956,15 +1962,10 @@ export class ExperimentController {
   // debugging endpoint, will read all keys in cache and return a summary
   @Get('/cache')
   async debugCache(): Promise<any> {
-    const prefixes = {
-      experiments: 'validExperiments-',
-      segments: 'segments-',
-      marks: 'markExperiments-',
-      featureFlags: 'featureFlags-',
-    };
+    const prefixes = Object.fromEntries(Object.entries(CACHE_PREFIX));
 
     // Get all keys from cache
-    const allKeys = (await (this.cacheService as any).memoryCache?.store?.keys()) || [];
+    const allKeys = await this.cacheService.getKeys();
 
     // Build summary for each prefix
     const summary = {};

--- a/packages/backend/src/api/services/CacheService.ts
+++ b/packages/backend/src/api/services/CacheService.ts
@@ -1,83 +1,122 @@
 import { env } from '../../env';
 import { Service } from 'typedi';
-import { MemoryCache, caching } from 'cache-manager';
+import { Cache, Store, caching } from 'cache-manager';
 import { CACHE_PREFIX } from 'upgrade_types';
+import { UpgradeLogger } from '../../lib/logger/UpgradeLogger';
+
+// this module will get swapped in if caching is enabled but the cache manager fails to initialize as a dummy default deliverer
+const noopStore: Cache<Store> = {
+  get: () => Promise.resolve(undefined),
+  set: () => Promise.resolve(),
+  del: () => Promise.resolve(),
+  reset: () => Promise.resolve(),
+  on: () => {
+    // noop
+  },
+  removeListener: () => {
+    // noop
+  },
+  wrap: (_key, fn) => fn(),
+  store: {
+    get: () => Promise.resolve(undefined),
+    set: () => Promise.resolve(),
+    del: () => Promise.resolve(),
+    reset: () => Promise.resolve(),
+    mget: () => Promise.resolve([]),
+    mset: () => Promise.resolve(),
+    mdel: () => Promise.resolve(),
+    keys: () => Promise.resolve([]),
+    ttl: () => Promise.resolve(0),
+  },
+};
 
 @Service()
 export class CacheService {
-  private memoryCache: MemoryCache;
+  private cache: Cache<Store> = noopStore;
   private ttl = env.caching.ttl || 900;
 
   constructor() {
-    // read from the environment variable for initializing caching
     if (env.caching.enabled) {
-      this.initializeMemoryCache();
+      this.initializeCache();
     }
   }
 
-  private async initializeMemoryCache() {
-    this.memoryCache = await caching('memory', {
-      max: env.caching?.maxKeys || 500,
-      ttl: this.ttl * 1000 /*milliseconds*/,
-    });
+  private async initializeCache() {
+    try {
+      this.cache = await caching('memory', {
+        max: env.caching?.maxKeys || 500,
+        ttl: this.ttl * 1000,
+      });
+    } catch (err) {
+      new UpgradeLogger().error({
+        message: 'CacheService failed to initialize — caching is enabled but cache is unavailable',
+        error: err,
+      });
+    }
   }
 
   public async setCache<T>(id: string, value: T): Promise<T> {
     if (value === null || value === undefined) {
-      return Promise.resolve(null);
+      return null;
     }
-    if (this.memoryCache) {
-      await this.memoryCache.set(id, value);
-      return value;
-    }
-    return Promise.resolve(null);
+    await this.cache.set(id, value);
+    return value;
   }
 
-  public getCache<T>(id: string): Promise<T> {
-    return this.memoryCache ? this.memoryCache.get(id) : Promise.resolve(null);
+  public getCache<T>(id: string): Promise<T | undefined> {
+    return this.cache.get(id);
   }
 
   public delCache(id: string): Promise<void> {
-    return this.memoryCache ? this.memoryCache.del(id) : Promise.resolve();
+    return this.cache.del(id);
   }
 
   public async resetPrefixCache(prefix: string): Promise<void> {
-    const keys = this.memoryCache ? await this.memoryCache.store.keys() : [];
+    const keys = await this.cache.store.keys();
     const filteredKeys = keys.filter((str) => str.startsWith(prefix));
-    return this.memoryCache ? this.memoryCache.store.mdel(...filteredKeys) : null;
+    if (filteredKeys.length > 0) {
+      return this.cache.store.mdel(...filteredKeys);
+    }
   }
 
-  public async resetAllCache(): Promise<void> {
-    return this.memoryCache ? this.memoryCache.store.reset() : Promise.resolve();
+  public resetAllCache(): Promise<void> {
+    return this.cache.store.reset();
   }
 
-  // Use this to wrap the function that you want to cache
+  public getKeys(): Promise<string[]> {
+    return this.cache.store.keys();
+  }
+
   public wrap<T>(key: string, fn: () => Promise<T>): Promise<T> {
-    return this.memoryCache ? this.memoryCache.wrap(key, fn) : fn();
+    return this.cache.wrap(key, fn);
   }
 
   public async wrapFunction<T>(prefix: CACHE_PREFIX, keys: string[], functionToCall: () => Promise<T[]>): Promise<T[]> {
-    const keysWithPrefix = keys.map((key) => prefix + key);
-    const cachedData = this.memoryCache ? await this.memoryCache.store.mget(...keysWithPrefix) : [];
+    if (!keys.length) {
+      return [];
+    }
 
-    const allCachedFound = cachedData.every((cached) => !!cached);
-    if (allCachedFound && env.caching.enabled) {
+    const keysWithPrefix = keys.map((key) => prefix + key);
+    const cachedData = (await this.cache.store.mget(...keysWithPrefix)) as (T | undefined)[];
+
+    const allCachedFound = cachedData.length > 0 && cachedData.every((cached) => !!cached);
+    if (allCachedFound) {
       return cachedData as T[];
     }
 
     const data = await functionToCall();
 
-    // creata an array of array containing key and data and then set it in cache
-    if (this.memoryCache) {
-      await this.memoryCache.store.mset(
+    if (data.length > 0) {
+      await this.cache.store.mset(
         keys.reduce((acc, key, index) => {
-          if (data[index] !== null && data[index] !== undefined) {
+          if (data[index] != null) {
             acc.push([prefix + key, data[index]]);
           }
           return acc;
         }, [])
       );
     }
+
     return data;
   }
 }

--- a/packages/backend/src/api/services/CacheService.ts
+++ b/packages/backend/src/api/services/CacheService.ts
@@ -34,11 +34,10 @@ const noopStore: Cache<Store> = {
 export class CacheService {
   private cache: Cache<Store> = noopStore;
   private ttl = env.caching.ttl || 900;
+  private initPromise: Promise<void>;
 
   constructor() {
-    if (env.caching.enabled) {
-      this.initializeCache();
-    }
+    this.initPromise = env.caching.enabled ? this.initializeCache() : Promise.resolve();
   }
 
   private async initializeCache() {
@@ -56,6 +55,7 @@ export class CacheService {
   }
 
   public async setCache<T>(id: string, value: T): Promise<T> {
+    await this.initPromise;
     if (value === null || value === undefined) {
       return null;
     }
@@ -63,15 +63,18 @@ export class CacheService {
     return value;
   }
 
-  public getCache<T>(id: string): Promise<T | undefined> {
+  public async getCache<T>(id: string): Promise<T | undefined> {
+    await this.initPromise;
     return this.cache.get(id);
   }
 
-  public delCache(id: string): Promise<void> {
+  public async delCache(id: string): Promise<void> {
+    await this.initPromise;
     return this.cache.del(id);
   }
 
   public async resetPrefixCache(prefix: string): Promise<void> {
+    await this.initPromise;
     const keys = await this.cache.store.keys();
     const filteredKeys = keys.filter((str) => str.startsWith(prefix));
     if (filteredKeys.length > 0) {
@@ -79,19 +82,23 @@ export class CacheService {
     }
   }
 
-  public resetAllCache(): Promise<void> {
+  public async resetAllCache(): Promise<void> {
+    await this.initPromise;
     return this.cache.store.reset();
   }
 
-  public getKeys(): Promise<string[]> {
+  public async getKeys(): Promise<string[]> {
+    await this.initPromise;
     return this.cache.store.keys();
   }
 
-  public wrap<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  public async wrap<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    await this.initPromise;
     return this.cache.wrap(key, fn);
   }
 
   public async wrapFunction<T>(prefix: CACHE_PREFIX, keys: string[], functionToCall: () => Promise<T[]>): Promise<T[]> {
+    await this.initPromise;
     if (!keys.length) {
       return [];
     }

--- a/packages/backend/src/api/services/SegmentService.ts
+++ b/packages/backend/src/api/services/SegmentService.ts
@@ -454,6 +454,11 @@ export class SegmentService {
       await transactionalEntityManager.getRepository(Segment).save(parentSegment);
       return deletedSegmentResponse;
     });
+
+    // reset cache
+    await this.cacheService.resetPrefixCache(CACHE_PREFIX.SEGMENT_KEY_PREFIX);
+    await this.cacheService.resetPrefixCache(CACHE_PREFIX.GLOBAL_EXCLUDE_SEGMENT_KEY_PREFIX);
+
     return deletedSegmentResponse[0];
   }
 
@@ -469,9 +474,14 @@ export class SegmentService {
   public async deleteSegment(id: string, logger: UpgradeLogger): Promise<Segment> {
     logger.info({ message: `Delete segment by id. segmentId: ${id}` });
     const manager = this.dataSource;
-    const deletedSegment = manager.transaction(async (transactionalEntityManager) => {
+    const deletedSegment = await manager.transaction(async (transactionalEntityManager) => {
       return this.deleteSegmentAndPrivateSubsegments(id, logger, transactionalEntityManager);
     });
+
+    // reset cache
+    await this.cacheService.resetPrefixCache(CACHE_PREFIX.SEGMENT_KEY_PREFIX);
+    await this.cacheService.resetPrefixCache(CACHE_PREFIX.GLOBAL_EXCLUDE_SEGMENT_KEY_PREFIX);
+
     return deletedSegment;
   }
 

--- a/packages/backend/src/api/services/SegmentService.ts
+++ b/packages/backend/src/api/services/SegmentService.ts
@@ -116,7 +116,9 @@ export class SegmentService {
    * @returns A promise that resolves to the global exclude segment.
    */
   public async getGlobalExcludeSegmentByContext(context: string): Promise<Segment> {
-    return this.segmentRepository.findOneSegmentByContextAndType(context, SEGMENT_TYPE.GLOBAL_EXCLUDE);
+    return this.cacheService.wrap(CACHE_PREFIX.GLOBAL_EXCLUDE_SEGMENT_KEY_PREFIX + context, () =>
+      this.segmentRepository.findOneSegmentByContextAndType(context, SEGMENT_TYPE.GLOBAL_EXCLUDE)
+    );
   }
 
   public async getAllPublicSegmentsAndSubsegments(logger: UpgradeLogger): Promise<Segment[]> {
@@ -150,9 +152,6 @@ export class SegmentService {
 
   public async getSegmentByIds(ids: string[]): Promise<Segment[]> {
     return this.cacheService.wrapFunction(CACHE_PREFIX.SEGMENT_KEY_PREFIX, ids, async () => {
-      if (!ids.length) {
-        return [];
-      }
       const result = await this.segmentRepository
         .createQueryBuilder('segment')
         .leftJoinAndSelect('segment.individualForSegment', 'individualForSegment')
@@ -167,11 +166,7 @@ export class SegmentService {
         return [];
       }
 
-      // sort according to ids
-      const sortedData = ids.map((id) => {
-        return result.find((data) => data.id === id);
-      });
-      return sortedData;
+      return ids.map((id) => result.find((data) => data.id === id));
     });
   }
 
@@ -1014,6 +1009,7 @@ export class SegmentService {
 
     // reset cache
     await this.cacheService.resetPrefixCache(CACHE_PREFIX.SEGMENT_KEY_PREFIX);
+    await this.cacheService.resetPrefixCache(CACHE_PREFIX.GLOBAL_EXCLUDE_SEGMENT_KEY_PREFIX);
 
     return transactionalEntityManager
       .getRepository(Segment)

--- a/packages/backend/test/unit/services/CacheService.test.ts
+++ b/packages/backend/test/unit/services/CacheService.test.ts
@@ -1,0 +1,201 @@
+import { CacheService } from '../../../src/api/services/CacheService';
+import { CACHE_PREFIX } from 'upgrade_types';
+
+jest.mock('../../../src/env', () => ({
+  env: {
+    caching: {
+      enabled: false,
+      ttl: 60,
+      maxKeys: 500,
+    },
+  },
+}));
+
+describe('CacheService', () => {
+  let service: CacheService;
+  let mockStore: {
+    get: jest.Mock;
+    set: jest.Mock;
+    del: jest.Mock;
+    wrap: jest.Mock;
+    store: {
+      mget: jest.Mock;
+      mset: jest.Mock;
+      mdel: jest.Mock;
+      keys: jest.Mock;
+      reset: jest.Mock;
+    };
+  };
+
+  beforeEach(() => {
+    service = new CacheService();
+    mockStore = {
+      get: jest.fn().mockResolvedValue(undefined),
+      set: jest.fn().mockResolvedValue(undefined),
+      del: jest.fn().mockResolvedValue(undefined),
+      wrap: jest.fn().mockImplementation((_key, fn) => fn()),
+      store: {
+        mget: jest.fn().mockResolvedValue([]),
+        mset: jest.fn().mockResolvedValue(undefined),
+        mdel: jest.fn().mockResolvedValue(undefined),
+        keys: jest.fn().mockResolvedValue([]),
+        reset: jest.fn().mockResolvedValue(undefined),
+      },
+    };
+    (service as any).cache = mockStore;
+  });
+
+  describe('setCache', () => {
+    it('returns null and skips set when value is null', async () => {
+      const result = await service.setCache('key', null);
+      expect(result).toBeNull();
+      expect(mockStore.set).not.toHaveBeenCalled();
+    });
+
+    it('returns null and skips set when value is undefined', async () => {
+      const result = await service.setCache('key', undefined);
+      expect(result).toBeNull();
+      expect(mockStore.set).not.toHaveBeenCalled();
+    });
+
+    it('stores the value and returns it', async () => {
+      const value = { id: 'test' };
+      const result = await service.setCache('key', value);
+      expect(mockStore.set).toHaveBeenCalledWith('key', value);
+      expect(result).toBe(value);
+    });
+  });
+
+  describe('getCache', () => {
+    it('returns the cached value', async () => {
+      const value = { id: 'test' };
+      mockStore.get.mockResolvedValue(value);
+      const result = await service.getCache('key');
+      expect(result).toBe(value);
+      expect(mockStore.get).toHaveBeenCalledWith('key');
+    });
+
+    it('returns undefined for an uncached key', async () => {
+      const result = await service.getCache('missing');
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('delCache', () => {
+    it('calls del on the store with the given key', async () => {
+      await service.delCache('key');
+      expect(mockStore.del).toHaveBeenCalledWith('key');
+    });
+  });
+
+  describe('resetPrefixCache', () => {
+    it('deletes only keys that match the given prefix', async () => {
+      mockStore.store.keys.mockResolvedValue(['segments-a', 'segments-b', 'featureFlags-x']);
+      await service.resetPrefixCache('segments-');
+      expect(mockStore.store.mdel).toHaveBeenCalledWith('segments-a', 'segments-b');
+    });
+
+    it('does not call mdel when no keys match the prefix', async () => {
+      mockStore.store.keys.mockResolvedValue(['featureFlags-x']);
+      await service.resetPrefixCache('segments-');
+      expect(mockStore.store.mdel).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resetAllCache', () => {
+    it('calls reset on the store', async () => {
+      await service.resetAllCache();
+      expect(mockStore.store.reset).toHaveBeenCalled();
+    });
+  });
+
+  describe('wrap', () => {
+    it('delegates to the store wrap and returns the fn result', async () => {
+      const fn = jest.fn().mockResolvedValue('result');
+      mockStore.wrap.mockImplementation((_key, fn) => fn());
+      const result = await service.wrap('key', fn);
+      expect(result).toBe('result');
+      expect(fn).toHaveBeenCalled();
+    });
+
+    it('returns a cached value without calling fn when the store has one', async () => {
+      const fn = jest.fn();
+      mockStore.wrap.mockResolvedValue('cached');
+      const result = await service.wrap('key', fn);
+      expect(result).toBe('cached');
+      expect(fn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('wrapFunction', () => {
+    const PREFIX = CACHE_PREFIX.SEGMENT_KEY_PREFIX;
+
+    it('returns empty array immediately without hitting the store when keys is empty', async () => {
+      const fetchFn = jest.fn();
+      const result = await service.wrapFunction(PREFIX, [], fetchFn);
+      expect(result).toEqual([]);
+      expect(mockStore.store.mget).not.toHaveBeenCalled();
+      expect(fetchFn).not.toHaveBeenCalled();
+    });
+
+    it('returns all cached values without calling fetchFn on a full cache hit', async () => {
+      const seg1 = { id: 'a' };
+      const seg2 = { id: 'b' };
+      mockStore.store.mget.mockResolvedValue([seg1, seg2]);
+      const fetchFn = jest.fn();
+
+      const result = await service.wrapFunction(PREFIX, ['a', 'b'], fetchFn);
+
+      expect(fetchFn).not.toHaveBeenCalled();
+      expect(result).toEqual([seg1, seg2]);
+    });
+
+    it('calls fetchFn and caches all results on a full cache miss', async () => {
+      const seg1 = { id: 'a' };
+      const seg2 = { id: 'b' };
+      mockStore.store.mget.mockResolvedValue([undefined, undefined]);
+      const fetchFn = jest.fn().mockResolvedValue([seg1, seg2]);
+
+      const result = await service.wrapFunction(PREFIX, ['a', 'b'], fetchFn);
+
+      expect(fetchFn).toHaveBeenCalled();
+      expect(mockStore.store.mset).toHaveBeenCalledWith([
+        [PREFIX + 'a', seg1],
+        [PREFIX + 'b', seg2],
+      ]);
+      expect(result).toEqual([seg1, seg2]);
+    });
+
+    it('calls fetchFn for all keys on a partial cache hit', async () => {
+      const seg1 = { id: 'a' };
+      const seg2 = { id: 'b' };
+      // 'a' is cached but 'b' is not — fetchFn still called for everything
+      mockStore.store.mget.mockResolvedValue([seg1, undefined]);
+      const fetchFn = jest.fn().mockResolvedValue([seg1, seg2]);
+
+      const result = await service.wrapFunction(PREFIX, ['a', 'b'], fetchFn);
+
+      expect(fetchFn).toHaveBeenCalled();
+      expect(result).toEqual([seg1, seg2]);
+    });
+
+    it('does not cache null or undefined values returned by fetchFn', async () => {
+      const seg1 = { id: 'a' };
+      mockStore.store.mget.mockResolvedValue([undefined, undefined]);
+      const fetchFn = jest.fn().mockResolvedValue([seg1, undefined]);
+
+      await service.wrapFunction(PREFIX, ['a', 'b'], fetchFn);
+
+      expect(mockStore.store.mset).toHaveBeenCalledWith([[PREFIX + 'a', seg1]]);
+    });
+
+    it('uses the prefixed key when calling mget', async () => {
+      mockStore.store.mget.mockResolvedValue([undefined]);
+      const fetchFn = jest.fn().mockResolvedValue([{ id: 'a' }]);
+
+      await service.wrapFunction(CACHE_PREFIX.SEGMENT_KEY_PREFIX, ['a'], fetchFn);
+
+      expect(mockStore.store.mget).toHaveBeenCalledWith(CACHE_PREFIX.SEGMENT_KEY_PREFIX + 'a');
+    });
+  });
+});

--- a/packages/backend/test/unit/services/SegmentService.test.ts
+++ b/packages/backend/test/unit/services/SegmentService.test.ts
@@ -33,6 +33,7 @@ import {
   FEATURE_FLAG_STATUS,
   IMPORT_COMPATIBILITY_TYPE,
   SORT_AS_DIRECTION,
+  CACHE_PREFIX,
 } from 'upgrade_types';
 import { configureLogger } from '../../utils/logger';
 import { ExperimentSegmentExclusion } from '../../../src/api/models/ExperimentSegmentExclusion';
@@ -1101,6 +1102,49 @@ describe('Segment Service Testing', () => {
         tags: undefined,
         subSegments: [existingSubsegment],
       });
+    });
+  });
+
+  describe('getGlobalExcludeSegmentByContext', () => {
+    it('delegates to findOneSegmentByContextAndType with correct args', async () => {
+      const globalExcludeSeg = new Segment();
+      globalExcludeSeg.id = 'global-exclude-id';
+      globalExcludeSeg.type = SEGMENT_TYPE.GLOBAL_EXCLUDE;
+      repo.findOneSegmentByContextAndType = jest.fn().mockResolvedValue(globalExcludeSeg);
+
+      const result = await service.getGlobalExcludeSegmentByContext('testContext');
+
+      expect(repo.findOneSegmentByContextAndType).toHaveBeenCalledWith('testContext', SEGMENT_TYPE.GLOBAL_EXCLUDE);
+      expect(result).toEqual(globalExcludeSeg);
+    });
+
+    it('calls cacheService.wrap with GLOBAL_EXCLUDE_SEGMENT_KEY_PREFIX + context as the cache key', async () => {
+      const globalExcludeSeg = new Segment();
+      globalExcludeSeg.id = 'global-exclude-id';
+      repo.findOneSegmentByContextAndType = jest.fn().mockResolvedValue(globalExcludeSeg);
+
+      const cacheService = module.get<CacheService>(CacheService);
+      const wrapSpy = jest.spyOn(cacheService, 'wrap');
+
+      await service.getGlobalExcludeSegmentByContext('myContext');
+
+      expect(wrapSpy).toHaveBeenCalledWith(
+        CACHE_PREFIX.GLOBAL_EXCLUDE_SEGMENT_KEY_PREFIX + 'myContext',
+        expect.any(Function)
+      );
+    });
+  });
+
+  describe('cache invalidation on segment save', () => {
+    it('resets both SEGMENT_KEY_PREFIX and GLOBAL_EXCLUDE_SEGMENT_KEY_PREFIX caches when a segment is saved', async () => {
+      const cacheService = module.get<CacheService>(CacheService);
+      const resetSpy = jest.spyOn(cacheService, 'resetPrefixCache');
+      service.checkIsDuplicateSegmentName = jest.fn().mockResolvedValue(false);
+
+      await service.upsertSegment(segVal, logger);
+
+      expect(resetSpy).toHaveBeenCalledWith(CACHE_PREFIX.SEGMENT_KEY_PREFIX);
+      expect(resetSpy).toHaveBeenCalledWith(CACHE_PREFIX.GLOBAL_EXCLUDE_SEGMENT_KEY_PREFIX);
     });
   });
 });

--- a/packages/types/src/Experiment/enums.ts
+++ b/packages/types/src/Experiment/enums.ts
@@ -336,6 +336,7 @@ export enum SUPPORTED_CALIPER_EVENTS {
 export enum CACHE_PREFIX {
   EXPERIMENT_KEY_PREFIX = 'validExperiments-',
   SEGMENT_KEY_PREFIX = 'segments-',
+  GLOBAL_EXCLUDE_SEGMENT_KEY_PREFIX = 'globalExcludeSegment-',
   MARK_KEY_PREFIX = 'markExperiments-',
   FEATURE_FLAG_KEY_PREFIX = 'featureFlags-',
 }


### PR DESCRIPTION
- adds explicit global segment cache

- refactors error-handling when cache-service isn't defined and caching is enabled... currently when undefined unexpectedly, it will silently fail and it pushes that responsibility on all the methods to discover that and have to be defensive and deliver defaults like. this made for annoying tests and overworked methods and i decided to change it up.

- now it will await initialization during construction and throw an error and swap in a dummy 'noop' cache store to handle giving defaults; this is the exact same as current resultant behavior except that now we'll at least see an error if this happens.