### PR TITLE
Pin Postgres image version in Docker Compose files

### DIFF
--- a/demo.singleContainerApp-docker-compose.yml
+++ b/demo.singleContainerApp-docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - "postgres"
 
   postgres:
-    image: postgres:alpine
+    image: postgres:16-alpine
     restart: always
     environment:
       POSTGRES_USER: postgres

--- a/demo.singleContainerApp-docker-compose.yml
+++ b/demo.singleContainerApp-docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - "postgres"
 
   postgres:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     restart: always
     environment:
       POSTGRES_USER: postgres
@@ -41,7 +41,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - upgradedbdata:/var/lib/postgresql/data
+      - upgradedbdata:/var/lib/postgresql
 
 volumes:
   upgradedbdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - "postgres"
 
   postgres:
-    image: postgres:alpine
+    image: postgres:16-alpine
     restart: always
     environment:
       POSTGRES_USER: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - "postgres"
 
   postgres:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     restart: always
     environment:
       POSTGRES_USER: postgres
@@ -44,7 +44,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - upgradedbdata:/var/lib/postgresql/data
+      - upgradedbdata:/var/lib/postgresql
 
 volumes:
   upgradedbdata:

--- a/singleContainerApp-docker-compose.yml
+++ b/singleContainerApp-docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - "postgres"
 
   postgres:
-    image: postgres:alpine
+    image: postgres:16-alpine
     restart: always
     environment:
       POSTGRES_USER: postgres

--- a/singleContainerApp-docker-compose.yml
+++ b/singleContainerApp-docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - "postgres"
 
   postgres:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     restart: always
     environment:
       POSTGRES_USER: postgres
@@ -32,7 +32,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - upgradedbdata:/var/lib/postgresql/data
+      - upgradedbdata:/var/lib/postgresql
 
 volumes:
   upgradedbdata:


### PR DESCRIPTION
Resolves #3150

Pins the Postgres image to `postgres:18-alpine` and updates the Docker volume mount to `/var/lib/postgresql`, which matches the recommended layout for Postgres 18 Docker images.