### PR TITLE
clientlibs/js: fix module name mapping for upgrade_types

### DIFF
--- a/clientlibs/js/jest.config.ts
+++ b/clientlibs/js/jest.config.ts
@@ -16,7 +16,7 @@ const config: Config.InitialOptions = {
     API_VERSION: 6,
   },
   moduleNameMapper: {
-    upgrade_types: '<rootDir>/../../types',
+    upgrade_types: '<rootDir>/../../packages/types/src',
   },
   coverageReporters: ['html'],
 };


### PR DESCRIPTION
this seems to have been missed in
48f7680914c254de55b43e354f4864fcbdcd3b15