### PR TITLE
split up monolithic createBaseQueryBuilder experiment query

### DIFF
--- a/packages/backend/src/api/repositories/ExperimentRepository.ts
+++ b/packages/backend/src/api/repositories/ExperimentRepository.ts
@@ -45,7 +45,7 @@ export class ExperimentRepository extends Repository<Experiment> {
       experimentFactorDecisionPointLevelPayloadQuery.getMany().catch((errorMsg: any) => {
         const errorMsgString = repositoryError(
           'ExperimentRepository',
-          'findAllExperiments-experimentFactorPartitionLevelPayloadData',
+          'findAllExperiments-experimentFactorDecisionPointLevelPayloadData',
           {},
           errorMsg
         );

--- a/packages/backend/src/api/repositories/ExperimentRepository.ts
+++ b/packages/backend/src/api/repositories/ExperimentRepository.ts
@@ -287,7 +287,7 @@ export class ExperimentRepository extends Repository<Experiment> {
         experimentConditionLevelPayloadQuery.getMany().catch((errorMsg: any) => {
           const errorMsgString = repositoryError(
             'ExperimentRepository',
-            'getValidExperiments-experimentConditionLevelPayloadQuery',
+            'getValidExperimentsWithPreview-experimentConditionLevelPayloadQuery',
             {},
             errorMsg
           );
@@ -296,7 +296,7 @@ export class ExperimentRepository extends Repository<Experiment> {
         experimentFactorDecisionPointLevelPayloadQuery.getMany().catch((errorMsg: any) => {
           const errorMsgString = repositoryError(
             'ExperimentRepository',
-            'getValidExperiments-experimentFactorDecisionPointLevelPayloadQuery',
+            'getValidExperimentsWithPreview-experimentFactorDecisionPointLevelPayloadQuery',
             {},
             errorMsg
           );
@@ -305,7 +305,7 @@ export class ExperimentRepository extends Repository<Experiment> {
         experimentSegmentQuery.getMany().catch((errorMsg: any) => {
           const errorMsgString = repositoryError(
             'ExperimentRepository',
-            'getValidExperiments-experimentSegmentQuery',
+            'getValidExperimentsWithPreview-experimentSegmentQuery',
             {},
             errorMsg
           );

--- a/packages/backend/src/api/repositories/ExperimentRepository.ts
+++ b/packages/backend/src/api/repositories/ExperimentRepository.ts
@@ -191,24 +191,27 @@ export class ExperimentRepository extends Repository<Experiment> {
       target,
     };
 
-    const conditionLevelPayloadQuery = this.buildConditionLevelPayloadQuery().where(
-      new Brackets((qb) => {
-        qb.where(baseWhereClause, whereClauseParams);
-      })
-    );
+    const conditionLevelPayloadQuery = this.buildConditionLevelPayloadQuery()
+      .leftJoin('experiment.partitions', 'partitions')
+      .where(
+        new Brackets((qb) => {
+          qb.where(decisionPointWhereClause, whereClauseParams);
+        })
+      );
 
-    // site/target filter lives here — this is the authoritative experiment list
     const factorDecisionPointPayloadQuery = this.buildFactorDecisionPointPayloadQuery().where(
       new Brackets((qb) => {
         qb.where(decisionPointWhereClause, whereClauseParams);
       })
     );
 
-    const segmentQuery = this.buildSegmentQuery().where(
-      new Brackets((qb) => {
-        qb.where(baseWhereClause, whereClauseParams);
-      })
-    );
+    const segmentQuery = this.buildSegmentQuery()
+      .leftJoin('experiment.partitions', 'partitions')
+      .where(
+        new Brackets((qb) => {
+          qb.where(decisionPointWhereClause, whereClauseParams);
+        })
+      );
 
     const [conditionLevelPayloadData, factorDecisionPointPayloadData, segmentData] = await Promise.all([
       conditionLevelPayloadQuery.getMany().catch((errorMsg: any) => {
@@ -240,7 +243,6 @@ export class ExperimentRepository extends Repository<Experiment> {
       }),
     ]);
 
-    // factorDecisionPointPayloadData is authoritative — it applied the site/target filter
     const experimentData = factorDecisionPointPayloadData.map((data) => {
       const condData = conditionLevelPayloadData.find((i) => i.id === data.id);
       return { ...condData, ...data };

--- a/packages/backend/src/api/repositories/ExperimentRepository.ts
+++ b/packages/backend/src/api/repositories/ExperimentRepository.ts
@@ -14,18 +14,9 @@ import { ExperimentCondition } from '../models/ExperimentCondition';
 @EntityRepository(Experiment)
 export class ExperimentRepository extends Repository<Experiment> {
   public async findAllExperiments(): Promise<Experiment[]> {
-    const experimentConditionLevelPayloadQuery = this.createQueryBuilder('experiment')
-      .leftJoinAndSelect('experiment.conditions', 'conditions')
-      .leftJoinAndSelect('conditions.levelCombinationElements', 'levelCombinationElements')
-      .leftJoinAndSelect('levelCombinationElements.level', 'level')
-      .leftJoinAndSelect('conditions.conditionPayloads', 'conditionPayload');
+    const experimentConditionLevelPayloadQuery = this.buildConditionLevelPayloadQuery();
 
-    const experimentFactorPartitionLevelPayloadQuery = this.createQueryBuilder('experiment')
-      .leftJoinAndSelect('experiment.partitions', 'partitions')
-      .leftJoinAndSelect('partitions.conditionPayloads', 'conditionPayloads')
-      .leftJoinAndSelect('conditionPayloads.parentCondition', 'parentCondition')
-      .leftJoinAndSelect('experiment.factors', 'factors')
-      .leftJoinAndSelect('factors.levels', 'levels');
+    const experimentFactorDecisionPointLevelPayloadQuery = this.buildFactorDecisionPointPayloadQuery();
 
     const experimentMetricQuery = this.createQueryBuilder('experiment')
       .leftJoinAndSelect('experiment.queries', 'queries')
@@ -34,18 +25,7 @@ export class ExperimentRepository extends Repository<Experiment> {
       .addOrderBy('queries.order', 'ASC', 'NULLS LAST')
       .addOrderBy('queries.createdAt', 'ASC');
 
-    const experimentSegment = this.createQueryBuilder('experiment')
-      .select('experiment.id')
-      .leftJoinAndSelect('experiment.experimentSegmentInclusion', 'experimentSegmentInclusion')
-      .leftJoinAndSelect('experimentSegmentInclusion.segment', 'segmentInclusion')
-      .leftJoinAndSelect('segmentInclusion.individualForSegment', 'individualForSegment')
-      .leftJoinAndSelect('segmentInclusion.groupForSegment', 'groupForSegment')
-      .leftJoinAndSelect('segmentInclusion.subSegments', 'subSegment')
-      .leftJoinAndSelect('experiment.experimentSegmentExclusion', 'experimentSegmentExclusion')
-      .leftJoinAndSelect('experimentSegmentExclusion.segment', 'segmentExclusion')
-      .leftJoinAndSelect('segmentExclusion.individualForSegment', 'individualForSegmentExclusion')
-      .leftJoinAndSelect('segmentExclusion.groupForSegment', 'groupForSegmentExclusion')
-      .leftJoinAndSelect('segmentExclusion.subSegments', 'subSegmentExclusion');
+    const experimentSegment = this.buildSegmentQuery();
 
     const [
       experimentConditionLevelPayloadData,
@@ -62,7 +42,7 @@ export class ExperimentRepository extends Repository<Experiment> {
         );
         throw errorMsgString;
       }),
-      experimentFactorPartitionLevelPayloadQuery.getMany().catch((errorMsg: any) => {
+      experimentFactorDecisionPointLevelPayloadQuery.getMany().catch((errorMsg: any) => {
         const errorMsgString = repositoryError(
           'ExperimentRepository',
           'findAllExperiments-experimentFactorPartitionLevelPayloadData',
@@ -127,50 +107,25 @@ export class ExperimentRepository extends Repository<Experiment> {
       assign: 'assign',
       context,
     };
-    const experimentConditionLevelPayloadQuery = this.createQueryBuilder('experiment')
-      .leftJoinAndSelect('experiment.conditions', 'conditions')
-      .leftJoinAndSelect('conditions.levelCombinationElements', 'levelCombinationElements')
-      .leftJoinAndSelect('levelCombinationElements.level', 'level')
-      .leftJoinAndSelect('conditions.conditionPayloads', 'conditionPayload')
-      .where(
-        new Brackets((qb) => {
-          qb.where(whereExperimentsClause, whereClauseParams);
-        })
-      );
+    const experimentConditionLevelPayloadQuery = this.buildConditionLevelPayloadQuery().where(
+      new Brackets((qb) => {
+        qb.where(whereExperimentsClause, whereClauseParams);
+      })
+    );
 
-    const experimentFactorPartitionLevelPayloadQuery = this.createQueryBuilder('experiment')
-      .leftJoinAndSelect('experiment.partitions', 'partitions')
-      .leftJoinAndSelect('experiment.stratificationFactor', 'stratificationFactor')
-      .leftJoinAndSelect('partitions.conditionPayloads', 'conditionPayloads')
-      .leftJoinAndSelect('conditionPayloads.parentCondition', 'parentCondition')
-      .leftJoinAndSelect('experiment.factors', 'factors')
-      .leftJoinAndSelect('factors.levels', 'levels')
-      .where(
-        new Brackets((qb) => {
-          qb.where(whereExperimentsClause, whereClauseParams);
-        })
-      );
+    const experimentFactorDecisionPointLevelPayloadQuery = this.buildFactorDecisionPointPayloadQuery().where(
+      new Brackets((qb) => {
+        qb.where(whereExperimentsClause, whereClauseParams);
+      })
+    );
 
-    const experimentSegmentQuery = this.createQueryBuilder('experiment')
-      // making small queries
-      .select('experiment.id')
-      .leftJoinAndSelect('experiment.experimentSegmentInclusion', 'experimentSegmentInclusion')
-      .leftJoinAndSelect('experimentSegmentInclusion.segment', 'segmentInclusion')
-      .leftJoinAndSelect('segmentInclusion.individualForSegment', 'individualForSegment')
-      .leftJoinAndSelect('segmentInclusion.groupForSegment', 'groupForSegment')
-      .leftJoinAndSelect('segmentInclusion.subSegments', 'subSegment')
-      .leftJoinAndSelect('experiment.experimentSegmentExclusion', 'experimentSegmentExclusion')
-      .leftJoinAndSelect('experimentSegmentExclusion.segment', 'segmentExclusion')
-      .leftJoinAndSelect('segmentExclusion.individualForSegment', 'individualForSegmentExclusion')
-      .leftJoinAndSelect('segmentExclusion.groupForSegment', 'groupForSegmentExclusion')
-      .leftJoinAndSelect('segmentExclusion.subSegments', 'subSegmentExclusion')
-      .where(
-        new Brackets((qb) => {
-          qb.where(whereExperimentsClause, whereClauseParams);
-        })
-      );
+    const experimentSegmentQuery = this.buildSegmentQuery().where(
+      new Brackets((qb) => {
+        qb.where(whereExperimentsClause, whereClauseParams);
+      })
+    );
 
-    const [experimentConditionLevelPayloadData, experimentFactorPartitionLevelPayloadData, experimentSegmentData] =
+    const [experimentConditionLevelPayloadData, experimentFactorDecisionPointLevelPayloadData, experimentSegmentData] =
       await Promise.all([
         experimentConditionLevelPayloadQuery.getMany().catch((errorMsg: any) => {
           const errorMsgString = repositoryError(
@@ -181,10 +136,10 @@ export class ExperimentRepository extends Repository<Experiment> {
           );
           throw errorMsgString;
         }),
-        experimentFactorPartitionLevelPayloadQuery.getMany().catch((errorMsg: any) => {
+        experimentFactorDecisionPointLevelPayloadQuery.getMany().catch((errorMsg: any) => {
           const errorMsgString = repositoryError(
             'ExperimentRepository',
-            'getValidExperiments-experimentFactorPartitionLevelPayloadQuery',
+            'getValidExperiments-experimentFactorDecisionPointLevelPayloadQuery',
             {},
             errorMsg
           );
@@ -202,7 +157,7 @@ export class ExperimentRepository extends Repository<Experiment> {
       ]);
 
     const experimentData = experimentConditionLevelPayloadData.map((data) => {
-      const data2 = experimentFactorPartitionLevelPayloadData.find((i) => i.id === data.id);
+      const data2 = experimentFactorDecisionPointLevelPayloadData.find((i) => i.id === data.id);
       return { ...data, ...data2 };
     });
 
@@ -222,8 +177,11 @@ export class ExperimentRepository extends Repository<Experiment> {
     site: string,
     target: string
   ): Promise<Experiment[]> {
-    const whereExperimentsClause =
-      '(experiment.state = :enrolling OR experiment.state = :enrollmentComplete) AND NOT (experiment.state = :enrollmentComplete AND experiment.postExperimentRule = :assign AND experiment.revertTo IS NULL) AND :context ILIKE ANY (ARRAY[experiment.context]) AND partitions.site = :site AND partitions.target = :target AND partitions.pendingActivation = false';
+    const baseWhereClause =
+      '(experiment.state = :enrolling OR experiment.state = :enrollmentComplete) AND NOT (experiment.state = :enrollmentComplete AND experiment.postExperimentRule = :assign AND experiment.revertTo IS NULL) AND :context ILIKE ANY (ARRAY[experiment.context])';
+    const decisionPointWhereClause =
+      baseWhereClause +
+      ' AND partitions.site = :site AND partitions.target = :target AND partitions.pendingActivation = false';
     const whereClauseParams = {
       enrolling: 'enrolling',
       enrollmentComplete: 'enrollmentComplete',
@@ -232,26 +190,66 @@ export class ExperimentRepository extends Repository<Experiment> {
       site,
       target,
     };
-    const experiment = await this.createBaseQueryBuilder().where(whereExperimentsClause, whereClauseParams).getMany();
-    return experiment;
-  }
 
-  public async getEnrollingExperimentsForContextAndDecisionPoint(
-    context: string,
-    site: string,
-    target: string
-  ): Promise<Experiment[]> {
-    const whereExperimentsClause =
-      'experiment.state = :enrolling AND :context ILIKE ANY (ARRAY[experiment.context]) AND partitions.site = :site AND partitions.target = :target AND partitions.pendingActivation = false';
-    const whereClauseParams = {
-      enrolling: 'enrolling',
-      assign: 'assign',
-      context,
-      site,
-      target,
-    };
-    const experiment = await this.createBaseQueryBuilder().where(whereExperimentsClause, whereClauseParams).getMany();
-    return experiment;
+    const conditionLevelPayloadQuery = this.buildConditionLevelPayloadQuery().where(
+      new Brackets((qb) => {
+        qb.where(baseWhereClause, whereClauseParams);
+      })
+    );
+
+    // site/target filter lives here — this is the authoritative experiment list
+    const factorDecisionPointPayloadQuery = this.buildFactorDecisionPointPayloadQuery().where(
+      new Brackets((qb) => {
+        qb.where(decisionPointWhereClause, whereClauseParams);
+      })
+    );
+
+    const segmentQuery = this.buildSegmentQuery().where(
+      new Brackets((qb) => {
+        qb.where(baseWhereClause, whereClauseParams);
+      })
+    );
+
+    const [conditionLevelPayloadData, factorDecisionPointPayloadData, segmentData] = await Promise.all([
+      conditionLevelPayloadQuery.getMany().catch((errorMsg: any) => {
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'getValidExperimentsForContextAndDecisionPoint-conditionLevelPayloadData',
+          {},
+          errorMsg
+        );
+        throw errorMsgString;
+      }),
+      factorDecisionPointPayloadQuery.getMany().catch((errorMsg: any) => {
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'getValidExperimentsForContextAndDecisionPoint-factorDecisionPointPayloadData',
+          {},
+          errorMsg
+        );
+        throw errorMsgString;
+      }),
+      segmentQuery.getMany().catch((errorMsg: any) => {
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'getValidExperimentsForContextAndDecisionPoint-segmentData',
+          {},
+          errorMsg
+        );
+        throw errorMsgString;
+      }),
+    ]);
+
+    // factorDecisionPointPayloadData is authoritative — it applied the site/target filter
+    const experimentData = factorDecisionPointPayloadData.map((data) => {
+      const condData = conditionLevelPayloadData.find((i) => i.id === data.id);
+      return { ...condData, ...data };
+    });
+
+    return experimentData.map((data) => {
+      const seg = segmentData.find((s) => s.id === data.id);
+      return seg ? { ...data, ...seg } : data;
+    });
   }
 
   public async getValidExperimentsWithPreview(context: string): Promise<Experiment[]> {
@@ -264,50 +262,25 @@ export class ExperimentRepository extends Repository<Experiment> {
       assign: 'assign',
       context,
     };
-    const experimentConditionLevelPayloadQuery = this.createQueryBuilder('experiment')
-      .leftJoinAndSelect('experiment.conditions', 'conditions')
-      .leftJoinAndSelect('conditions.levelCombinationElements', 'levelCombinationElements')
-      .leftJoinAndSelect('levelCombinationElements.level', 'level')
-      .leftJoinAndSelect('conditions.conditionPayloads', 'conditionPayload')
-      .where(
-        new Brackets((qb) => {
-          qb.where(whereExperimentsClause, whereClauseParams);
-        })
-      );
+    const experimentConditionLevelPayloadQuery = this.buildConditionLevelPayloadQuery().where(
+      new Brackets((qb) => {
+        qb.where(whereExperimentsClause, whereClauseParams);
+      })
+    );
 
-    const experimentFactorPartitionLevelPayloadQuery = this.createQueryBuilder('experiment')
-      .leftJoinAndSelect('experiment.partitions', 'partitions')
-      .leftJoinAndSelect('experiment.stratificationFactor', 'stratificationFactor')
-      .leftJoinAndSelect('partitions.conditionPayloads', 'conditionPayloads')
-      .leftJoinAndSelect('conditionPayloads.parentCondition', 'parentCondition')
-      .leftJoinAndSelect('experiment.factors', 'factors')
-      .leftJoinAndSelect('factors.levels', 'levels')
-      .where(
-        new Brackets((qb) => {
-          qb.where(whereExperimentsClause, whereClauseParams);
-        })
-      );
+    const experimentFactorDecisionPointLevelPayloadQuery = this.buildFactorDecisionPointPayloadQuery().where(
+      new Brackets((qb) => {
+        qb.where(whereExperimentsClause, whereClauseParams);
+      })
+    );
 
-    const experimentSegmentQuery = this.createQueryBuilder('experiment')
-      // making small queries
-      .select('experiment.id')
-      .leftJoinAndSelect('experiment.experimentSegmentInclusion', 'experimentSegmentInclusion')
-      .leftJoinAndSelect('experimentSegmentInclusion.segment', 'segmentInclusion')
-      .leftJoinAndSelect('segmentInclusion.individualForSegment', 'individualForSegment')
-      .leftJoinAndSelect('segmentInclusion.groupForSegment', 'groupForSegment')
-      .leftJoinAndSelect('segmentInclusion.subSegments', 'subSegment')
-      .leftJoinAndSelect('experiment.experimentSegmentExclusion', 'experimentSegmentExclusion')
-      .leftJoinAndSelect('experimentSegmentExclusion.segment', 'segmentExclusion')
-      .leftJoinAndSelect('segmentExclusion.individualForSegment', 'individualForSegmentExclusion')
-      .leftJoinAndSelect('segmentExclusion.groupForSegment', 'groupForSegmentExclusion')
-      .leftJoinAndSelect('segmentExclusion.subSegments', 'subSegmentExclusion')
-      .where(
-        new Brackets((qb) => {
-          qb.where(whereExperimentsClause, whereClauseParams);
-        })
-      );
+    const experimentSegmentQuery = this.buildSegmentQuery().where(
+      new Brackets((qb) => {
+        qb.where(whereExperimentsClause, whereClauseParams);
+      })
+    );
 
-    const [experimentConditionLevelPayloadData, experimentFactorPartitionLevelPayloadData, experimentSegmentData] =
+    const [experimentConditionLevelPayloadData, experimentFactorDecisionPointLevelPayloadData, experimentSegmentData] =
       await Promise.all([
         experimentConditionLevelPayloadQuery.getMany().catch((errorMsg: any) => {
           const errorMsgString = repositoryError(
@@ -318,10 +291,10 @@ export class ExperimentRepository extends Repository<Experiment> {
           );
           throw errorMsgString;
         }),
-        experimentFactorPartitionLevelPayloadQuery.getMany().catch((errorMsg: any) => {
+        experimentFactorDecisionPointLevelPayloadQuery.getMany().catch((errorMsg: any) => {
           const errorMsgString = repositoryError(
             'ExperimentRepository',
-            'getValidExperiments-experimentFactorPartitionLevelPayloadQuery',
+            'getValidExperiments-experimentFactorDecisionPointLevelPayloadQuery',
             {},
             errorMsg
           );
@@ -339,7 +312,7 @@ export class ExperimentRepository extends Repository<Experiment> {
       ]);
 
     const experimentData = experimentConditionLevelPayloadData.map((data) => {
-      const data2 = experimentFactorPartitionLevelPayloadData.find((i) => i.id === data.id);
+      const data2 = experimentFactorDecisionPointLevelPayloadData.find((i) => i.id === data.id);
       return { ...data, ...data2 };
     });
 
@@ -473,16 +446,28 @@ export class ExperimentRepository extends Repository<Experiment> {
     }
   }
 
-  private createBaseQueryBuilder() {
+  private buildConditionLevelPayloadQuery() {
     return this.createQueryBuilder('experiment')
       .leftJoinAndSelect('experiment.conditions', 'conditions')
+      .leftJoinAndSelect('conditions.levelCombinationElements', 'levelCombinationElements')
+      .leftJoinAndSelect('levelCombinationElements.level', 'level')
+      .leftJoinAndSelect('conditions.conditionPayloads', 'conditionPayload');
+  }
+
+  private buildFactorDecisionPointPayloadQuery() {
+    return this.createQueryBuilder('experiment')
       .leftJoinAndSelect('experiment.partitions', 'partitions')
-      .leftJoinAndSelect('experiment.queries', 'queries')
-      .leftJoinAndSelect('experiment.stateTimeLogs', 'stateTimeLogs')
-      .leftJoinAndSelect('experiment.experimentSegmentInclusion', 'experimentSegmentInclusion')
-      .leftJoinAndSelect('experiment.factors', 'factors')
-      .leftJoinAndSelect('factors.levels', 'levels')
       .leftJoinAndSelect('experiment.stratificationFactor', 'stratificationFactor')
+      .leftJoinAndSelect('partitions.conditionPayloads', 'conditionPayloads')
+      .leftJoinAndSelect('conditionPayloads.parentCondition', 'parentCondition')
+      .leftJoinAndSelect('experiment.factors', 'factors')
+      .leftJoinAndSelect('factors.levels', 'levels');
+  }
+
+  private buildSegmentQuery() {
+    return this.createQueryBuilder('experiment')
+      .select('experiment.id')
+      .leftJoinAndSelect('experiment.experimentSegmentInclusion', 'experimentSegmentInclusion')
       .leftJoinAndSelect('experimentSegmentInclusion.segment', 'segmentInclusion')
       .leftJoinAndSelect('segmentInclusion.individualForSegment', 'individualForSegment')
       .leftJoinAndSelect('segmentInclusion.groupForSegment', 'groupForSegment')
@@ -491,31 +476,79 @@ export class ExperimentRepository extends Repository<Experiment> {
       .leftJoinAndSelect('experimentSegmentExclusion.segment', 'segmentExclusion')
       .leftJoinAndSelect('segmentExclusion.individualForSegment', 'individualForSegmentExclusion')
       .leftJoinAndSelect('segmentExclusion.groupForSegment', 'groupForSegmentExclusion')
-      .leftJoinAndSelect('segmentExclusion.subSegments', 'subSegmentExclusion')
-      .leftJoinAndSelect('queries.metric', 'metric')
-      .leftJoinAndSelect('partitions.conditionPayloads', 'ConditionPayloadsArray')
-      .leftJoinAndSelect('ConditionPayloadsArray.parentCondition', 'parentCondition')
-      .leftJoinAndSelect('conditions.levelCombinationElements', 'levelCombinationElements')
-      .leftJoinAndSelect('levelCombinationElements.level', 'level')
-      .leftJoinAndSelect('conditions.conditionPayloads', 'conditionPayload');
+      .leftJoinAndSelect('segmentExclusion.subSegments', 'subSegmentExclusion');
   }
 
   public async findOneExperiment(id: string): Promise<Experiment> {
-    const experiment = await this.createBaseQueryBuilder()
+    const conditionLevelPayloadQuery = this.buildConditionLevelPayloadQuery()
       .addOrderBy('conditions.order', 'ASC')
+      .where({ id });
+
+    const factorDecisionPointPayloadQuery = this.buildFactorDecisionPointPayloadQuery()
       .addOrderBy('partitions.order', 'ASC')
       .addOrderBy('factors.order', 'ASC')
       .addOrderBy('levels.order', 'ASC')
+      .where({ id });
+
+    const metricQuery = this.createQueryBuilder('experiment')
+      .leftJoinAndSelect('experiment.queries', 'queries')
+      .leftJoinAndSelect('queries.metric', 'metric')
+      .leftJoinAndSelect('experiment.stateTimeLogs', 'stateTimeLogs')
       .addOrderBy('queries.order', 'ASC', 'NULLS LAST')
       .addOrderBy('queries.createdAt', 'ASC')
-      .where({ id })
-      .getOne();
-    return experiment;
+      .where({ id });
+
+    const segmentQuery = this.buildSegmentQuery().where({ id });
+
+    const [conditionLevelPayloadData, factorDecisionPointPayloadData, metricData, segmentData] = await Promise.all([
+      conditionLevelPayloadQuery.getOne().catch((errorMsg: any) => {
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'findOneExperiment-conditionLevelPayloadData',
+          { id },
+          errorMsg
+        );
+        throw errorMsgString;
+      }),
+      factorDecisionPointPayloadQuery.getOne().catch((errorMsg: any) => {
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'findOneExperiment-factorDecisionPointPayloadData',
+          { id },
+          errorMsg
+        );
+        throw errorMsgString;
+      }),
+      metricQuery.getOne().catch((errorMsg: any) => {
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'findOneExperiment-metricData',
+          { id },
+          errorMsg
+        );
+        throw errorMsgString;
+      }),
+      segmentQuery.getOne().catch((errorMsg: any) => {
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'findOneExperiment-segmentData',
+          { id },
+          errorMsg
+        );
+        throw errorMsgString;
+      }),
+    ]);
+
+    if (!conditionLevelPayloadData) {
+      return undefined;
+    }
+
+    return { ...conditionLevelPayloadData, ...factorDecisionPointPayloadData, ...metricData, ...segmentData };
   }
 
   public async fetchExperimentDetailsForCSVDataExport(experimentId: string): Promise<ExperimentDetailsForCSVData[]> {
     // Get the experiment details
-    const experimentQuery = await this.createBaseQueryBuilder()
+    const experimentQuery = await this.createQueryBuilder('experiment')
       .select([
         'experiment.id as "experimentId"',
         'experiment.name as "experimentName"',

--- a/packages/backend/src/api/repositories/ExperimentRepository.ts
+++ b/packages/backend/src/api/repositories/ExperimentRepository.ts
@@ -479,7 +479,7 @@ export class ExperimentRepository extends Repository<Experiment> {
       .leftJoinAndSelect('segmentExclusion.subSegments', 'subSegmentExclusion');
   }
 
-  public async findOneExperiment(id: string): Promise<Experiment> {
+  public async findOneExperiment(id: string): Promise<Experiment | undefined> {
     const conditionLevelPayloadQuery = this.buildConditionLevelPayloadQuery()
       .addOrderBy('conditions.order', 'ASC')
       .where({ id });

--- a/packages/backend/test/unit/repositories/ExperimentRepository.test.ts
+++ b/packages/backend/test/unit/repositories/ExperimentRepository.test.ts
@@ -157,7 +157,7 @@ describe('ExperimentRepository Testing', () => {
 
     expect(repo.createQueryBuilder).toHaveBeenCalledTimes(4);
 
-    expect(mock.leftJoinAndSelect).toHaveBeenCalledTimes(22);
+    expect(mock.leftJoinAndSelect).toHaveBeenCalledTimes(23);
     expect(mock.select).toHaveBeenCalledTimes(1);
     expect(mock.getMany).toHaveBeenCalledTimes(4);
 
@@ -178,7 +178,7 @@ describe('ExperimentRepository Testing', () => {
 
     expect(repo.createQueryBuilder).toHaveBeenCalledTimes(4);
 
-    expect(mock.leftJoinAndSelect).toHaveBeenCalledTimes(22);
+    expect(mock.leftJoinAndSelect).toHaveBeenCalledTimes(23);
     expect(mock.select).toHaveBeenCalledTimes(1);
     expect(mock.getMany).toHaveBeenCalledTimes(4);
   });
@@ -369,15 +369,16 @@ describe('ExperimentRepository Testing', () => {
   it('should find one experiment ordered by queries.order then createdAt', async () => {
     const res = await repo.findOneExperiment(experiment.id);
 
-    expect(repo.createQueryBuilder).toHaveBeenCalledTimes(1);
+    // 4 parallel queries: conditionLevelPayload, factorPartitionPayload, metric, segment
+    expect(repo.createQueryBuilder).toHaveBeenCalledTimes(4);
 
-    // conditions, partitions, factors, levels, queries.order, queries.createdAt = 6 addOrderBy calls
+    // conditions(1) + partitions+factors+levels(3) + queries.order+createdAt(2) = 6 addOrderBy calls
     expect(mock.addOrderBy).toHaveBeenCalledTimes(6);
     expect(mock.addOrderBy).toHaveBeenCalledWith('queries.order', 'ASC', 'NULLS LAST');
     expect(mock.addOrderBy).toHaveBeenCalledWith('queries.createdAt', 'ASC');
 
-    expect(mock.where).toHaveBeenCalledTimes(1);
-    expect(mock.getOne).toHaveBeenCalledTimes(1);
+    expect(mock.where).toHaveBeenCalledTimes(4);
+    expect(mock.getOne).toHaveBeenCalledTimes(4);
 
     expect(res).toEqual(experiment);
   });

--- a/packages/backend/test/unit/repositories/ExperimentRepository.test.ts
+++ b/packages/backend/test/unit/repositories/ExperimentRepository.test.ts
@@ -369,7 +369,7 @@ describe('ExperimentRepository Testing', () => {
   it('should find one experiment ordered by queries.order then createdAt', async () => {
     const res = await repo.findOneExperiment(experiment.id);
 
-    // 4 parallel queries: conditionLevelPayload, factorPartitionPayload, metric, segment
+    // 4 parallel queries: conditionLevelPayload, factorDecisionPointPayload, metric, segment
     expect(repo.createQueryBuilder).toHaveBeenCalledTimes(4);
 
     // conditions(1) + partitions+factors+levels(3) + queries.order+createdAt(2) = 6 addOrderBy calls

--- a/packages/backend/test/unit/repositories/ExperimentRepository.test.ts
+++ b/packages/backend/test/unit/repositories/ExperimentRepository.test.ts
@@ -411,6 +411,105 @@ describe('ExperimentRepository Testing', () => {
     expect(res).toBeUndefined();
   });
 
+  describe('getValidExperimentsForContextAndDecisionPoint', () => {
+    it('should build three queries and add a leftJoin on partitions (decision points) for the condition and segment queries', async () => {
+      const result = [experiment];
+      mock.getMany.mockResolvedValue(result);
+
+      const res = await repo.getValidExperimentsForContextAndDecisionPoint('context', 'site1', 'target1');
+
+      expect(repo.createQueryBuilder).toHaveBeenCalledTimes(3);
+      // 4 (conditionLevel) + 6 (factorDecisionPoint) + 10 (segment) = 20
+      expect(mock.leftJoinAndSelect).toHaveBeenCalledTimes(20);
+      // conditionLevelPayloadQuery and segmentQuery each add a non-selecting leftJoin for partition filtering
+      expect(mock.leftJoin).toHaveBeenCalledTimes(2);
+      expect(mock.leftJoin).toHaveBeenCalledWith('experiment.partitions', 'partitions');
+      // buildSegmentQuery calls .select('experiment.id')
+      expect(mock.select).toHaveBeenCalledTimes(1);
+      expect(mock.where).toHaveBeenCalledTimes(3);
+      expect(mock.getMany).toHaveBeenCalledTimes(3);
+
+      expect(res).toEqual(result);
+    });
+
+    it('should return empty array when no experiments match the site/target', async () => {
+      // conditionLevel and segment find experiments, but factorDecisionPoint finds none at this site/target
+      mock.getMany.mockResolvedValueOnce([experiment]).mockResolvedValueOnce([]).mockResolvedValueOnce([experiment]);
+
+      const res = await repo.getValidExperimentsForContextAndDecisionPoint('context', 'site1', 'target1');
+
+      expect(res).toHaveLength(0);
+    });
+
+    it('should exclude experiments not present in factorDecisionPointPayloadData', async () => {
+      const expA = new Experiment();
+      expA.id = 'exp-a';
+      const expB = new Experiment();
+      expB.id = 'exp-b';
+
+      // conditionLevel and segment over-fetch; only expA matches the site/target in factorDecisionPoint
+      mock.getMany
+        .mockResolvedValueOnce([expA, expB])
+        .mockResolvedValueOnce([expA])
+        .mockResolvedValueOnce([expA, expB]);
+
+      const res = await repo.getValidExperimentsForContextAndDecisionPoint('context', 'site1', 'target1');
+
+      expect(res).toHaveLength(1);
+      expect(res[0].id).toBe('exp-a');
+    });
+
+    it('should merge condition, partition, and segment data onto each result experiment', async () => {
+      const condData = { id: 'exp-a', conditions: ['cond1'] } as any;
+      const factorData = { id: 'exp-a', partitions: ['part1'] } as any;
+      const segData = { id: 'exp-a', experimentSegmentInclusion: ['seg1'] } as any;
+
+      mock.getMany
+        .mockResolvedValueOnce([condData])
+        .mockResolvedValueOnce([factorData])
+        .mockResolvedValueOnce([segData]);
+
+      const [result] = await repo.getValidExperimentsForContextAndDecisionPoint('context', 'site1', 'target1');
+
+      expect(result).toMatchObject({
+        id: 'exp-a',
+        conditions: ['cond1'],
+        partitions: ['part1'],
+        experimentSegmentInclusion: ['seg1'],
+      });
+    });
+
+    it('should return experiment without segment data when segment query returns no match', async () => {
+      const condData = { id: 'exp-a', conditions: ['cond1'] } as any;
+      const factorData = { id: 'exp-a', partitions: ['part1'] } as any;
+
+      mock.getMany.mockResolvedValueOnce([condData]).mockResolvedValueOnce([factorData]).mockResolvedValueOnce([]);
+
+      const [result] = await repo.getValidExperimentsForContextAndDecisionPoint('context', 'site1', 'target1');
+
+      expect(result).toMatchObject({ id: 'exp-a', conditions: ['cond1'], partitions: ['part1'] });
+    });
+
+    it('should return factorDecisionPoint data even when conditionLevel query returns no match', async () => {
+      const factorData = { id: 'exp-a', partitions: ['part1'] } as any;
+      const segData = { id: 'exp-a', experimentSegmentInclusion: ['seg1'] } as any;
+
+      mock.getMany.mockResolvedValueOnce([]).mockResolvedValueOnce([factorData]).mockResolvedValueOnce([segData]);
+
+      const [result] = await repo.getValidExperimentsForContextAndDecisionPoint('context', 'site1', 'target1');
+
+      expect(result).toMatchObject({ id: 'exp-a', partitions: ['part1'], experimentSegmentInclusion: ['seg1'] });
+    });
+
+    it('should throw an error when a sub-query fails', async () => {
+      mock.getMany.mockRejectedValue(err);
+
+      await expect(repo.getValidExperimentsForContextAndDecisionPoint('context', 'site1', 'target1')).rejects.toThrow();
+
+      expect(repo.createQueryBuilder).toHaveBeenCalledTimes(3);
+    });
+  });
+
   it('should throw an error when clear the database fails', async () => {
     const entities = [
       {


### PR DESCRIPTION
#3157

`createBaseQueryBuilder` broken up into individual calls, same as other calls. This affects `/experiments/:id`, csv data export, and batch-assign. 

after creating individual queries, we end up with identical query builder implementations in several places in ExperimentRepository, so these were refactored in general as private entity builder functions. one of the implementations was only different in that a query to leftJoin stratification data was apparently missing, so i took the liberty of adding that.

also also, got rid of the word partition where i could in the process.

btw `getEnrollingExperimentsForContextAndDecisionPoint` was dead code, i'm guess a missed merge conflict resolution artifact.