### PR TITLE
Fix duplicate experiment row after first experiment creation

### DIFF
--- a/packages/frontend/projects/upgrade/src/app/core/experiments/store/experiments.reducer.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/experiments/store/experiments.reducer.ts
@@ -94,9 +94,9 @@ const reducer = createReducer(
   on(experimentsAction.actionUpsertExperiment, experimentsAction.actionGetExperimentById, (state) => ({
     ...state,
     isLoadingExperiment: true,
-    // if we don't have a totalExperiments count yet (no paginated call with > 1 has occured yet),
-    // set it to 1 because we are loading at least one experiment so that nav to root page will not show empty template
-    totalExperiments: state.totalExperiments ? state.totalExperiments : 1,
+    // If the total count is unknown, assume at least one experiment is loading so the root page skips the empty state.
+    // Preserve 0 because it means the backend already confirmed an empty list.
+    totalExperiments: state.totalExperiments ?? 1,
   })),
   on(experimentsAction.actionGetExperimentByIdSuccess, (state, { experiment }) => {
     // Upsert experiment: update if exists, add if not (for direct navigation)


### PR DESCRIPTION
Resolves #3172 

After creating the first experiment and navigating back to the Experiments page, the same experiment could appear twice until refresh.

This happened because the store treated `totalExperiments = 0` as if the total count was unknown. When the detail page loaded the newly created experiment, the reducer changed `totalExperiments` from `0` to `1`, which allowed the root page pagination logic to fetch and append the first page again.

This change preserves `0` as a valid loaded total count and only falls back to `1` when the total count is actually unknown (`null` or `undefined`). That keeps direct detail loading behavior intact while preventing the extra pagination fetch that caused the duplicate row.
