### PR TITLE
lighten flag detail load and list add/edit for large lists

### DIFF
--- a/packages/backend/src/api/controllers/FeatureFlagController.ts
+++ b/packages/backend/src/api/controllers/FeatureFlagController.ts
@@ -30,7 +30,7 @@ import {
   IdValidator,
 } from './validators/FeatureFlagValidator';
 import { ExperimentUserService } from '../services/ExperimentUserService';
-import { FeatureFlagListValidator } from './validators/FeatureFlagListValidator';
+import { FeatureFlagListValidator, FeatureFlagListStatusValidator } from './validators/FeatureFlagListValidator';
 import { Segment } from '../models/Segment';
 import { Response } from 'express';
 import { UserDTO } from '../DTO/UserDTO';
@@ -214,7 +214,7 @@ export class FeatureFlagsController {
     @Params({ validate: true }) { id }: IdValidator,
     @Req() request: AppRequest
   ): Promise<FeatureFlag | undefined> {
-    return this.featureFlagService.findOne(id, request.logger);
+    return this.featureFlagService.findOneForDetails(id, request.logger);
   }
 
   /**
@@ -628,6 +628,98 @@ export class FeatureFlagsController {
       );
     }
     return this.featureFlagService.updateList(inclusionList, LIST_FILTER_MODE.INCLUSION, currentUser, request.logger);
+  }
+
+  /**
+   * @swagger
+   * /flags/inclusionList/{id}/status:
+   *    patch:
+   *       description: Toggle the enabled status of a Feature Flag inclusion list without modifying its members
+   *       consumes:
+   *         - application/json
+   *       parameters:
+   *         - in: path
+   *           name: id
+   *           required: true
+   *           schema:
+   *             type: string
+   *           description: Segment id of the list
+   *         - in: body
+   *           name: status
+   *           description: New enabled status
+   *           schema:
+   *             type: object
+   *             properties:
+   *               enabled:
+   *                 type: boolean
+   *       tags:
+   *         - Feature Flags
+   *       produces:
+   *         - application/json
+   *       responses:
+   *          '200':
+   *            description: Feature flag inclusion list status is updated
+   */
+  @Patch('/inclusionList/:id/status')
+  public async updateInclusionListStatus(
+    @Params({ validate: true }) { id }: IdValidator,
+    @Body({ validate: true }) { enabled }: FeatureFlagListStatusValidator,
+    @CurrentUser() currentUser: UserDTO,
+    @Req() request: AppRequest
+  ): Promise<FeatureFlagSegmentInclusion> {
+    return this.featureFlagService.updateListStatus(
+      id,
+      enabled,
+      LIST_FILTER_MODE.INCLUSION,
+      currentUser,
+      request.logger
+    );
+  }
+
+  /**
+   * @swagger
+   * /flags/exclusionList/{id}/status:
+   *    patch:
+   *       description: Toggle the enabled status of a Feature Flag exclusion list without modifying its members
+   *       consumes:
+   *         - application/json
+   *       parameters:
+   *         - in: path
+   *           name: id
+   *           required: true
+   *           schema:
+   *             type: string
+   *           description: Segment id of the list
+   *         - in: body
+   *           name: status
+   *           description: New enabled status
+   *           schema:
+   *             type: object
+   *             properties:
+   *               enabled:
+   *                 type: boolean
+   *       tags:
+   *         - Feature Flags
+   *       produces:
+   *         - application/json
+   *       responses:
+   *          '200':
+   *            description: Feature flag exclusion list status is updated
+   */
+  @Patch('/exclusionList/:id/status')
+  public async updateExclusionListStatus(
+    @Params({ validate: true }) { id }: IdValidator,
+    @Body({ validate: true }) { enabled }: FeatureFlagListStatusValidator,
+    @CurrentUser() currentUser: UserDTO,
+    @Req() request: AppRequest
+  ): Promise<FeatureFlagSegmentExclusion> {
+    return this.featureFlagService.updateListStatus(
+      id,
+      enabled,
+      LIST_FILTER_MODE.EXCLUSION,
+      currentUser,
+      request.logger
+    );
   }
 
   /**

--- a/packages/backend/src/api/controllers/SegmentController.ts
+++ b/packages/backend/src/api/controllers/SegmentController.ts
@@ -414,6 +414,43 @@ export class SegmentController {
 
   /**
    * @swagger
+   * /segments/{segmentId}/members:
+   *    get:
+   *      description: Get a segment (including private lists) by id with its full member lists
+   *      tags:
+   *        - Segment
+   *      produces:
+   *        - application/json
+   *      parameters:
+   *        - in: path
+   *          name: segmentId
+   *          description: Segment id
+   *          required: true
+   *          schema:
+   *            type: string
+   *      responses:
+   *        '200':
+   *          description: Get segment with members by id
+   *          schema:
+   *            $ref: '#/definitions/segmentResponse'
+   *        '404':
+   *          description: Segment not found
+   */
+  @Get('/:segmentId/members')
+  public async getSegmentByIdWithMembers(
+    @Params({ validate: true }) { segmentId }: IdValidator,
+    @Req() request: AppRequest
+  ): Promise<Segment> {
+    const segment = await this.segmentService.getSegmentByIdWithMembers(segmentId, request.logger);
+    if (!segment) {
+      throw new NotFoundException('Segment not found.');
+    }
+
+    return segment;
+  }
+
+  /**
+   * @swagger
    * /segments/status/{segmentId}:
    *    get:
    *      description: Get segment by id with status

--- a/packages/backend/src/api/controllers/validators/FeatureFlagListValidator.ts
+++ b/packages/backend/src/api/controllers/validators/FeatureFlagListValidator.ts
@@ -18,3 +18,9 @@ export class FeatureFlagListValidator {
   @Type(() => SegmentInputValidator)
   public segment: SegmentInputValidator;
 }
+
+export class FeatureFlagListStatusValidator {
+  @IsDefined()
+  @IsBoolean()
+  public enabled: boolean;
+}

--- a/packages/backend/src/api/models/Segment.ts
+++ b/packages/backend/src/api/models/Segment.ts
@@ -48,6 +48,12 @@ export class Segment extends BaseModel {
   @Type(() => GroupForSegment)
   public groupForSegment: GroupForSegment[];
 
+  // Not persisted columns. Populated via loadRelationCountAndMap when a segment is loaded
+  // without its member lists (e.g. the feature-flag details page), so the UI can show counts
+  // without shipping the full individualForSegment / groupForSegment arrays.
+  public individualForSegmentCount?: number;
+  public groupForSegmentCount?: number;
+
   @ManyToMany(() => Segment, (segment) => segment.subSegments)
   @JoinTable({
     name: 'segment_for_segment',

--- a/packages/backend/src/api/models/Segment.ts
+++ b/packages/backend/src/api/models/Segment.ts
@@ -48,9 +48,7 @@ export class Segment extends BaseModel {
   @Type(() => GroupForSegment)
   public groupForSegment: GroupForSegment[];
 
-  // Not persisted columns. Populated via loadRelationCountAndMap when a segment is loaded
-  // without its member lists (e.g. the feature-flag details page), so the UI can show counts
-  // without shipping the full individualForSegment / groupForSegment arrays.
+  // Not persisted; populated via loadRelationCountAndMap for counts-only loads (see findOneForDetails).
   public individualForSegmentCount?: number;
   public groupForSegmentCount?: number;
 

--- a/packages/backend/src/api/services/FeatureFlagService.ts
+++ b/packages/backend/src/api/services/FeatureFlagService.ts
@@ -155,6 +155,35 @@ export class FeatureFlagService {
     return featureFlag;
   }
 
+  // Lightweight variant of findOne for the details page, which only renders member *counts*
+  // per inclusion/exclusion list. It skips loading the (potentially tens of thousands of rows)
+  // individualForSegment and groupForSegment collections — which in findOne also cause a
+  // Cartesian-product row explosion — and instead maps lightweight COUNT subqueries onto each
+  // segment (individualForSegmentCount / groupForSegmentCount). The full member lists are
+  // fetched on demand via GET /segments/:id/members when a list is opened for editing.
+  // NOTE: callers that need the actual members (e.g. exports) must use findOne, not this.
+  public async findOneForDetails(id: string, logger?: UpgradeLogger): Promise<FeatureFlag | undefined> {
+    if (logger) {
+      logger.info({ message: `Find feature flag (details view) by id => ${id}` });
+    }
+    const featureFlag = await this.featureFlagRepository
+      .createQueryBuilder('feature_flag')
+      .leftJoinAndSelect('feature_flag.featureFlagSegmentInclusion', 'featureFlagSegmentInclusion')
+      .leftJoinAndSelect('featureFlagSegmentInclusion.segment', 'segmentInclusion')
+      .loadRelationCountAndMap('segmentInclusion.individualForSegmentCount', 'segmentInclusion.individualForSegment')
+      .loadRelationCountAndMap('segmentInclusion.groupForSegmentCount', 'segmentInclusion.groupForSegment')
+      .leftJoinAndSelect('segmentInclusion.subSegments', 'subSegment')
+      .leftJoinAndSelect('feature_flag.featureFlagSegmentExclusion', 'featureFlagSegmentExclusion')
+      .leftJoinAndSelect('featureFlagSegmentExclusion.segment', 'segmentExclusion')
+      .loadRelationCountAndMap('segmentExclusion.individualForSegmentCount', 'segmentExclusion.individualForSegment')
+      .loadRelationCountAndMap('segmentExclusion.groupForSegmentCount', 'segmentExclusion.groupForSegment')
+      .leftJoinAndSelect('segmentExclusion.subSegments', 'subSegmentExclusion')
+      .where({ id })
+      .getOne();
+
+    return featureFlag;
+  }
+
   public async create(
     flagDTO: FeatureFlagValidation,
     currentUser: UserDTO,
@@ -698,9 +727,11 @@ export class FeatureFlagService {
     logger.info({ message: `Update ${filterType} list for feature flag` });
     await this.cacheService.resetPrefixCache(CACHE_PREFIX.FEATURE_FLAG_KEY_PREFIX);
     return await this.dataSource.transaction(async (transactionalEntityManager) => {
-      // Find the existing record
+      // Find the existing record. Only the flag id/name are needed here (for the audit log
+      // below), so use the counts-only variant to avoid loading every list's members — which
+      // for large lists made saving an edit very slow.
       let existingRecord: FeatureFlagSegmentInclusion | FeatureFlagSegmentExclusion;
-      const featureFlag = await this.findOne(listInput.id);
+      const featureFlag = await this.findOneForDetails(listInput.id);
 
       if (filterType === LIST_FILTER_MODE.INCLUSION) {
         existingRecord = await this.featureFlagSegmentInclusionRepository.findOne({
@@ -803,6 +834,72 @@ export class FeatureFlagService {
 
       return existingRecord;
     });
+  }
+
+  public async updateListStatus(
+    segmentId: string,
+    enabled: boolean,
+    filterType: LIST_FILTER_MODE,
+    currentUser: UserDTO,
+    logger: UpgradeLogger
+  ): Promise<FeatureFlagSegmentInclusion | FeatureFlagSegmentExclusion> {
+    logger.info({ message: `Update ${filterType} list status for feature flag => segment ${segmentId}` });
+
+    let existingRecord: FeatureFlagSegmentInclusion | FeatureFlagSegmentExclusion;
+    if (filterType === LIST_FILTER_MODE.INCLUSION) {
+      existingRecord = await this.featureFlagSegmentInclusionRepository.findOne({
+        where: { segment: { id: segmentId } },
+        relations: ['featureFlag', 'segment'],
+      });
+    } else {
+      existingRecord = await this.featureFlagSegmentExclusionRepository.findOne({
+        where: { segment: { id: segmentId } },
+        relations: ['featureFlag', 'segment'],
+      });
+    }
+
+    if (!existingRecord) {
+      const error = new Error(`No existing ${filterType} record found for segment ${segmentId}`);
+      (error as any).type = SERVER_ERROR.QUERY_FAILED;
+      logger.error(error);
+      throw error;
+    }
+
+    const statusChanged = existingRecord.enabled !== enabled;
+    existingRecord.enabled = enabled;
+
+    try {
+      if (filterType === LIST_FILTER_MODE.INCLUSION) {
+        await this.featureFlagSegmentInclusionRepository.save(existingRecord);
+      } else {
+        await this.featureFlagSegmentExclusionRepository.save(existingRecord);
+      }
+    } catch (err) {
+      const error = new Error(`Error in updating ${filterType} list status: ${err}`);
+      (error as any).type = SERVER_ERROR.QUERY_FAILED;
+      logger.error(error);
+      throw error;
+    }
+
+    await this.clearCachedFlagsForContext(existingRecord.featureFlag.context[0]);
+
+    if (statusChanged) {
+      const listData: ListOperationsData = {
+        listId: existingRecord.segment.id,
+        listName: existingRecord.segment.name,
+        filterType: filterType,
+        enabled: enabled,
+        operation: FEATURE_FLAG_LIST_OPERATION.STATUS_CHANGED,
+      };
+      const updateAuditLog: FeatureFlagUpdatedData = {
+        flagId: existingRecord.featureFlag.id,
+        flagName: existingRecord.featureFlag.name,
+        list: listData,
+      };
+      await this.experimentAuditLogRepository.saveRawJson(LOG_TYPE.FEATURE_FLAG_UPDATED, updateAuditLog, currentUser);
+    }
+
+    return existingRecord;
   }
 
   private paginatedSearchString(params: IFeatureFlagSearchParams): string {

--- a/packages/backend/src/api/services/FeatureFlagService.ts
+++ b/packages/backend/src/api/services/FeatureFlagService.ts
@@ -155,13 +155,8 @@ export class FeatureFlagService {
     return featureFlag;
   }
 
-  // Lightweight variant of findOne for the details page, which only renders member *counts*
-  // per inclusion/exclusion list. It skips loading the (potentially tens of thousands of rows)
-  // individualForSegment and groupForSegment collections — which in findOne also cause a
-  // Cartesian-product row explosion — and instead maps lightweight COUNT subqueries onto each
-  // segment (individualForSegmentCount / groupForSegmentCount). The full member lists are
-  // fetched on demand via GET /segments/:id/members when a list is opened for editing.
-  // NOTE: callers that need the actual members (e.g. exports) must use findOne, not this.
+  // Counts-only variant of findOne for the details page: maps member counts instead of loading
+  // the member lists. Callers that need the actual members (e.g. exports) must use findOne.
   public async findOneForDetails(id: string, logger?: UpgradeLogger): Promise<FeatureFlag | undefined> {
     if (logger) {
       logger.info({ message: `Find feature flag (details view) by id => ${id}` });
@@ -273,7 +268,7 @@ export class FeatureFlagService {
   ): Promise<FeatureFlag | undefined> {
     logger.info({ message: `Delete Feature Flag => ${featureFlagId}` });
     return await this.dataSource.transaction(async (transactionalEntityManager) => {
-      const featureFlag = await this.findOne(featureFlagId, logger);
+      const featureFlag = await this.findOneForDetails(featureFlagId, logger);
 
       if (featureFlag) {
         await this.clearCachedFlagsForContext(featureFlag.context[0]);
@@ -317,7 +312,7 @@ export class FeatureFlagService {
   }
 
   public async updateState(flagId: string, status: FEATURE_FLAG_STATUS, currentUser: UserDTO): Promise<FeatureFlag> {
-    const oldFeatureFlag = await this.findOne(flagId);
+    const oldFeatureFlag = await this.findOneForDetails(flagId);
     await this.clearCachedFlagsForContext(oldFeatureFlag.context[0]);
     let updatedState: FeatureFlag;
     try {
@@ -447,7 +442,7 @@ export class FeatureFlagService {
       createdAt,
       updatedAt,
       ...oldFlagDoc
-    } = await this.findOne(flag.id);
+    } = await this.findOneForDetails(flag.id);
 
     let includeList = [...featureFlagSegmentInclusion];
     let excludeList = [...featureFlagSegmentExclusion];
@@ -727,9 +722,7 @@ export class FeatureFlagService {
     logger.info({ message: `Update ${filterType} list for feature flag` });
     await this.cacheService.resetPrefixCache(CACHE_PREFIX.FEATURE_FLAG_KEY_PREFIX);
     return await this.dataSource.transaction(async (transactionalEntityManager) => {
-      // Find the existing record. Only the flag id/name are needed here (for the audit log
-      // below), so use the counts-only variant to avoid loading every list's members — which
-      // for large lists made saving an edit very slow.
+      // Only the flag id/name are needed here (audit log), so use the counts-only variant.
       let existingRecord: FeatureFlagSegmentInclusion | FeatureFlagSegmentExclusion;
       const featureFlag = await this.findOneForDetails(listInput.id);
 
@@ -1328,7 +1321,7 @@ export class FeatureFlagService {
         const featureFlagListFile = featureFlagListFiles.find((file) => file.fileName === fileStatus.fileName);
         return this.segmentService.convertJSONStringToSegInputValFormat(featureFlagListFile.fileContent as string);
       });
-    const featureFlag = await this.findOne(featureFlagId, logger);
+    const featureFlag = await this.findOneForDetails(featureFlagId, logger);
 
     const createdLists: (FeatureFlagSegmentInclusion | FeatureFlagSegmentExclusion)[] =
       await this.dataSource.transaction(async (transactionalEntityManager) => {

--- a/packages/backend/src/api/services/SegmentService.ts
+++ b/packages/backend/src/api/services/SegmentService.ts
@@ -150,6 +150,21 @@ export class SegmentService {
     return segmentDoc;
   }
 
+  // Fetches a segment (including private lists) by id with its full member lists. Unlike
+  // getSegmentById this does not exclude private segments, so a feature flag or experiment's
+  // private inclusion/exclusion list can be loaded on demand for editing (its members are not
+  // loaded on the counts-only details page).
+  public async getSegmentByIdWithMembers(id: string, logger: UpgradeLogger): Promise<Segment> {
+    logger.info({ message: `Find segment (including private) with members by id. segmentId: ${id}` });
+    return this.segmentRepository
+      .createQueryBuilder('segment')
+      .leftJoinAndSelect('segment.individualForSegment', 'individualForSegment')
+      .leftJoinAndSelect('segment.groupForSegment', 'groupForSegment')
+      .leftJoinAndSelect('segment.subSegments', 'subSegment')
+      .where({ id })
+      .getOne();
+  }
+
   public async getSegmentByIds(ids: string[]): Promise<Segment[]> {
     return this.cacheService.wrapFunction(CACHE_PREFIX.SEGMENT_KEY_PREFIX, ids, async () => {
       const result = await this.segmentRepository
@@ -884,31 +899,16 @@ export class SegmentService {
   ): Promise<Segment> {
     let segmentDoc: Segment;
 
-    let usersToDelete = [],
-      groupsToDelete = [];
     if (segment.id) {
       try {
-        // get segment by ids
-        segmentDoc = await transactionalEntityManager.getRepository(Segment).findOne({
-          where: { id: segment.id },
-          relations: ['individualForSegment', 'groupForSegment', 'subSegments'],
-        });
-
-        // delete individual for segment
-        if (segmentDoc && segmentDoc.individualForSegment && segmentDoc.individualForSegment.length > 0) {
-          usersToDelete = segmentDoc.individualForSegment.map((individual) => {
-            return { userId: individual.userId, segment: segment };
-          });
-          await transactionalEntityManager.getRepository(IndividualForSegment).delete(usersToDelete as any);
-        }
-
-        // delete group for segment
-        if (segmentDoc && segmentDoc.groupForSegment && segmentDoc.groupForSegment.length > 0) {
-          groupsToDelete = segmentDoc.groupForSegment.map((group) => {
-            return { groupId: group.groupId, type: group.type, segment: segment };
-          });
-          await transactionalEntityManager.getRepository(GroupForSegment).delete(groupsToDelete as any);
-        }
+        // Clear the existing members before re-inserting them below (the update model is a full
+        // replace). We delete with a single "WHERE segmentId = :id" statement per member table.
+        // Previously this fetched every member and passed a per-row criteria array to .delete(),
+        // which TypeORM expands into one giant OR predicate — extremely slow for large lists.
+        await Promise.all([
+          transactionalEntityManager.getRepository(IndividualForSegment).delete({ segmentId: segment.id }),
+          transactionalEntityManager.getRepository(GroupForSegment).delete({ segmentId: segment.id }),
+        ]);
       } catch (err) {
         const error = err as ErrorWithType;
         error.details = 'Error in deleting segment from DB';

--- a/packages/backend/src/api/services/SegmentService.ts
+++ b/packages/backend/src/api/services/SegmentService.ts
@@ -150,10 +150,7 @@ export class SegmentService {
     return segmentDoc;
   }
 
-  // Fetches a segment (including private lists) by id with its full member lists. Unlike
-  // getSegmentById this does not exclude private segments, so a feature flag or experiment's
-  // private inclusion/exclusion list can be loaded on demand for editing (its members are not
-  // loaded on the counts-only details page).
+  // Like getSegmentById but includes private lists, so a flag/experiment list can be loaded for editing.
   public async getSegmentByIdWithMembers(id: string, logger: UpgradeLogger): Promise<Segment> {
     logger.info({ message: `Find segment (including private) with members by id. segmentId: ${id}` });
     return this.segmentRepository
@@ -901,10 +898,8 @@ export class SegmentService {
 
     if (segment.id) {
       try {
-        // Clear the existing members before re-inserting them below (the update model is a full
-        // replace). We delete with a single "WHERE segmentId = :id" statement per member table.
-        // Previously this fetched every member and passed a per-row criteria array to .delete(),
-        // which TypeORM expands into one giant OR predicate — extremely slow for large lists.
+        // Full replace: clear members with one delete per table. A per-row criteria array (the
+        // previous approach) expands into a giant OR predicate that is very slow for large lists.
         await Promise.all([
           transactionalEntityManager.getRepository(IndividualForSegment).delete({ segmentId: segment.id }),
           transactionalEntityManager.getRepository(GroupForSegment).delete({ segmentId: segment.id }),

--- a/packages/backend/test/integration/FeatureFlags/FeatureFlagInclusionExclusion.ts
+++ b/packages/backend/test/integration/FeatureFlags/FeatureFlagInclusionExclusion.ts
@@ -1,6 +1,7 @@
 import { Container } from 'typedi';
 import { UpgradeLogger } from '../../../src/lib/logger/UpgradeLogger';
 import { FeatureFlagService } from '../../../src/api/services/FeatureFlagService';
+import { SegmentService } from '../../../src/api/services/SegmentService';
 import { featureFlag } from '../mockData/featureFlag';
 import { experimentUsers } from '../mockData/experimentUsers/index';
 import { LIST_FILTER_MODE, SEGMENT_TYPE } from 'upgrade_types';
@@ -119,4 +120,43 @@ export default async function FeatureFlagInclusionExclusionLogic(): Promise<void
     paginatedFind = await featureFlagService.findPaginated(0, 5, new UpgradeLogger());
   }
   expect(paginatedFind[0][0].featureFlagExposures).toEqual(2);
+
+  // --- Details view (findOneForDetails): returns member counts, not the member lists ---
+  const detailsFlag = await featureFlagService.findOneForDetails(flag.id, new UpgradeLogger());
+  const detailsInclusionSegment = detailsFlag.featureFlagSegmentInclusion[0].segment;
+  const detailsExclusionSegment = detailsFlag.featureFlagSegmentExclusion[0].segment;
+  // inclusion list has one group and no individuals; exclusion list has one individual
+  expect(detailsInclusionSegment.groupForSegmentCount).toEqual(1);
+  expect(detailsInclusionSegment.individualForSegmentCount).toEqual(0);
+  expect(detailsExclusionSegment.individualForSegmentCount).toEqual(1);
+  // the counts-only view must not load the (potentially huge) member arrays
+  expect(detailsInclusionSegment.groupForSegment).toBeUndefined();
+  expect(detailsExclusionSegment.individualForSegment).toBeUndefined();
+
+  // --- getSegmentByIdWithMembers: returns a private list together with its members ---
+  const segmentService = Container.get<SegmentService>(SegmentService);
+  const inclusionSegmentId = detailsInclusionSegment.id;
+  const segmentWithMembers = await segmentService.getSegmentByIdWithMembers(inclusionSegmentId, new UpgradeLogger());
+  expect(segmentWithMembers).toBeTruthy();
+  expect(segmentWithMembers.type).toEqual(SEGMENT_TYPE.PRIVATE);
+  expect(segmentWithMembers.groupForSegment.length).toEqual(1);
+  // the plain getSegmentById excludes private lists — which is exactly why /members exists
+  const publicOnlyLookup = await segmentService.getSegmentById(inclusionSegmentId, new UpgradeLogger());
+  expect(publicOnlyLookup).toBeFalsy();
+
+  // --- updateListStatus: toggles enabled without rewriting the segment's members ---
+  const toggledRecord = await featureFlagService.updateListStatus(
+    inclusionSegmentId,
+    false,
+    LIST_FILTER_MODE.INCLUSION,
+    user,
+    new UpgradeLogger()
+  );
+  expect(toggledRecord.enabled).toEqual(false);
+  const flagAfterToggle = await featureFlagService.findOne(flag.id, new UpgradeLogger());
+  const inclusionAfterToggle = flagAfterToggle.featureFlagSegmentInclusion.find(
+    (inclusion) => inclusion.segment.id === inclusionSegmentId
+  );
+  expect(inclusionAfterToggle.enabled).toEqual(false);
+  expect(inclusionAfterToggle.segment.groupForSegment.length).toEqual(1);
 }

--- a/packages/backend/test/unit/controllers/FeatureFlagController.test.ts
+++ b/packages/backend/test/unit/controllers/FeatureFlagController.test.ts
@@ -83,9 +83,35 @@ describe('Feature Flag Controller Testing', () => {
       .expect(200);
   });
 
+  test('Get request for /api/flags/id', () => {
+    return request(app)
+      .get('/api/flags/' + crypto.randomUUID())
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
+  });
+
   test('Delete request for /api/flags/id', () => {
     return request(app)
       .delete('/api/flags/' + crypto.randomUUID())
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
+  });
+
+  test('Patch request for /api/flags/inclusionList/id/status', () => {
+    return request(app)
+      .patch('/api/flags/inclusionList/' + crypto.randomUUID() + '/status')
+      .send({ enabled: false })
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
+  });
+
+  test('Patch request for /api/flags/exclusionList/id/status', () => {
+    return request(app)
+      .patch('/api/flags/exclusionList/' + crypto.randomUUID() + '/status')
+      .send({ enabled: true })
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
       .expect(200);

--- a/packages/backend/test/unit/controllers/SegmentController.test.ts
+++ b/packages/backend/test/unit/controllers/SegmentController.test.ts
@@ -68,6 +68,14 @@ describe('Segment Controller Testing', () => {
       .expect(200);
   });
 
+  test('Get request for /api/segments/:segmentId/members', () => {
+    return request(app)
+      .get(`/api/segments/${crypto.randomUUID()}/members`)
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
+  });
+
   test('Get request for /api/segments/status/:segmentId', () => {
     return request(app)
       .get(`/api/segments/status/${crypto.randomUUID()}`)

--- a/packages/backend/test/unit/controllers/mocks/FeatureFlagServiceMock.ts
+++ b/packages/backend/test/unit/controllers/mocks/FeatureFlagServiceMock.ts
@@ -59,6 +59,20 @@ export default class FeatureFlagServiceMock {
     return Promise.resolve([]);
   }
 
+  public findOneForDetails(id: string, logger: UpgradeLogger): Promise<Record<string, unknown>> {
+    return Promise.resolve({});
+  }
+
+  public updateListStatus(
+    segmentId: string,
+    enabled: boolean,
+    filterType: string,
+    currentUser: unknown,
+    logger: UpgradeLogger
+  ): Promise<Record<string, unknown>> {
+    return Promise.resolve({});
+  }
+
   public validateFeatureFlagContext(flag: FeatureFlag): boolean {
     return false;
   }

--- a/packages/backend/test/unit/controllers/mocks/SegmentServiceMock.ts
+++ b/packages/backend/test/unit/controllers/mocks/SegmentServiceMock.ts
@@ -15,6 +15,10 @@ export default class SegmentServiceMock {
     return Promise.resolve([]);
   }
 
+  public getSegmentByIdWithMembers(id: string): Promise<Record<string, unknown>> {
+    return Promise.resolve({});
+  }
+
   public getSegmentWithStatusById(id: string): Promise<[]> {
     return Promise.resolve([]);
   }

--- a/packages/backend/test/unit/services/FeatureFlagService.test.ts
+++ b/packages/backend/test/unit/services/FeatureFlagService.test.ts
@@ -448,6 +448,14 @@ describe('Feature Flag Service Testing', () => {
     expect(results).toBeTruthy();
   });
 
+  it('should use the counts-only fetch (not the full-member findOne) when toggling flag state', async () => {
+    const detailsSpy = jest.spyOn(service, 'findOneForDetails');
+    const findOneSpy = jest.spyOn(service, 'findOne');
+    await service.updateState(mockFlag1.id, FEATURE_FLAG_STATUS.ENABLED, mockUser1);
+    expect(detailsSpy).toHaveBeenCalledWith(mockFlag1.id);
+    expect(findOneSpy).not.toHaveBeenCalled();
+  });
+
   it('should update the filter mode', async () => {
     flagRepo.updateFilterMode = jest.fn().mockResolvedValue(mockFlag1);
     const results = await service.updateFilterMode(mockFlag1.id, FILTER_MODE.EXCLUDE_ALL, mockUser1);
@@ -461,7 +469,7 @@ describe('Feature Flag Service Testing', () => {
   });
 
   it('should return undefined when no flag to delete', async () => {
-    service.findOne = jest.fn().mockResolvedValue(undefined);
+    service.findOneForDetails = jest.fn().mockResolvedValue(undefined);
     const results = await service.delete(mockFlag1.id, mockUser1, logger);
     expect(results).toEqual(undefined);
   });

--- a/packages/backend/test/unit/services/FeatureFlagService.test.ts
+++ b/packages/backend/test/unit/services/FeatureFlagService.test.ts
@@ -500,6 +500,58 @@ describe('Feature Flag Service Testing', () => {
     expect(result).toBeTruthy();
   });
 
+  it('should find one flag for the details view', async () => {
+    const result = await service.findOneForDetails(mockFlag1.id, logger);
+    expect(result).toEqual(mockFlag1);
+  });
+
+  describe('updateListStatus', () => {
+    it('should update an inclusion list enabled status without rewriting its members', async () => {
+      const inclusionRepo = module.get(getRepositoryToken(FeatureFlagSegmentInclusionRepository)) as any;
+      const segmentService = module.get<SegmentService>(SegmentService);
+      inclusionRepo.findOne = jest.fn().mockResolvedValue({
+        enabled: false,
+        featureFlag: { id: mockFlag1.id, name: mockFlag1.name, context: ['context1'] },
+        segment: { id: 'segment-1', name: 'list' },
+      });
+      inclusionRepo.save = jest.fn().mockResolvedValue({});
+      mockExperimentAuditLogRepository.saveRawJson.mockClear();
+
+      const result = await service.updateListStatus('segment-1', true, LIST_FILTER_MODE.INCLUSION, mockUser1, logger);
+
+      expect(result.enabled).toBe(true);
+      expect(inclusionRepo.save).toHaveBeenCalled();
+      // a status-only toggle must NOT re-upsert the segment (which would rewrite all members)
+      expect(segmentService.upsertSegmentInPipeline).not.toHaveBeenCalled();
+      // a status change is recorded in the audit log
+      expect(mockExperimentAuditLogRepository.saveRawJson).toHaveBeenCalled();
+    });
+
+    it('should update an exclusion list enabled status', async () => {
+      const exclusionRepo = module.get(getRepositoryToken(FeatureFlagSegmentExclusionRepository)) as any;
+      exclusionRepo.findOne = jest.fn().mockResolvedValue({
+        enabled: true,
+        featureFlag: { id: mockFlag1.id, name: mockFlag1.name, context: ['context1'] },
+        segment: { id: 'segment-2', name: 'list' },
+      });
+      exclusionRepo.save = jest.fn().mockResolvedValue({});
+
+      const result = await service.updateListStatus('segment-2', false, LIST_FILTER_MODE.EXCLUSION, mockUser1, logger);
+
+      expect(result.enabled).toBe(false);
+      expect(exclusionRepo.save).toHaveBeenCalled();
+    });
+
+    it('should throw when no existing list record is found', async () => {
+      const inclusionRepo = module.get(getRepositoryToken(FeatureFlagSegmentInclusionRepository)) as any;
+      inclusionRepo.findOne = jest.fn().mockResolvedValue(undefined);
+
+      await expect(
+        service.updateListStatus('missing-segment', true, LIST_FILTER_MODE.INCLUSION, mockUser1, logger)
+      ).rejects.toThrow();
+    });
+  });
+
   it('should import a feature flag from a valid file', async () => {
     const result = await service.importFeatureFlags(
       [{ fileName: 'import.json', fileContent: JSON.stringify(mockFlag4) }],

--- a/packages/backend/test/unit/services/SegmentService.test.ts
+++ b/packages/backend/test/unit/services/SegmentService.test.ts
@@ -355,6 +355,11 @@ describe('Segment Service Testing', () => {
     expect(segments).toEqual(seg1);
   });
 
+  it('should get a segment (including private) with members by id', async () => {
+    const segment = await service.getSegmentByIdWithMembers(seg1.id, logger);
+    expect(segment).toEqual(seg1);
+  });
+
   it('should get segments by ids', async () => {
     const segments = await service.getSegmentByIds([seg1.id]);
     expect(segments).toEqual([seg1]);
@@ -511,6 +516,17 @@ describe('Segment Service Testing', () => {
     service.checkIsDuplicateSegmentName = jest.fn().mockResolvedValue(false);
     const segments = await service.upsertSegment(segVal, logger);
     expect(segments).toEqual(seg1);
+  });
+
+  it('should clear existing members with a single delete-by-segmentId when editing', async () => {
+    // Editing is a full replace: members are deleted then re-inserted. The delete must be a
+    // single "WHERE segmentId = :id" per member table rather than a per-row criteria list.
+    service.checkIsDuplicateSegmentName = jest.fn().mockResolvedValue(false);
+    repo.delete = jest.fn();
+
+    await service.upsertSegment(segVal, logger);
+
+    expect(repo.delete).toHaveBeenCalledWith({ segmentId: segVal.id });
   });
 
   it('should upsert a segment with trimmed whitespace and removed newline or carriage return', async () => {

--- a/packages/frontend/projects/upgrade/src/app/core/experiments/experiments.service.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/experiments/experiments.service.ts
@@ -23,6 +23,7 @@ import {
   selectAllExperiment,
   selectHasInitialExperimentsDataLoaded,
   selectIsLoadingExperiment,
+  selectIsLoadingUpsertPrivateSegmentList,
   selectSelectedExperiment,
   selectExperimentOverviewDetails,
   selectSearchExperimentParams,
@@ -71,6 +72,7 @@ export class ExperimentService {
   experiments$: Observable<Experiment[]> = this.store$.pipe(select(selectAllExperiment));
   currentUserEmailAddress$ = this.store$.pipe(select(selectCurrentUserEmail));
   isLoadingExperiment$ = this.store$.pipe(select(selectIsLoadingExperiment));
+  isLoadingUpsertPrivateSegmentList$ = this.store$.pipe(select(selectIsLoadingUpsertPrivateSegmentList));
   selectedExperiment$ = this.store$.pipe(select(selectSelectedExperiment));
   selectedExperimentOverviewDetails$ = this.store$.pipe(select(selectExperimentOverviewDetails));
   searchParams$ = this.store$.pipe(select(selectSearchExperimentParams));

--- a/packages/frontend/projects/upgrade/src/app/core/experiments/store/experiments.model.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/experiments/store/experiments.model.ts
@@ -632,6 +632,7 @@ export interface ExperimentState {
   isLoadingImportExperiment: boolean;
   isLoadingRewardsSummary: boolean;
   rewardsSummaries: Record<string, ExperimentRewardsSummary>;
+  isLoadingUpsertPrivateSegmentList?: boolean;
 }
 
 export interface State extends AppState {

--- a/packages/frontend/projects/upgrade/src/app/core/experiments/store/experiments.reducer.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/experiments/store/experiments.reducer.ts
@@ -30,6 +30,7 @@ export const initialState: ExperimentState = {
   isLoadingImportExperiment: false,
   isLoadingRewardsSummary: false,
   rewardsSummaries: {},
+  isLoadingUpsertPrivateSegmentList: false,
 };
 
 const reducer = createReducer(

--- a/packages/frontend/projects/upgrade/src/app/core/experiments/store/experiments.selectors.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/experiments/store/experiments.selectors.ts
@@ -42,6 +42,11 @@ export const selectAllExperiment = createSelector(
 
 export const selectIsLoadingExperiment = createSelector(selectExperimentState, (state) => state.isLoadingExperiment);
 
+export const selectIsLoadingUpsertPrivateSegmentList = createSelector(
+  selectExperimentState,
+  (state) => state.isLoadingUpsertPrivateSegmentList
+);
+
 export const selectHasInitialExperimentsDataLoaded = createSelector(
   selectExperimentState,
   (state) => state.hasInitialExperimentsDataLoaded

--- a/packages/frontend/projects/upgrade/src/app/core/feature-flags/feature-flags.data.service.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/feature-flags/feature-flags.data.service.ts
@@ -125,6 +125,11 @@ export class FeatureFlagsDataService {
     return this.http.delete(url);
   }
 
+  updateInclusionListStatus(segmentId: string, enabled: boolean) {
+    const url = `${API_ENDPOINTS.addFlagInclusionList}/${segmentId}/status`;
+    return this.http.patch(url, { enabled });
+  }
+
   addExclusionList(list: AddPrivateSegmentListRequest): Observable<FeatureFlagSegmentListDetails> {
     const url = API_ENDPOINTS.addFlagExclusionList;
     return this.http.post<FeatureFlagSegmentListDetails>(url, list);
@@ -138,6 +143,11 @@ export class FeatureFlagsDataService {
   deleteExclusionList(segmentId: string) {
     const url = `${API_ENDPOINTS.addFlagExclusionList}/${segmentId}`;
     return this.http.delete(url);
+  }
+
+  updateExclusionListStatus(segmentId: string, enabled: boolean) {
+    const url = `${API_ENDPOINTS.addFlagExclusionList}/${segmentId}/status`;
+    return this.http.patch(url, { enabled });
   }
 
   fetchFeatureFlagGraphInfo(params: { flagId: string; range: DATE_RANGE; clientOffset: number }) {

--- a/packages/frontend/projects/upgrade/src/app/core/feature-flags/feature-flags.service.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/feature-flags/feature-flags.service.ts
@@ -10,6 +10,7 @@ import {
   selectSearchKey,
   selectSearchString,
   selectIsLoadingUpsertFeatureFlag,
+  selectIsLoadingUpsertPrivateSegmentList,
   selectIsLoadingUpdateFeatureFlagStatus,
   selectSelectedFeatureFlag,
   selectSearchFeatureFlagParams,
@@ -61,7 +62,7 @@ export class FeatureFlagsService {
   isLoadingFeatureFlagDelete$ = this.store$.pipe(select(selectIsLoadingFeatureFlagDelete));
   isLoadingImportFeatureFlag$ = this.store$.pipe(select(selectIsLoadingImportFeatureFlag));
   isLoadingUpdateFeatureFlagStatus$ = this.store$.pipe(select(selectIsLoadingUpdateFeatureFlagStatus));
-  isLoadingUpsertPrivateSegmentList$ = this.store$.pipe(select(selectIsLoadingUpsertFeatureFlag));
+  isLoadingUpsertPrivateSegmentList$ = this.store$.pipe(select(selectIsLoadingUpsertPrivateSegmentList));
   featureFlags$ = this.store$.pipe(select(selectAllFeatureFlags));
   allFeatureFlags$ = this.store$.pipe(select(selectAllFeatureFlagsSortedByDate));
   appContexts$ = this.store$.pipe(select(selectAppContexts));
@@ -186,6 +187,10 @@ export class FeatureFlagsService {
     this.store$.dispatch(FeatureFlagsActions.actionDeleteFeatureFlagInclusionList({ segmentId }));
   }
 
+  updateFeatureFlagInclusionListStatus(segmentId: string, enabled: boolean) {
+    this.store$.dispatch(FeatureFlagsActions.actionUpdateFeatureFlagInclusionListStatus({ segmentId, enabled }));
+  }
+
   addFeatureFlagExclusionPrivateSegmentList(list: AddPrivateSegmentListRequest) {
     this.store$.dispatch(FeatureFlagsActions.actionAddFeatureFlagExclusionList({ list }));
   }
@@ -196,6 +201,10 @@ export class FeatureFlagsService {
 
   deleteFeatureFlagExclusionPrivateSegmentList(segmentId: string) {
     this.store$.dispatch(FeatureFlagsActions.actionDeleteFeatureFlagExclusionList({ segmentId }));
+  }
+
+  updateFeatureFlagExclusionListStatus(segmentId: string, enabled: boolean) {
+    this.store$.dispatch(FeatureFlagsActions.actionUpdateFeatureFlagExclusionListStatus({ segmentId, enabled }));
   }
 
   setGraphRange(range: DATE_RANGE | null, flagId: string, clientOffset: number) {

--- a/packages/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.actions.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.actions.ts
@@ -200,6 +200,21 @@ export const actionUpdateFeatureFlagInclusionListFailure = createAction(
   props<{ error: any }>()
 );
 
+export const actionUpdateFeatureFlagInclusionListStatus = createAction(
+  '[Feature Flags] Update Feature Flag Inclusion List Status',
+  props<{ segmentId: string; enabled: boolean }>()
+);
+
+export const actionUpdateFeatureFlagInclusionListStatusSuccess = createAction(
+  '[Feature Flags] Update Feature Flag Inclusion List Status Success',
+  props<{ segmentId: string; enabled: boolean }>()
+);
+
+export const actionUpdateFeatureFlagInclusionListStatusFailure = createAction(
+  '[Feature Flags] Update Feature Flag Inclusion List Status Failure',
+  props<{ error: any }>()
+);
+
 export const actionDeleteFeatureFlagInclusionList = createAction(
   '[Feature Flags] Delete Feature Flag Inclusion List',
   props<{ segmentId: string }>()
@@ -242,6 +257,21 @@ export const actionUpdateFeatureFlagExclusionListSuccess = createAction(
 
 export const actionUpdateFeatureFlagExclusionListFailure = createAction(
   '[Feature Flags] Update Feature Flag Exclusion List Failure',
+  props<{ error: any }>()
+);
+
+export const actionUpdateFeatureFlagExclusionListStatus = createAction(
+  '[Feature Flags] Update Feature Flag Exclusion List Status',
+  props<{ segmentId: string; enabled: boolean }>()
+);
+
+export const actionUpdateFeatureFlagExclusionListStatusSuccess = createAction(
+  '[Feature Flags] Update Feature Flag Exclusion List Status Success',
+  props<{ segmentId: string; enabled: boolean }>()
+);
+
+export const actionUpdateFeatureFlagExclusionListStatusFailure = createAction(
+  '[Feature Flags] Update Feature Flag Exclusion List Status Failure',
   props<{ error: any }>()
 );
 

--- a/packages/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.effects.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.effects.ts
@@ -2,7 +2,7 @@ import { FeatureFlagsDataService } from '../feature-flags.data.service';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Injectable } from '@angular/core';
 import * as FeatureFlagsActions from './feature-flags.actions';
-import { catchError, switchMap, map, filter, withLatestFrom, tap, first } from 'rxjs/operators';
+import { catchError, switchMap, mergeMap, map, filter, withLatestFrom, tap, first } from 'rxjs/operators';
 import { FeatureFlag, FeatureFlagsPaginationParams, NUMBER_OF_FLAGS } from './feature-flags.model';
 import { DATE_RANGE } from '../../experiments/store/experiments.model';
 import { Router } from '@angular/router';
@@ -221,6 +221,26 @@ export class FeatureFlagsEffects {
     )
   );
 
+  updateFeatureFlagInclusionListStatus$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(FeatureFlagsActions.actionUpdateFeatureFlagInclusionListStatus),
+      mergeMap(({ segmentId, enabled }) => {
+        return this.featureFlagsDataService.updateInclusionListStatus(segmentId, enabled).pipe(
+          map(() => {
+            this.notificationService.showSuccess(
+              this.translate.instant('feature-flags.inclusions.update-success.text')
+            );
+            return FeatureFlagsActions.actionUpdateFeatureFlagInclusionListStatusSuccess({ segmentId, enabled });
+          }),
+          catchError((error) => {
+            this.notificationService.showError(this.translate.instant('feature-flags.inclusions.update-error.text'));
+            return of(FeatureFlagsActions.actionUpdateFeatureFlagInclusionListStatusFailure({ error }));
+          })
+        );
+      })
+    )
+  );
+
   deleteFeatureFlagInclusionList$ = createEffect(() =>
     this.actions$.pipe(
       ofType(FeatureFlagsActions.actionDeleteFeatureFlagInclusionList),
@@ -430,6 +450,26 @@ export class FeatureFlagsEffects {
           })
         )
       )
+    )
+  );
+
+  updateFeatureFlagExclusionListStatus$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(FeatureFlagsActions.actionUpdateFeatureFlagExclusionListStatus),
+      mergeMap(({ segmentId, enabled }) => {
+        return this.featureFlagsDataService.updateExclusionListStatus(segmentId, enabled).pipe(
+          map(() => {
+            this.notificationService.showSuccess(
+              this.translate.instant('feature-flags.exclusions.update-success.text')
+            );
+            return FeatureFlagsActions.actionUpdateFeatureFlagExclusionListStatusSuccess({ segmentId, enabled });
+          }),
+          catchError((error) => {
+            this.notificationService.showError(this.translate.instant('feature-flags.exclusions.update-error.text'));
+            return of(FeatureFlagsActions.actionUpdateFeatureFlagExclusionListStatusFailure({ error }));
+          })
+        );
+      })
     )
   );
 

--- a/packages/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.reducer.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.reducer.ts
@@ -182,6 +182,10 @@ const reducer = createReducer(
   }),
 
   // Feature Flag Inclusion List Update Actions
+  on(FeatureFlagsActions.actionUpdateFeatureFlagInclusionList, (state) => ({
+    ...state,
+    isLoadingUpsertPrivateSegmentList: true,
+  })),
   on(FeatureFlagsActions.actionUpdateFeatureFlagInclusionListSuccess, (state, { listResponse }) => {
     const { featureFlag } = listResponse;
 
@@ -201,6 +205,28 @@ const reducer = createReducer(
       ...state,
       selectedFlag: updatedSelectedFlag,
       isLoadingUpsertPrivateSegmentList: false,
+    };
+  }),
+  on(FeatureFlagsActions.actionUpdateFeatureFlagInclusionListFailure, (state) => ({
+    ...state,
+    isLoadingUpsertPrivateSegmentList: false,
+  })),
+
+  // Feature Flag Inclusion List Status Toggle Actions
+  on(FeatureFlagsActions.actionUpdateFeatureFlagInclusionListStatusSuccess, (state, { segmentId, enabled }) => {
+    const updatedSelectedFlag = state.selectedFlag
+      ? {
+          ...state.selectedFlag,
+          featureFlagSegmentInclusion:
+            state.selectedFlag.featureFlagSegmentInclusion?.map((inclusion) =>
+              inclusion.segment.id === segmentId ? { ...inclusion, enabled } : inclusion
+            ) ?? [],
+        }
+      : state.selectedFlag;
+
+    return {
+      ...state,
+      selectedFlag: updatedSelectedFlag,
     };
   }),
 
@@ -259,6 +285,10 @@ const reducer = createReducer(
   }),
 
   // Feature Flag Exclusion List Update Actions
+  on(FeatureFlagsActions.actionUpdateFeatureFlagExclusionList, (state) => ({
+    ...state,
+    isLoadingUpsertPrivateSegmentList: true,
+  })),
   on(FeatureFlagsActions.actionUpdateFeatureFlagExclusionListSuccess, (state, { listResponse }) => {
     const { featureFlag } = listResponse;
 
@@ -278,6 +308,28 @@ const reducer = createReducer(
       ...state,
       selectedFlag: updatedSelectedFlag,
       isLoadingUpsertPrivateSegmentList: false,
+    };
+  }),
+  on(FeatureFlagsActions.actionUpdateFeatureFlagExclusionListFailure, (state) => ({
+    ...state,
+    isLoadingUpsertPrivateSegmentList: false,
+  })),
+
+  // Feature Flag Exclusion List Status Toggle Actions
+  on(FeatureFlagsActions.actionUpdateFeatureFlagExclusionListStatusSuccess, (state, { segmentId, enabled }) => {
+    const updatedSelectedFlag = state.selectedFlag
+      ? {
+          ...state.selectedFlag,
+          featureFlagSegmentExclusion:
+            state.selectedFlag.featureFlagSegmentExclusion?.map((exclusion) =>
+              exclusion.segment.id === segmentId ? { ...exclusion, enabled } : exclusion
+            ) ?? [],
+        }
+      : state.selectedFlag;
+
+    return {
+      ...state,
+      selectedFlag: updatedSelectedFlag,
     };
   }),
 

--- a/packages/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.selectors.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/feature-flags/store/feature-flags.selectors.ts
@@ -48,6 +48,11 @@ export const selectIsLoadingUpsertFeatureFlag = createSelector(
   (state) => state.isLoadingUpsertFeatureFlag
 );
 
+export const selectIsLoadingUpsertPrivateSegmentList = createSelector(
+  selectFeatureFlagsState,
+  (state) => state.isLoadingUpsertPrivateSegmentList
+);
+
 export const selectDuplicateKeyFound = createSelector(selectFeatureFlagsState, (state) => state.duplicateKeyFound);
 
 export const selectSelectedFeatureFlag = createSelector(

--- a/packages/frontend/projects/upgrade/src/app/core/segments/segments.data.service.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/segments/segments.data.service.ts
@@ -48,6 +48,14 @@ export class SegmentsDataService {
     return this.http.get(url);
   }
 
+  // Fetches a single segment including its full member lists. Used to lazy-load members when
+  // editing a list, since the details page loads segments with counts only (no member arrays).
+  // Uses the /members endpoint, which (unlike GET /segments/:id) also returns private lists.
+  fetchSegmentWithMembersById(id: string): Observable<Segment> {
+    const url = `${API_ENDPOINTS.segments}/${id}/members`;
+    return this.http.get<Segment>(url);
+  }
+
   deleteSegment(id: string) {
     const url = `${API_ENDPOINTS.segments}/${id}`;
     return this.http.delete(url);

--- a/packages/frontend/projects/upgrade/src/app/core/segments/segments.data.service.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/segments/segments.data.service.ts
@@ -48,9 +48,7 @@ export class SegmentsDataService {
     return this.http.get(url);
   }
 
-  // Fetches a single segment including its full member lists. Used to lazy-load members when
-  // editing a list, since the details page loads segments with counts only (no member arrays).
-  // Uses the /members endpoint, which (unlike GET /segments/:id) also returns private lists.
+  // Lazy-loads a list's members for editing; the /members endpoint also returns private lists.
   fetchSegmentWithMembersById(id: string): Observable<Segment> {
     const url = `${API_ENDPOINTS.segments}/${id}/members`;
     return this.http.get<Segment>(url);

--- a/packages/frontend/projects/upgrade/src/app/core/segments/segments.service.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/segments/segments.service.ts
@@ -34,6 +34,7 @@ import {
   AddSegmentRequest,
   EditPrivateSegmentListRequest,
   LIST_OPTION_TYPE,
+  Segment,
   SegmentInput,
   SegmentLocalStorageKeys,
   UpdateSegmentRequest,
@@ -120,6 +121,12 @@ export class SegmentsService {
 
   fetchSegmentById(segmentId: string) {
     this.store$.dispatch(SegmentsActions.actionGetSegmentById({ segmentId }));
+  }
+
+  // Fetches a single segment with its full member lists directly (bypassing the store), used
+  // to lazy-load members when editing a list loaded from the counts-only details endpoint.
+  fetchSegmentWithMembersById(segmentId: string): Observable<Segment> {
+    return this.segmentsDataService.fetchSegmentWithMembersById(segmentId);
   }
 
   refetchCurrentSelectedSegment() {

--- a/packages/frontend/projects/upgrade/src/app/core/segments/segments.service.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/segments/segments.service.ts
@@ -123,8 +123,7 @@ export class SegmentsService {
     this.store$.dispatch(SegmentsActions.actionGetSegmentById({ segmentId }));
   }
 
-  // Fetches a single segment with its full member lists directly (bypassing the store), used
-  // to lazy-load members when editing a list loaded from the counts-only details endpoint.
+  // Lazy-loads a list's members for editing (bypasses the store).
   fetchSegmentWithMembersById(segmentId: string): Observable<Segment> {
     return this.segmentsDataService.fetchSegmentWithMembersById(segmentId);
   }

--- a/packages/frontend/projects/upgrade/src/app/core/segments/store/segments.model.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/segments/store/segments.model.ts
@@ -107,6 +107,10 @@ export interface Segment {
   individualForSegment: IndividualForSegment[];
   groupForSegment: GroupForSegment[];
   subSegments: Segment[];
+  // Lightweight member counts returned when the segment is loaded without its full member
+  // lists (e.g. the feature-flag details page). Undefined when the full lists are present.
+  individualForSegmentCount?: number;
+  groupForSegmentCount?: number;
   listType?: MemberTypes | string;
   type: SEGMENT_TYPE;
   status: SEGMENT_STATUS;

--- a/packages/frontend/projects/upgrade/src/app/core/segments/store/segments.model.ts
+++ b/packages/frontend/projects/upgrade/src/app/core/segments/store/segments.model.ts
@@ -107,8 +107,7 @@ export interface Segment {
   individualForSegment: IndividualForSegment[];
   groupForSegment: GroupForSegment[];
   subSegments: Segment[];
-  // Lightweight member counts returned when the segment is loaded without its full member
-  // lists (e.g. the feature-flag details page). Undefined when the full lists are present.
+  // Member counts from counts-only loads (e.g. flag details); undefined when full lists are present.
   individualForSegmentCount?: number;
   groupForSegmentCount?: number;
   listType?: MemberTypes | string;

--- a/packages/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-inclusions-section-card/feature-flag-inclusions-section-card.component.ts
+++ b/packages/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-details-page/feature-flag-details-page-content/feature-flag-inclusions-section-card/feature-flag-inclusions-section-card.component.ts
@@ -6,7 +6,7 @@ import {
 } from '@shared-component-lib';
 import { TranslateModule } from '@ngx-translate/core';
 import { CommonModule } from '@angular/common';
-import { IMenuButtonItem, FILTER_MODE, SEGMENT_TYPE } from 'upgrade_types';
+import { IMenuButtonItem, FILTER_MODE } from 'upgrade_types';
 import { FeatureFlagInclusionsTableComponent } from './feature-flag-inclusions-table/feature-flag-inclusions-table.component';
 import { FeatureFlagsService } from '../../../../../../../core/feature-flags/feature-flags.service';
 import { DialogService } from '../../../../../../../shared/services/common-dialog.service';
@@ -21,11 +21,7 @@ import {
   ParticipantListRowActionEvent,
   ParticipantListTableRow,
 } from '../../../../../../../core/feature-flags/store/feature-flags.model';
-import {
-  EditPrivateSegmentListDetails,
-  EditPrivateSegmentListRequest,
-  Segment,
-} from '../../../../../../../core/segments/store/segments.model';
+import { Segment } from '../../../../../../../core/segments/store/segments.model';
 import { UserPermission } from '../../../../../../../core/auth/store/auth.models';
 import { AuthService } from '../../../../../../../core/auth/auth.service';
 
@@ -164,10 +160,10 @@ export class FeatureFlagInclusionsSectionCardComponent {
   onRowAction(event: ParticipantListRowActionEvent, flagId: string): void {
     switch (event.action) {
       case PARTICIPANT_LIST_ROW_ACTION.ENABLE:
-        this.onEnableIncludeList(event.rowData, flagId);
+        this.onEnableIncludeList(event.rowData);
         break;
       case PARTICIPANT_LIST_ROW_ACTION.DISABLE:
-        this.onDisableIncludeList(event.rowData, flagId);
+        this.onDisableIncludeList(event.rowData);
         break;
       case PARTICIPANT_LIST_ROW_ACTION.EDIT:
         this.onEditIncludeList(event.rowData, flagId);
@@ -178,62 +174,30 @@ export class FeatureFlagInclusionsSectionCardComponent {
     }
   }
 
-  onEnableIncludeList(rowData: ParticipantListTableRow, flagId: string): void {
+  onEnableIncludeList(rowData: ParticipantListTableRow): void {
     this.dialogService
       .openEnableIncludeListModal(rowData.segment.name)
       .afterClosed()
       .subscribe((confirmClicked) => {
         if (confirmClicked) {
-          this.sendUpdateIncludeListRequest(flagId, true, rowData.listType, rowData.segment);
+          this.featureFlagService.updateFeatureFlagInclusionListStatus(rowData.segment.id, true);
         }
       });
   }
 
-  onDisableIncludeList(rowData: ParticipantListTableRow, flagId: string): void {
+  onDisableIncludeList(rowData: ParticipantListTableRow): void {
     this.dialogService
       .openDisableIncludeListModal(rowData.segment.name)
       .afterClosed()
       .subscribe((confirmClicked) => {
         if (confirmClicked) {
-          this.sendUpdateIncludeListRequest(flagId, false, rowData.listType, rowData.segment);
+          this.featureFlagService.updateFeatureFlagInclusionListStatus(rowData.segment.id, false);
         }
       });
   }
 
   onEditIncludeList(rowData: ParticipantListTableRow, flagId: string): void {
     this.dialogService.openFeatureFlagEditIncludeListModal(rowData, rowData.segment.context, flagId);
-  }
-
-  sendUpdateIncludeListRequest(flagId: string, enabled: boolean, listType: string, segment: Segment): void {
-    const list: EditPrivateSegmentListDetails = this.createEditPrivateSegmentListDetails(segment);
-
-    const listRequest: EditPrivateSegmentListRequest = {
-      id: flagId,
-      enabled,
-      listType,
-      segment: list,
-    };
-
-    this.sendUpdateFeatureFlagInclusionRequest(listRequest);
-  }
-
-  createEditPrivateSegmentListDetails(segment: Segment): EditPrivateSegmentListDetails {
-    const editPrivateSegmentListDetails: EditPrivateSegmentListDetails = {
-      id: segment.id,
-      name: segment.name,
-      description: segment.description,
-      context: segment.context,
-      type: SEGMENT_TYPE.PRIVATE,
-      userIds: segment.individualForSegment.map((individual) => individual.userId),
-      groups: segment.groupForSegment,
-      subSegmentIds: segment.subSegments.map((subSegment) => subSegment.id),
-    };
-
-    return editPrivateSegmentListDetails;
-  }
-
-  sendUpdateFeatureFlagInclusionRequest(request: EditPrivateSegmentListRequest): void {
-    this.featureFlagService.updateFeatureFlagInclusionPrivateSegmentList(request);
   }
 
   onDeleteIncludeList(segment: Segment): void {

--- a/packages/frontend/projects/upgrade/src/app/features/dashboard/segments/modals/upsert-private-segment-list-modal/upsert-private-segment-list-modal.component.ts
+++ b/packages/frontend/projects/upgrade/src/app/features/dashboard/segments/modals/upsert-private-segment-list-modal/upsert-private-segment-list-modal.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Inject, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Inject, ViewChild } from '@angular/core';
 import { CommonModalComponent, CommonTagsInputComponent } from '@shared-component-lib';
 import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { CommonModule } from '@angular/common';
@@ -35,7 +35,16 @@ import {
   UpsertPrivateSegmentListParams,
 } from '../../../../../core/segments/store/segments.model';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
-import { BehaviorSubject, combineLatestWith, map, Observable, startWith, Subscription, timer } from 'rxjs';
+import {
+  BehaviorSubject,
+  combineLatest,
+  combineLatestWith,
+  map,
+  Observable,
+  startWith,
+  Subscription,
+  timer,
+} from 'rxjs';
 import { SEGMENT_TYPE } from '../../../../../../../../../../types/src';
 import isEqual from 'lodash.isequal';
 import { FeatureFlagsService } from '../../../../../core/feature-flags/feature-flags.service';
@@ -63,7 +72,15 @@ import { SharedModule } from '../../../../../shared/shared.module';
 export class UpsertPrivateSegmentListModalComponent {
   @ViewChild('typeSelectRef') typeSelectRef: MatSelect;
   listOptionTypes$: Observable<{ value: string; viewValue: string }[]>;
-  isLoadingUpsertFeatureFlagList$ = this.featureFlagService.isLoadingUpsertPrivateSegmentList$;
+  // This modal drives add/edit for feature-flag lists, experiment lists, and standalone
+  // segment lists — each backed by a different store. Disable the primary button while an
+  // upsert is in flight in ANY of them so it can't be double-submitted. Each store resets its
+  // own flag on success/failure, so this re-enables (or the modal closes) automatically.
+  isUpsertLoading$ = combineLatest([
+    this.featureFlagService.isLoadingUpsertPrivateSegmentList$,
+    this.experimentService.isLoadingUpsertPrivateSegmentList$,
+    this.segmentsService.isLoadingSegments$,
+  ]).pipe(map((loadingFlags) => loadingFlags.some(Boolean)));
   initialFormValues$ = new BehaviorSubject<PrivateSegmentListFormData>(null);
 
   subscriptions = new Subscription();
@@ -86,6 +103,7 @@ export class UpsertPrivateSegmentListModalComponent {
     private experimentService: ExperimentService,
     private featureFlagService: FeatureFlagsService,
     private commonExportHelpersService: CommonExportHelpersService,
+    private changeDetectorRef: ChangeDetectorRef,
     public dialogRef: MatDialogRef<UpsertPrivateSegmentListModalComponent>
   ) {}
 
@@ -187,13 +205,31 @@ export class UpsertPrivateSegmentListModalComponent {
       return;
     }
 
-    const values = this.determineValues(sourceList.listType, sourceList.segment);
+    this.applyEditFormValues(sourceList.listType, sourceList.segment);
+
+    // The feature-flag details page loads segments with member counts only (no member
+    // arrays) to stay lightweight, so lazy-load the full segment when we detect that members
+    // exist but weren't loaded. Editing then operates on the complete list.
+    if (this.segmentMembersNeedFetch(sourceList.listType, sourceList.segment)) {
+      this.subscriptions.add(
+        this.segmentsService.fetchSegmentWithMembersById(sourceList.segment.id).subscribe((segment) => {
+          if (segment) {
+            this.applyEditFormValues(sourceList.listType, segment);
+            this.changeDetectorRef.markForCheck();
+          }
+        })
+      );
+    }
+  }
+
+  private applyEditFormValues(listType: string, segment: Segment): void {
+    const values = this.determineValues(listType, segment);
     const formValue: PrivateSegmentListFormData = {
-      listType: sourceList.listType as LIST_OPTION_TYPE,
-      segment: sourceList.segment,
+      listType: listType as LIST_OPTION_TYPE,
+      segment,
       values,
-      name: sourceList.segment.name,
-      description: sourceList.segment.description,
+      name: segment.name,
+      description: segment.description,
     };
 
     this.privateSegmentListForm.patchValue(formValue, { emitEvent: false });
@@ -202,17 +238,29 @@ export class UpsertPrivateSegmentListModalComponent {
     this.initialFormValues$.next(formValue);
 
     // Trigger validators after populating the form
-    this.setValidatorsBasedOnListType(sourceList.listType);
+    this.setValidatorsBasedOnListType(listType);
+  }
+
+  // True when the segment's member list wasn't loaded (counts-only) but a non-zero count
+  // indicates members exist, so the full list must be fetched before editing.
+  private segmentMembersNeedFetch(listType: string, segment: Segment): boolean {
+    if (!segment?.id || listType === LIST_OPTION_TYPE.SEGMENT) {
+      return false;
+    }
+    if (listType === LIST_OPTION_TYPE.INDIVIDUAL) {
+      return !segment.individualForSegment?.length && (segment.individualForSegmentCount ?? 0) > 0;
+    }
+    return !segment.groupForSegment?.length && (segment.groupForSegmentCount ?? 0) > 0;
   }
 
   determineValues(listType: string, segment: Segment): string[] {
     switch (listType) {
       case LIST_OPTION_TYPE.INDIVIDUAL:
-        return segment.individualForSegment.map((individual) => individual.userId);
+        return segment.individualForSegment?.map((individual) => individual.userId) ?? [];
       case LIST_OPTION_TYPE.SEGMENT:
         return [];
       default:
-        return segment.groupForSegment.map((group) => group.groupId);
+        return segment.groupForSegment?.map((group) => group.groupId) ?? [];
     }
   }
 
@@ -231,7 +279,7 @@ export class UpsertPrivateSegmentListModalComponent {
   }
 
   listenForPrimaryButtonDisabled() {
-    this.isPrimaryButtonDisabled$ = this.isLoadingUpsertFeatureFlagList$.pipe(
+    this.isPrimaryButtonDisabled$ = this.isUpsertLoading$.pipe(
       combineLatestWith(this.isInitialFormValueChanged$),
       map(([isLoading, isInitialFormValueChanged]) => isLoading || !isInitialFormValueChanged)
     );

--- a/packages/frontend/projects/upgrade/src/app/features/dashboard/segments/modals/upsert-private-segment-list-modal/upsert-private-segment-list-modal.component.ts
+++ b/packages/frontend/projects/upgrade/src/app/features/dashboard/segments/modals/upsert-private-segment-list-modal/upsert-private-segment-list-modal.component.ts
@@ -37,8 +37,10 @@ import {
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import {
   BehaviorSubject,
+  catchError,
   combineLatest,
   combineLatestWith,
+  EMPTY,
   map,
   Observable,
   startWith,
@@ -72,15 +74,18 @@ import { SharedModule } from '../../../../../shared/shared.module';
 export class UpsertPrivateSegmentListModalComponent {
   @ViewChild('typeSelectRef') typeSelectRef: MatSelect;
   listOptionTypes$: Observable<{ value: string; viewValue: string }[]>;
-  // This modal drives add/edit for feature-flag lists, experiment lists, and standalone
-  // segment lists — each backed by a different store. Disable the primary button while an
-  // upsert is in flight in ANY of them so it can't be double-submitted. Each store resets its
-  // own flag on success/failure, so this re-enables (or the modal closes) automatically.
+  // Disable the primary button while an add/edit is in flight in any of the three stores this
+  // modal drives (flag/experiment/segment), to prevent double-submits.
   isUpsertLoading$ = combineLatest([
     this.featureFlagService.isLoadingUpsertPrivateSegmentList$,
     this.experimentService.isLoadingUpsertPrivateSegmentList$,
     this.segmentsService.isLoadingSegments$,
   ]).pipe(map((loadingFlags) => loadingFlags.some(Boolean)));
+  // True while the lazy member fetch (for counts-only edit sources) is in flight. Until it
+  // resolves the form's values control holds only the partial (counts-only) data, so submitting
+  // would send a full-replacement update that drops the unloaded members. Included in
+  // isPrimaryButtonDisabled$ to block saving during the fetch.
+  isLoadingMembers$ = new BehaviorSubject<boolean>(false);
   initialFormValues$ = new BehaviorSubject<PrivateSegmentListFormData>(null);
 
   subscriptions = new Subscription();
@@ -207,17 +212,28 @@ export class UpsertPrivateSegmentListModalComponent {
 
     this.applyEditFormValues(sourceList.listType, sourceList.segment);
 
-    // The feature-flag details page loads segments with member counts only (no member
-    // arrays) to stay lightweight, so lazy-load the full segment when we detect that members
-    // exist but weren't loaded. Editing then operates on the complete list.
+    // Lazy-load the full members when the (counts-only) source list didn't include them.
     if (this.segmentMembersNeedFetch(sourceList.listType, sourceList.segment)) {
+      // Block saving until the members load; otherwise a submit could full-replace with partial data.
+      this.isLoadingMembers$.next(true);
       this.subscriptions.add(
-        this.segmentsService.fetchSegmentWithMembersById(sourceList.segment.id).subscribe((segment) => {
-          if (segment) {
-            this.applyEditFormValues(sourceList.listType, segment);
-            this.changeDetectorRef.markForCheck();
-          }
-        })
+        this.segmentsService
+          .fetchSegmentWithMembersById(sourceList.segment.id)
+          .pipe(
+            catchError(() => {
+              // The HTTP interceptor shows the error; close the modal so a partially-loaded list can't be saved.
+              this.isLoadingMembers$.next(false);
+              this.closeModal();
+              return EMPTY;
+            })
+          )
+          .subscribe((segment) => {
+            if (segment) {
+              this.applyEditFormValues(sourceList.listType, segment);
+              this.changeDetectorRef.markForCheck();
+            }
+            this.isLoadingMembers$.next(false);
+          })
       );
     }
   }
@@ -241,8 +257,7 @@ export class UpsertPrivateSegmentListModalComponent {
     this.setValidatorsBasedOnListType(listType);
   }
 
-  // True when the segment's member list wasn't loaded (counts-only) but a non-zero count
-  // indicates members exist, so the full list must be fetched before editing.
+  // True when members exist (count > 0) but weren't loaded, so they must be fetched before editing.
   private segmentMembersNeedFetch(listType: string, segment: Segment): boolean {
     if (!segment?.id || listType === LIST_OPTION_TYPE.SEGMENT) {
       return false;
@@ -280,8 +295,11 @@ export class UpsertPrivateSegmentListModalComponent {
 
   listenForPrimaryButtonDisabled() {
     this.isPrimaryButtonDisabled$ = this.isUpsertLoading$.pipe(
-      combineLatestWith(this.isInitialFormValueChanged$),
-      map(([isLoading, isInitialFormValueChanged]) => isLoading || !isInitialFormValueChanged)
+      combineLatestWith(this.isInitialFormValueChanged$, this.isLoadingMembers$),
+      map(
+        ([isLoading, isInitialFormValueChanged, isLoadingMembers]) =>
+          isLoading || isLoadingMembers || !isInitialFormValueChanged
+      )
     );
     this.subscriptions.add(this.isPrimaryButtonDisabled$.subscribe());
   }

--- a/packages/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-details-participant-list-table/common-details-participant-list-table.component.html
+++ b/packages/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-details-participant-list-table/common-details-participant-list-table.component.html
@@ -27,12 +27,7 @@
       </th>
       <td mat-cell *matCellDef="let rowData" class="values-column ft-14-400">
         @if (rowData?.segment && rowData.listType?.toLowerCase() !== memberTypes.SEGMENT.toLowerCase()) {
-        <span
-          [matTooltip]="getValuesTooltipText(rowData)"
-          [matTooltipDisabled]="!getValuesText(rowData)"
-          matTooltipPosition="above"
-          matTooltipClass="values-tooltip"
-        >
+        <span>
           {{ getValuesText(rowData) }}
         </span>
         }

--- a/packages/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-details-participant-list-table/common-details-participant-list-table.component.ts
+++ b/packages/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-details-participant-list-table/common-details-participant-list-table.component.ts
@@ -81,8 +81,6 @@ export class CommonDetailsParticipantListTableComponent {
     ACTIONS: 'segments.global-actions.text',
   };
 
-  private readonly MAX_TOOLTIP_VALUES = 10;
-
   ngOnInit() {
     this.displayedColumns =
       this.tableType === LIST_FILTER_MODE.INCLUSION
@@ -94,10 +92,12 @@ export class CommonDetailsParticipantListTableComponent {
     const listType = rowData.listType;
     let count: number;
 
+    // Prefer the lightweight count returned by the details endpoint (member lists are not
+    // loaded there); fall back to the array length when the full lists are present.
     if (listType?.toLowerCase() === this.memberTypes.INDIVIDUAL.toLowerCase()) {
-      count = rowData.segment.individualForSegment?.length || 0;
+      count = rowData.segment.individualForSegmentCount ?? rowData.segment.individualForSegment?.length ?? 0;
     } else {
-      count = rowData.segment.groupForSegment?.length || 0;
+      count = rowData.segment.groupForSegmentCount ?? rowData.segment.groupForSegment?.length ?? 0;
     }
 
     if (count === 0) {
@@ -107,24 +107,6 @@ export class CommonDetailsParticipantListTableComponent {
     } else {
       return `${count} Values`;
     }
-  }
-
-  getValuesTooltipText(rowData: ParticipantListTableRow): string {
-    const listType = rowData.listType;
-    let values: string[];
-
-    if (listType?.toLowerCase() === this.memberTypes.INDIVIDUAL.toLowerCase()) {
-      values = rowData.segment.individualForSegment?.map((item) => item.userId) || [];
-    } else {
-      values = rowData.segment.groupForSegment?.map((item) => item.groupId) || [];
-    }
-
-    // Show only first 10 values if there are more
-    if (values.length > this.MAX_TOOLTIP_VALUES) {
-      return values.slice(0, this.MAX_TOOLTIP_VALUES).join(', ') + '...';
-    }
-
-    return values.join(', ');
   }
 
   getFormattedListType(rowData: ParticipantListTableRow): string {

--- a/packages/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-details-participant-list-table/common-details-participant-list-table.component.ts
+++ b/packages/frontend/projects/upgrade/src/app/shared-standalone-component-lib/components/common-details-participant-list-table/common-details-participant-list-table.component.ts
@@ -92,8 +92,7 @@ export class CommonDetailsParticipantListTableComponent {
     const listType = rowData.listType;
     let count: number;
 
-    // Prefer the lightweight count returned by the details endpoint (member lists are not
-    // loaded there); fall back to the array length when the full lists are present.
+    // Prefer the count field (counts-only load); fall back to array length when full lists are present.
     if (listType?.toLowerCase() === this.memberTypes.INDIVIDUAL.toLowerCase()) {
       count = rowData.segment.individualForSegmentCount ?? rowData.segment.individualForSegment?.length ?? 0;
     } else {


### PR DESCRIPTION
https://github.com/CarnegieLearningWeb/UpGrade/issues/3210

From the broader https://github.com/CarnegieLearningWeb/UpGrade/issues/3208

This was tested with lists up to 20k.

The current details page for FF breaks because the current UI strategy has `/flags/:id` do a heavy load of everything about the flag and load it into ngrx store in order to support heavy request payloads to edit and enable lists. This eager get-and-send-everything for every CRUD operation doesn't scale.

This does a few things in tandem to break down 
- A new lightweight endpoint for details page flag operations that don't need all the data to do their job
- Lazy-load the members of the lists on edit-modal load (new endpoint also)
- A PATCH endpoint for toggling list status to mitigate sending a bunch of info in the request

It also fixes a couple of other things:
- On backend, edit list still does an entire replacement, which has a bug in the sql has it delete every member individually. Ideally it would PATCH but to avoid making a large change larger, this works perfectly fine with a minor sql change to delete the whole thing before replacement.

- For flags, the submit button for editing lists was not getting disabled, so it looks like nothing is happening and you can keep clicking and sending these giant requests. So I sewed that up in this PR also, it would crash the server. a separate ticket was filed for this: https://github.com/CarnegieLearningWeb/UpGrade/issues/3209