### PR TITLE
Fix snake_case decision point truncation

### DIFF
--- a/packages/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-decision-points-section-card/experiment-decision-points-table/experiment-decision-points-table.component.html
+++ b/packages/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-decision-points-section-card/experiment-decision-points-table/experiment-decision-points-table.component.html
@@ -20,7 +20,7 @@
         <span
           [appTextOverflowTooltip]="getDecisionPoint(decisionPoint)"
           matTooltipPosition="above"
-          class="line-clamp-1"
+          class="line-clamp-1 break-all"
         >
           {{ getDecisionPoint(decisionPoint) }}
         </span>

--- a/packages/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-payloads-section-card/experiment-payloads-table/experiment-payloads-table.component.html
+++ b/packages/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-details-page/experiment-details-page-content/experiment-payloads-section-card/experiment-payloads-table/experiment-payloads-table.component.html
@@ -11,7 +11,7 @@
     [ngClass]="{ 'no-data': !conditionPayloads?.length }"
     class="payloads-table"
   >
-    <!-- Decision Point Column (Site + Target stacked) -->
+    <!-- Decision Point Column (Site + Target) -->
     <ng-container matColumnDef="decisionPoint">
       <th mat-header-cell *matHeaderCellDef class="decision-point-column ft-14-600">
         {{ PAYLOAD_TRANSLATION_KEYS.DECISION_POINT | translate }}
@@ -20,7 +20,7 @@
         <span
           [appTextOverflowTooltip]="getDecisionPoint(payload.decisionPoint)"
           matTooltipPosition="above"
-          class="line-clamp-1"
+          class="line-clamp-1 break-all"
         >
           {{ getDecisionPoint(payload.decisionPoint) }}
         </span>

--- a/packages/frontend/projects/upgrade/src/styles.scss
+++ b/packages/frontend/projects/upgrade/src/styles.scss
@@ -542,3 +542,7 @@ button[mat-icon-button] {
   -webkit-line-clamp: 4;
   line-clamp: 4;
 }
+
+.break-all {
+  word-break: break-all;
+}


### PR DESCRIPTION
Resolves #3234

## Changes

- Added a reusable `break-all` utility class.
- Applied character-level word breaking to decision point displays in the Payloads table.
- Applied the same behavior to the Decision Points table for consistency.
- Preserved the existing line clamp and overflow tooltip behavior.
- Left other line-clamped content unchanged to avoid affecting natural-language and multi-line text.
