### PR TITLE
use featureflag ttl for ff precomputed segments

### DIFF
--- a/packages/backend/src/api/services/CacheService.ts
+++ b/packages/backend/src/api/services/CacheService.ts
@@ -12,7 +12,8 @@ const PREFIX_CATEGORY: Record<CACHE_PREFIX, CacheBucket> = {
   [CACHE_PREFIX.FEATURE_FLAG_KEY_PREFIX]: 'featureFlags',
   [CACHE_PREFIX.SEGMENT_KEY_PREFIX]: 'segments',
   [CACHE_PREFIX.GLOBAL_EXCLUDE_SEGMENT_KEY_PREFIX]: 'segments',
-  [CACHE_PREFIX.FEATURE_FLAG_PRECOMPUTED_SEGMENT_KEY_PREFIX]: 'segments',
+  // We want these segments to be subject to the same TTL as feature flags
+  [CACHE_PREFIX.FEATURE_FLAG_PRECOMPUTED_SEGMENT_KEY_PREFIX]: 'featureFlags',
 };
 
 // this module will get swapped in if caching is enabled but the cache manager fails to initialize as a dummy default deliverer

--- a/packages/backend/test/unit/services/CacheService.test.ts
+++ b/packages/backend/test/unit/services/CacheService.test.ts
@@ -220,7 +220,8 @@ describe('CacheService', () => {
       [CACHE_PREFIX.FEATURE_FLAG_KEY_PREFIX, 45000],
       [CACHE_PREFIX.SEGMENT_KEY_PREFIX, 90000],
       [CACHE_PREFIX.GLOBAL_EXCLUDE_SEGMENT_KEY_PREFIX, 90000],
-      [CACHE_PREFIX.FEATURE_FLAG_PRECOMPUTED_SEGMENT_KEY_PREFIX, 90000],
+      // Flag-scoped membership tracks the feature flag TTL, not the shared-segment TTL
+      [CACHE_PREFIX.FEATURE_FLAG_PRECOMPUTED_SEGMENT_KEY_PREFIX, 45000],
     ])('wraps %s with its category TTL (ms)', async (prefix, expectedTtl) => {
       const fn = jest.fn().mockResolvedValue('v');
       await service.wrap(prefix + 'context', fn);


### PR DESCRIPTION
repoint which ttl precomputed flag segments use.