### PR TITLE
add perftrace scaffolding and teardown skill for claude

### DIFF
--- a/.claude/skills/setup-perftrace/SKILL.md
+++ b/.claude/skills/setup-perftrace/SKILL.md
@@ -1,0 +1,524 @@
+---
+name: setup-perftrace
+description: Install temporary request-correlated performance tracing on the UpGrade backend client hot path and instrument the /v6 client endpoints with spans, so latency can be attributed span-by-span under load. Reproduces the log format and span conventions of the origin/reference/client-perftraces branch. Use when investigating slow or spiky client endpoints (/v6/assign, /v6/init, /v6/mark, /v6/featureflag, etc.), when asked to "add perf traces", "instrument the hot path", "find where the time goes", or when profiling a load test. Remove it afterwards with /teardown-perftrace.
+---
+
+# setup-perftrace
+
+Installs a throwaway tracing harness. **This is never meant to be committed or maintained** — it is
+applied to a branch, used to find something, then removed with `/teardown-perftrace`.
+
+The harness is deliberately tiny: **one new file plus one three-line edit**. Everything else is
+env-var driven. Keeping the footprint at two files is what makes teardown reliable.
+
+## Scope
+
+The UpGrade backend client hot path — the `/v6` (and `/v5`) client controllers and the services they
+call. The outer envelope is registered globally, so it will cover any express route; the guidance
+below is about the *client* endpoints because that is where load-test latency lives.
+
+## The reference implementation is the source of truth
+
+**`origin/reference/client-perftraces` is a complete, working instance of this harness.** It is not
+an example to be loosely inspired by — it is the spec. The harness asset, the log format, the span
+labels, and the choice of what to wrap all come from that branch, and a fresh install should be
+indistinguishable from it on any file both have in common.
+
+Fetch it before you do anything else, and keep referring back to it at every step:
+
+```bash
+git fetch origin reference/client-perftraces
+B=origin/reference/client-perftraces; M=$(git merge-base origin/dev $B)
+
+git diff --stat $M $B                          # the whole footprint
+git diff $M $B -- packages/backend/src/api/    # every span, in context
+git show $B:packages/backend/src/api/services/ExperimentAssignmentService.ts | grep -n tracePerf
+```
+
+> **Shell variables do not survive between Bash tool calls** — only the working directory does. Every
+> snippet below that uses `$B` or `$M` must re-declare them on the same line, and the snippets are
+> written that way. This is not cosmetic: with `$M` empty, the Step 8 drift check silently collapses
+> from `git diff --quiet $M HEAD` to `git diff --quiet HEAD`, which reports CLEAN for every file on a
+> clean tree — so a drifted file gets reference hunks applied to code that has moved underneath them.
+
+This is the log format, and it is fixed by `perfTrace.ts` plus the label grammar — nothing else may
+alter it:
+
+```
+[perf] ┌───── req=005w inflight=2 start=243915.094 POST /api/v6/assign
+[perf] │ req=005w inflight=2 dur=1.204ms start=… end=… span=UserCheckMiddleware.getUserDoc
+[perf] │ req=005w inflight=2 dur=8.771ms start=… end=… span=getAssignmentsAndExclusionsForUser(experiments=4)
+[perf] └───── req=005w inflight=2 dur=21.412ms start=… end=… POST /api/v6/assign
+```
+
+Why it matters that the format is *exact*: these logs are read by diffing runs against each other —
+before/after a fix, one branch against another, a load test against a baseline. Span labels are the
+join key. A label that reads `assignExperiments(n=3)` on one branch and
+`assignExperiments(experiments=3)` on another cannot be compared, and the count-in-label convention
+(see [Conventions](#conventions-from-the-reference-branch)) is frequently the thing that cracks the
+case. Reproduce labels character-for-character.
+
+## What this skill does and does not do
+
+**Does:** install the harness, wire the outer envelope, configure the local `.env`, **ask which
+`/v6` client endpoints to instrument and then instrument them**, record a snapshot manifest for
+teardown, verify the install.
+
+**Does not:** invent new spans where the reference branch already has them, or instrument admin /
+non-client routes. Depth is fixed by the reference, not chosen fresh each run —
+over-instrumenting a hot path distorts the measurement and buries the signal, and the reference's
+span set is already the product of that tuning.
+
+---
+
+## Step 1 — Preflight
+
+```bash
+ls packages/backend/src/lib/perf/perfTrace.ts 2>/dev/null && echo "ALREADY INSTALLED"
+ls .claude/.perftrace/manifest.json 2>/dev/null && echo "MANIFEST EXISTS"
+```
+
+If either exists, stop and tell the user it is already installed — offer `/teardown-perftrace`
+first. Do not reinstall over an existing manifest; that would overwrite the snapshot of the
+*original* files with a snapshot of the *instrumented* ones, and teardown could never get back.
+
+Also check the working tree is not mid-conflict (`git status`). Uncommitted work is fine — the
+snapshot approach preserves it — but note in your summary which files you are about to touch.
+
+## Step 2 — Snapshot before touching anything
+
+Create the manifest directory (gitignored via `.claude/*`) and back up every file you are about to
+modify, **before** modifying it.
+
+```bash
+mkdir -p .claude/.perftrace/backups
+```
+
+For each file to be **modified**, copy the current content to
+`.claude/.perftrace/backups/<path-with-slashes-replaced-by-underscores>` and record its sha256.
+For each file to be **created**, record only that it is new.
+
+Write `.claude/.perftrace/manifest.json`:
+
+```json
+{
+  "installedAt": "<ISO timestamp from `date -u +%Y-%m-%dT%H:%M:%SZ`>",
+  "branch": "<git branch --show-current>",
+  "files": [
+    {
+      "path": "packages/backend/src/lib/perf/perfTrace.ts",
+      "action": "created"
+    },
+    {
+      "path": "packages/backend/src/loaders/app/index.ts",
+      "action": "modified",
+      "backup": ".claude/.perftrace/backups/packages_backend_src_loaders_app_index.ts",
+      "sha256Before": "<sha256 of the original>",
+      "sha256AfterSetup": "<sha256 after your edit — fill this in at the end>"
+    }
+  ]
+}
+```
+
+`sha256AfterSetup` is what lets teardown detect that a file was edited *after* setup (by the user,
+or by you adding spans) and warn before overwriting. Compute with `shasum -a 256 <file> | cut -d' ' -f1`.
+
+The two entries above are only the harness itself. **Step 8 appends one entry per instrumented
+file**, and so must you if you add spans in a later turn — a span added to `FeatureFlagService.ts`
+tomorrow must be snapshotted the same way, or teardown will miss it. A fully instrumented install
+has around seven entries, not two.
+
+## Step 3 — Install the harness
+
+Copy the asset verbatim:
+
+```bash
+mkdir -p packages/backend/src/lib/perf
+cp .claude/skills/setup-perftrace/assets/perfTrace.ts packages/backend/src/lib/perf/perfTrace.ts
+```
+
+Do not hand-write it and do not "improve" it. It encodes several non-obvious decisions (see
+[Why the harness looks like this](#why-the-harness-looks-like-this)), and **it is what fixes the log
+format** — the `┌`/`│`/`└` glyphs, the field order, `inflight`, the shared `performance.now()`
+marks. Any edit to this file changes the format and breaks comparability with previous runs.
+
+Confirm it is byte-identical to the reference:
+
+```bash
+git show origin/reference/client-perftraces:packages/backend/src/lib/perf/perfTrace.ts \
+  | diff - packages/backend/src/lib/perf/perfTrace.ts && echo "IDENTICAL"
+```
+
+If that prints anything but `IDENTICAL`, prefer the reference's version — the checked-in asset has
+drifted and the reference is authoritative.
+
+## Step 4 — Register the envelope outermost
+
+`packages/backend/src/loaders/app/index.ts` uses `createExpressServer(options)`, which builds the
+app internally and gives no chance to register middleware ahead of the routes. Swap it for
+`express()` + `useExpressServer(app, options)` — verified identical internally
+(`createExpressServer` *is* `useExpressServer` with an internally-created app):
+
+Take this edit from the reference verbatim, including its explanatory comment:
+
+```bash
+B=origin/reference/client-perftraces; M=$(git merge-base origin/dev $B)
+git diff $M $B -- packages/backend/src/loaders/app/index.ts
+```
+
+```ts
+import express, { Application } from 'express';
+import { useExpressServer } from 'routing-controllers';
+import { perfTraceMiddleware } from '../../lib/perf/perfTrace';
+
+// useExpressServer(app, options) is exactly what createExpressServer(options) does internally, but
+// against an app we own. Owning it lets us register the perf trace ahead of routing-controllers'
+// own routes so the request envelope encloses CORS, body parsing, validation, the @UseBefore
+// middlewares, the handler, and response serialization. A span registered inside the handler misses
+// all of that, which is the gap between traced time and client-observed time.
+const expressApp: Application = express();
+
+expressApp.use(perfTraceMiddleware);
+
+useExpressServer(expressApp, {
+  /* ...existing options, unchanged... */
+});
+
+export default expressApp;
+```
+
+This placement is the whole point. A span registered inside a handler misses the `@UseBefore`
+middleware, body parsing, class-validator, and response serialization — which is precisely the gap
+between what the trace reports and what an external client measures.
+
+Make this edit with the Edit tool, then **verify it landed**:
+
+```bash
+grep -n "createExpressServer\|useExpressServer\|perfTraceMiddleware" packages/backend/src/loaders/app/index.ts
+```
+
+Expect `useExpressServer` and `perfTraceMiddleware`, and no `createExpressServer`. Scripted
+search-and-replace on this file has silently no-op'd before; a failed edit here is easy to miss
+because everything still compiles and runs — you just get no `[perf]` output at all.
+
+## Step 5 — Configure the local .env
+
+`packages/backend/.env` only (gitignored). **Never touch `.env.example` or `.env.test`** — those are
+tracked, and this harness must leave no committed trace.
+
+**Check for an existing block first and replace it rather than appending:**
+
+```bash
+grep -n "PERF_TRACE" packages/backend/.env
+```
+
+`.env` is gitignored, so it does *not* reset when you switch branches. A previous install's block
+will still be sitting there, and blindly appending gives you duplicate keys — dotenv takes the
+first, so a stale `PERF_TRACE_PATHS` silently wins and you spend an hour wondering why isolation
+isn't working. If a block exists, edit it in place; only append when there is none.
+
+On a fresh branch a complete, correct block from a previous install is the *expected* case, not the
+exception. Read it before changing anything: if all four keys are present exactly once and the
+values are the defaults below, leave the file alone and say so in your summary. Rewriting it is
+churn, and the diff-free outcome is the correct one.
+
+```bash
+PERF_TRACE_ENABLED=true
+# 0 logs every child span — fine for low-rate manual runs. Raise to ~5 before a load test:
+# console.log to a TTY is a synchronous write and will perturb what you are measuring.
+# The ┌/└ request envelope is always logged regardless of this value.
+PERF_TRACE_THRESHOLD_MS=0
+# Empty traces every request. Set to isolate, e.g. /v6/assign
+PERF_TRACE_PATHS=
+# Applied after PERF_TRACE_PATHS, so an exclusion always wins. e.g. /v6/log,/v6/mark
+PERF_TRACE_EXCLUDE_PATHS=
+```
+
+After writing, re-run the grep and confirm each key appears exactly once.
+
+## Step 6 — Verify
+
+```bash
+cd packages/backend && npx tsc --noEmit && npx jest --config=jest.config.js test/unit
+```
+
+Note that this `cd` persists for every later Bash call in the session. Use absolute paths from here
+on, or the cleanup `rm` at the end of this step fails with "No such file or directory".
+
+### The `.env` block does not reach jest — pass the vars inline
+
+**`NODE_ENV` is `test` for any jest run — jest defaults it, and `package-scripts.js` sets it
+explicitly via `cross-env` — and `src/env.ts` loads `` `.env${NODE_ENV === 'test' ? '.test' : ''}` ``.
+So under jest dotenv reads `.env.test`, which has no `PERF_TRACE` keys.** The block you just wrote
+to `.env` is invisible to every command in this step, `enabled` is `false`, and the verification test
+prints **zero `[perf]` lines**.
+
+This failure is indistinguishable from a Step 4 edit that silently no-op'd. Do not go re-checking the
+envelope wiring when you see no output here — check this first.
+
+Do **not** fix it by adding keys to `.env.test`; that file is tracked, and the harness must leave no
+committed trace. Instead pass the vars inline on each command. Shell-provided `process.env` wins,
+because dotenv does not override variables that are already set:
+
+```bash
+PERF_TRACE_ENABLED=true npx jest --config=jest.config.js test/unit/tracefilter.test.ts
+```
+
+Only the jest path is affected. `npm start serve` and any load test run without `NODE_ENV=test`, so
+they read the `.env` block normally — Step 5 is still doing real work for the user's actual runs.
+
+Then prove the harness actually emits, with a throwaway test (delete it afterwards):
+
+```ts
+// packages/backend/test/unit/tracefilter.test.ts
+import 'reflect-metadata';
+import request from 'supertest';
+jest.setTimeout(60000);
+it('filter', async () => {
+  const app = require('../../src/loaders/app').default;
+  for (const p of ['init', 'assign', 'mark', 'featureflag'])
+    await request(app).post(`/api/v6/${p}`).set('User-Id', 'u').send({ context: 'test' });
+});
+```
+
+Run it four ways, varying only the inline env vars. Each mode is one command:
+
+```bash
+J="npx jest --config=jest.config.js test/unit/tracefilter.test.ts"
+PERF_TRACE_ENABLED=true $J                                  # all four endpoints
+PERF_TRACE_ENABLED=true PERF_TRACE_PATHS=/v6/assign $J      # assign only
+PERF_TRACE_ENABLED=true PERF_TRACE_EXCLUDE_PATHS=/v6/mark $J  # everything but mark
+PERF_TRACE_ENABLED=false $J                                 # zero [perf] lines
+```
+
+The test output is loud — every request 500s and winston logs a stack trace per request. Both are
+expected: you are testing the envelope, not the endpoint, and the app under test has no DB. Filter
+to just the envelope rather than reading it all:
+
+```bash
+... | grep -oE "\[perf\] [┌└].*POST /api/v6/[a-z]+"
+```
+
+For the disabled mode, assert on the count instead: `| grep -c "\[perf\]"` must print `0`.
+
+Confirm every `┌` has a matching `└` in each mode — that pairing is what proves the `finish`/`close`
+listeners fire, and it is the one thing the grep above makes easy to eyeball.
+
+Delete the throwaway test (absolute path — see the `cd` note above), then fill in
+`sha256AfterSetup` in the manifest for the two files installed so far.
+
+At this point the envelope works. Everything after this adds spans inside it.
+
+## Step 7 — Ask which endpoints to instrument
+
+**Always ask, and default to all.** Use AskUserQuestion with `multiSelect: true`, listing the `/v6`
+client endpoints from the [inventory](#span-inventory) with every one pre-selected. Skip the prompt
+only when the user already named endpoints in their invocation (`/setup-perftrace assign` →
+instrument `/v6/assign`, no question).
+
+Two things are **not** part of the selection:
+
+- **The two client middlewares are always instrumented**, whatever the user picks. `ClientLibMiddleware`
+  and `UserCheckMiddleware` sit in front of essentially every client route, so auth and user-lookup
+  time would otherwise be an unexplained gap between `┌` and the first child span. This costs nothing
+  when the user narrows scope: `tracePerf*` no-ops outside a traced request, so `PERF_TRACE_PATHS`
+  still isolates output to the endpoint under study.
+- **`/v6/clearDB` is never instrumented.** It is a test-support route, not a hot path, and the
+  reference branch leaves it alone.
+
+## Step 8 — Instrument, per file, drift-aware
+
+For each file in the [inventory](#span-inventory) that the selection requires, decide **verbatim or
+by hand** based on whether that file has moved since the reference branch's base:
+
+```bash
+B=origin/reference/client-perftraces; M=$(git merge-base origin/dev $B)
+git diff --quiet $M HEAD -- <file> && echo "CLEAN -> verbatim" || echo "DRIFTED -> hand-apply"
+```
+
+**CLEAN** — the file is byte-identical to what the reference instrumented. Take its hunks verbatim
+so the labels are exact. Read the reference's version and apply the same edits:
+
+```bash
+B=origin/reference/client-perftraces; M=$(git merge-base origin/dev $B)
+git diff $M $B -- <file>     # the exact hunks to reproduce
+```
+
+Do **not** `git checkout $B -- <file>` even when clean. It works today and silently reverts real
+work the moment the file has any unrelated change you did not notice — and the whole point of the
+drift check is to never be in that position.
+
+**DRIFTED** — the surrounding code has changed. Hand-apply the spans following
+[Conventions](#conventions-from-the-reference-branch), keeping the reference's label spelling
+character-for-character even though the call site moved. **Name every hand-derived file in your
+summary** so the user knows which ones to spot-check; that list is the honest edge of what this
+skill can guarantee.
+
+Before editing each file, **snapshot it and append it to the manifest** exactly as Step 2 does —
+`action: "modified"`, `backup`, `sha256Before`, and `sha256AfterSetup` once the edit lands. A file
+instrumented but not in the manifest is a file teardown will not restore.
+
+Then typecheck and re-run the suite — span wrapping changes inferred types at call sites, and a
+`tracePerfAsync` around a destructured return is the usual place it goes wrong:
+
+```bash
+cd packages/backend && npx tsc --noEmit && npx jest --config=jest.config.js test/unit
+```
+
+## Step 9 — Report
+
+Report to the user: which endpoints were instrumented, which files were taken verbatim versus
+hand-derived, how to switch modes, that traces will not appear under jest without inline vars, and
+that `/teardown-perftrace` reverses all of it. If you left the `.env` block untouched because it was
+already correct, say that explicitly — otherwise it reads as a skipped step.
+
+---
+
+## Span inventory
+
+The full footprint of `origin/reference/client-perftraces`. Endpoint → the spans it needs and the
+file they live in. Verify against the branch rather than trusting this table if the two disagree.
+
+| Endpoint | Spans | File |
+|---|---|---|
+| *(always)* | `ClientLibMiddleware.getClientCheck`, `ClientLibMiddleware.jwtVerify` (sync) | `middlewares/ClientLibMiddleware.ts` |
+| *(always)* | `UserCheckMiddleware.getUserDoc`, `UserCheckMiddleware.handleProvidedGroupsForSession` | `middlewares/UserCheckMiddleware.ts` |
+| `POST /v6/init` | `experimentUserService.upsertOnChange` | `controllers/ExperimentClientController.v6.ts` |
+| `PATCH /v6/groupmembership` | `experimentUserService.updateGroupMembership` | controller |
+| `PATCH /v6/workinggroup` | `experimentUserService.updateWorkingGroup` | controller |
+| `PATCH /v6/useraliases` | `experimentUserService.setAliasesForUser(aliases=N)` | controller |
+| `POST /v6/reward` | `moocletRewardsService.sendReward` | controller |
+| `POST /v6/mark` | `experimentAssignmentService.markExperimentPoint` | controller |
+| " | 8 spans inside `markExperimentPoint` — `previewUserService.findOneFromCache`, `getCachedExperiments`, `checkUserOrGroupIsGloballyExcluded`, `experimentLevelExclusionInclusion`, `monitoredDecisionPointRepository.findOne`, `saveGroupExclusionDoc`, `updateEnrollmentExclusionDocumentsAndCheckEndingCriteria`, `monitoredDecisionPointRepository.saveRawJson` | `services/ExperimentAssignmentService.ts` |
+| `POST /v6/assign` | `formatAssignments` (sync) | controller |
+| " | 11 spans inside `getAllExperimentConditions` — `previewUserService.findOneFromCache`, `checkUserOrGroupIsGloballyExcluded`, `filterAndProcessGroupExperiments`, `getAssignmentsAndExclusionsForUser(experiments=N)`, `experimentLevelExclusionInclusion`, `processExperimentPools` (sync), `assignExperiments(experiments=N)` + per-item `assignExperiment(<id>)` and `getEnrollmentCountPerCondition(<id>)`, `getRepeatedEnrollmentCount`, `buildDecisionPoints` (sync) | `services/ExperimentAssignmentService.ts` |
+| `POST /v6/log` | `experimentAssignmentService.dataLog(logs=N)` | controller |
+| " | `createLogs(logs=N)` + per-item `createLog[<index>]` | `services/ExperimentAssignmentService.ts` |
+| `POST /v6/featureflag` | `featureFlagService.getKeys` | controller |
+| " | `getCachedFlagsForKeys`, `featureFlagLevelInclusionExclusion(flags=N)` | `services/FeatureFlagService.ts` |
+| `DELETE /v6/clearDB` | *none — never instrumented* | — |
+
+`getExperimentsForUser` in `ExperimentAssignmentService` is wrapped as a whole and is shared by the
+mark and assign paths — include it if either endpoint is selected.
+
+Note that `/v6/assign`'s top-level `getAllExperimentConditions` call is deliberately **not** wrapped
+in the controller: the service method is instrumented from the inside, so a controller span would
+only duplicate the envelope minus a few microseconds.
+
+## Conventions from the reference branch
+
+These are the rules the reference already applies. Follow them for a DRIFTED file, or for an
+endpoint the reference never covered.
+
+The goal is a timeline that **reconstructs with no unexplained gaps** — spans plus inter-span gaps
+should sum to the envelope.
+
+If you are extending past the inventory, work outside-in:
+
+1. **Start with the envelope only.** Run it. Read the gap between `┌` and the first child span, and
+   between the last child and `└`. Those are framework cost (parse/validate, serialize) and are
+   usually 0.5–2.5ms. If one is large, that is your lead.
+2. **Wrap the handler's top-level service call.** One span per endpoint. Now you know whether time
+   is in the handler or in the middleware around it.
+3. **Descend only into the span that dominates.** Wrap every `await` in that method, plus any
+   obviously expensive synchronous block. Re-run, find the new dominant span, repeat.
+
+What is worth a span:
+
+- **Every `await` in the request pipeline** — each is a DB round trip, a cache read, or an external
+  call. These are where the time is.
+- **Synchronous CPU blocks** — deep clones, `new Set(bigArray)`, large `map`/`reduce`, JSON
+  serialization. Use `tracePerfSync`. These matter far more than their own duration suggests:
+  they block the event loop and inflate *other* concurrent requests. Wrapping them is how you catch
+  a whole class of bug that per-request averages hide.
+- **Fan-out** — wrap both the aggregate and each item (`assignExperiments(experiments=3)` plus
+  `assignExperiment(<id>)`). The threshold keeps per-item spans quiet unless one is individually
+  slow, which is exactly how you identify a single bad item.
+
+Put **counts in the label** wherever a span's cost scales with a collection:
+`getAssignmentsAndExclusionsForUser(experiments=4)`, `dataLog(logs=12)`,
+`featureFlagLevelInclusionExclusion(flags=13)`. A duration without its N is not interpretable, and
+this is frequently the thing that cracks the case.
+
+**Label grammar — reproduce it exactly:**
+
+| Shape | When | From the reference |
+|---|---|---|
+| `camelCaseService.methodName` | calling out into another injected service | `experimentUserService.upsertOnChange`, `featureFlagService.getKeys` |
+| `ClassName.methodName` | inside a middleware | `ClientLibMiddleware.getClientCheck`, `UserCheckMiddleware.getUserDoc` |
+| `methodName` (bare) | a private helper on the class being traced | `getCachedExperiments`, `processExperimentPools` |
+| `label(thing=N)` | cost scales with a collection | `assignExperiments(experiments=3)`, `dataLog(logs=12)` |
+| `label(<id>)` | one span per item of a fan-out | `assignExperiment(abc-123)` |
+| `label[<index>]` | fan-out with no meaningful id | `createLog[0]` |
+
+The canonical call shape is an arrow function, which preserves `this` and leaves the arguments
+untouched — this is also why wrapping is a low-risk edit:
+
+```ts
+const result = await tracePerfAsync('service.method', () => this.service.method(a, b, logger));
+const value = tracePerfSync('cpuBlock', () => this.cpuBlock(input));
+```
+
+Comment the non-obvious ones the way the reference does — a line saying *why* a count is in the
+label (`// Experiment count is in the label because it sizes the IN (...) list on all four queries.`)
+is worth more later than the span itself.
+
+What **not** to wrap: trivial synchronous getters, pure field access, anything already inside a
+wrapped span that cannot itself be slow. Every span is a `console.log` under load.
+
+## Reading the output
+
+**Reconstruct the timeline by subtraction.** Spans nest; the gaps between them are the
+uninstrumented work. If spans plus gaps do not sum to the envelope, something significant is
+unmeasured — go find it.
+
+**`inflight` is the most important field.** With `inflight=1` throughout, you are not testing
+concurrency and cannot draw conclusions about contention, no matter how the durations look. If a
+load test shows `inflight=1`, the load generator is not producing concurrent requests at that
+endpoint — fix that before interpreting anything else.
+
+**Distinguishing the three causes of a spike** — this is what the shared clock is for:
+
+| Signature | Cause |
+|---|---|
+| Several overlapping requests all inflate, landing on nearly the same `end` mark; a gap in the log where nothing completes | Stop-the-world stall: major GC, or a synchronous block on the event loop |
+| One request inflates while `inflight` shows peers finishing normally | That request waited on something of its own — pool acquire, or a genuinely slow query |
+| A trivial span (a 1-row `SELECT`) inflates *while fully overlapping* another request's known CPU-heavy span | Event-loop blocking by that span. The strongest signal available — a query that cannot be slow, made slow by a neighbour |
+
+**A clean floor with occasional spikes is not pool saturation.** Pool exhaustion raises the floor.
+Bimodal-with-a-clean-floor points at a discrete stop-the-world event instead.
+
+**Cold-start artifacts.** node-postgres defaults `idleTimeoutMillis` to 10s and `max` to 10. A
+request arriving after >10s idle re-establishes connections; a 4-query `Promise.all` opens four at
+once. Before reading anything into a slow isolated request, fire two back-to-back under 10s apart —
+if the second is fast, it was connection establishment.
+
+**Client-observed time will exceed the envelope**, by network RTT plus the load generator's own
+overhead. At high thread counts JMeter is often CPU-bound itself. Don't chase that gap as if it were
+server time.
+
+**Before concluding "slow query", measure it.** Capture the real SQL (set `TYPEORM_LOGGING=true`, or
+attach a capturing `logger` to a `DataSource`) and run `EXPLAIN (ANALYZE, BUFFERS)` twice, reading
+the second. `shared hit` vs `shared read` tells you memory vs disk. Repeatedly in this codebase the
+server-side execution has been ~0.05ms while the app saw 3ms — meaning the cost was round trip and
+pool contention, not the query. That distinction changes the fix entirely: caching removes the round
+trip, whereas indexing would do nothing.
+
+## Why the harness looks like this
+
+Decisions that are load-bearing — do not "simplify" them away:
+
+- **Registered before `useExpressServer`.** Anywhere else and it misses middleware and serialization.
+- **`tracePerf*` no-ops outside a traced request.** Global middleware runs on excluded endpoints too;
+  without this gate their spans print unattributed and `PERF_TRACE_PATHS` stops isolating anything.
+- **Envelope ignores the threshold, children respect it.** Guarantees a `┌` always has its `└`.
+- **`inflight` logged before decrement**, so a request is counted in its own closing line.
+- **Both `finish` and `close` listeners**, so a client abort cannot leak the counter.
+- **Config read from `process.env`, not the typed `env` module.** Keeps the harness to one file so
+  teardown has almost nothing to unwind. `import '../../env'` is there purely so dotenv has run.
+- **A monotonic base-36 counter, not a uuid** — the hot path should not allocate to make an id.
+
+## Teardown
+
+`/teardown-perftrace` restores from the manifest. Keep the manifest accurate as you add spans, or
+teardown will leave instrumentation behind.

--- a/.claude/skills/setup-perftrace/assets/perfTrace.ts
+++ b/.claude/skills/setup-perftrace/assets/perfTrace.ts
@@ -1,0 +1,194 @@
+import { AsyncLocalStorage } from 'async_hooks';
+import { performance } from 'perf_hooks';
+import type { NextFunction, Request, Response } from 'express';
+// Imported for its side effect only: env.ts runs dotenv.config(), which must happen before the
+// process.env reads below. Config is read straight from process.env rather than through the typed
+// env module so this harness stays a single self-contained file — teardown deletes this file and
+// unpicks one middleware registration, with no edits to shared config to unwind.
+import '../../env';
+
+/**
+ * TEMPORARY request-correlated performance tracing. Installed by /setup-perftrace, removed by
+ * /teardown-perftrace. Not intended to be committed or maintained.
+ *
+ * Every span logs the id of the request it belongs to, how many traced requests were in flight when
+ * it closed, and its start/end marks on the shared `performance.now()` monotonic clock. Because all
+ * spans in a process share that one clock, marks from concurrent requests are directly comparable —
+ * which is what makes the output diagnostic rather than merely descriptive:
+ *
+ *   - A stop-the-world stall (major GC, a long synchronous block) delays every request awaiting at
+ *     that instant. Several requests with overlapping windows all inflate and land on nearly the
+ *     same `end` mark.
+ *   - Connection-pool queueing delays only the request that had to wait for a connection. One
+ *     duration inflates while `inflight` shows peers that finished normally.
+ *
+ * Output brackets each request so boundaries are findable in a busy log:
+ *
+ *   [perf] ┌───── req=005w inflight=2 start=243915.094 POST /api/v6/assign
+ *   [perf] │ req=005w inflight=2 dur=1.204ms start=… end=… span=UserCheckMiddleware.getUserDoc
+ *   [perf] └───── req=005w inflight=2 dur=21.412ms start=… end=… POST /api/v6/assign
+ *
+ * The ┌/└ envelope is emitted for every traced request. The threshold applies only to the child
+ * spans in between, so a fast request collapses to just its two envelope lines.
+ *
+ * Env vars:
+ *   PERF_TRACE_ENABLED        off unless 'true'
+ *   PERF_TRACE_THRESHOLD_MS   child spans below this are suppressed; 0 logs all of them
+ *   PERF_TRACE_PATHS          comma-separated URL substrings to trace; empty traces every request
+ *   PERF_TRACE_EXCLUDE_PATHS  comma-separated URL substrings to skip; wins over PERF_TRACE_PATHS
+ *
+ * isolate one endpoint:      PERF_TRACE_PATHS=/v6/assign
+ * watch everything:          leave both path vars empty
+ * all but the noisy ones:    PERF_TRACE_EXCLUDE_PATHS=/v6/log,/v6/mark
+ *
+ * Keep the threshold above zero under load: console.log to a TTY is a synchronous write, so tracing
+ * every span perturbs the very event-loop latency you are trying to measure.
+ */
+
+interface PerfTraceContext {
+  requestId: string;
+}
+
+const storage = new AsyncLocalStorage<PerfTraceContext>();
+
+function envFlag(name: string): boolean {
+  return process.env[name] === 'true';
+}
+
+function envList(name: string): string[] {
+  return (process.env[name] || '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function envNumber(name: string, fallback: number): number {
+  const parsed = parseInt(process.env[name] ?? '', 10);
+  return Number.isNaN(parsed) ? fallback : parsed;
+}
+
+const enabled = envFlag('PERF_TRACE_ENABLED');
+const thresholdMs = envNumber('PERF_TRACE_THRESHOLD_MS', 5);
+const tracedPaths = envList('PERF_TRACE_PATHS');
+const excludedPaths = envList('PERF_TRACE_EXCLUDE_PATHS');
+
+// Monotonic counter rather than a uuid — ids only need to be unique within one process lifetime,
+// and this keeps the hot path free of allocation-heavy id generation.
+let requestCounter = 0;
+let inFlight = 0;
+
+const RULE = '─'.repeat(5);
+
+function shouldTrace(path: string): boolean {
+  if (!enabled) {
+    return false;
+  }
+  // Exclusions win, so a broad include list can be narrowed without rewriting it.
+  if (excludedPaths.some((excluded) => path.includes(excluded))) {
+    return false;
+  }
+  // No configured paths means trace everything.
+  return tracedPaths.length === 0 || tracedPaths.some((tracedPath) => path.includes(tracedPath));
+}
+
+function logSpan(label: string, start: number, end: number, requestId: string): void {
+  const duration = end - start;
+  if (duration < thresholdMs) {
+    return;
+  }
+  console.log(
+    `[perf] │ req=${requestId} inflight=${inFlight} dur=${duration.toFixed(3)}ms ` +
+      `start=${start.toFixed(3)} end=${end.toFixed(3)} span=${label}`
+  );
+}
+
+/**
+ * Spans only log inside a traced request.
+ *
+ * Shared code — global middleware especially — runs on endpoints the path filter has excluded.
+ * Without this gate those spans would still print, unattributed, and narrowing PERF_TRACE_PATHS to
+ * one endpoint would not actually isolate its output. Gating on the presence of an
+ * AsyncLocalStorage context makes the path filter authoritative for everything beneath it.
+ */
+function ambientRequestId(): string | undefined {
+  return storage.getStore()?.requestId;
+}
+
+/**
+ * Outermost span. Register on the express app *before* the routing layer wires up its routes, so
+ * the envelope encloses everything the framework does on the request's behalf: CORS, body parsing,
+ * validation, per-route middleware, the handler, and response serialization.
+ *
+ * That placement is the whole point — an in-handler span misses the middleware work and the
+ * response serialization, which is exactly the gap between what the trace reports and what an
+ * external client (JMeter, curl) measures.
+ *
+ * Also establishes the request id that every nested tracePerf* call picks up via AsyncLocalStorage,
+ * so no request context has to be threaded through method signatures.
+ */
+export function perfTraceMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const path = req.originalUrl || req.url;
+  if (!shouldTrace(path)) {
+    next();
+    return;
+  }
+
+  const requestId = (++requestCounter).toString(36).padStart(4, '0');
+  const label = `${req.method} ${path}`;
+  const start = performance.now();
+  inFlight++;
+
+  console.log(`[perf] ┌${RULE} req=${requestId} inflight=${inFlight} start=${start.toFixed(3)} ${label}`);
+
+  let settled = false;
+  const close = () => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    const end = performance.now();
+    // Log before decrementing so `inflight` includes this request in its own line.
+    console.log(
+      `[perf] └${RULE} req=${requestId} inflight=${inFlight} dur=${(end - start).toFixed(3)}ms ` +
+        `start=${start.toFixed(3)} end=${end.toFixed(3)} ${label}`
+    );
+    inFlight--;
+  };
+
+  // 'finish' fires once the response is flushed to the socket, so the envelope covers serialization
+  // and the write. 'close' is the fallback for client aborts, so inFlight cannot leak.
+  res.on('finish', close);
+  res.on('close', close);
+
+  storage.run({ requestId }, () => next());
+}
+
+/** Times an awaited span against the ambient request id. No-op outside a traced request. */
+export async function tracePerfAsync<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  const requestId = enabled ? ambientRequestId() : undefined;
+  if (!requestId) {
+    return fn();
+  }
+
+  const start = performance.now();
+  try {
+    return await fn();
+  } finally {
+    logSpan(label, start, performance.now(), requestId);
+  }
+}
+
+/** Times a synchronous span against the ambient request id. No-op outside a traced request. */
+export function tracePerfSync<T>(label: string, fn: () => T): T {
+  const requestId = enabled ? ambientRequestId() : undefined;
+  if (!requestId) {
+    return fn();
+  }
+
+  const start = performance.now();
+  try {
+    return fn();
+  } finally {
+    logSpan(label, start, performance.now(), requestId);
+  }
+}

--- a/.claude/skills/teardown-perftrace/SKILL.md
+++ b/.claude/skills/teardown-perftrace/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: teardown-perftrace
+description: Remove the temporary performance tracing installed by /setup-perftrace from the UpGrade backend, restoring every touched file byte-exact from its snapshot. Use when finished profiling, when asked to "remove the perf traces", "clean up the instrumentation", or before committing a branch that was harnessed for tracing.
+---
+
+# teardown-perftrace
+
+Reverses `/setup-perftrace` using the snapshot manifest it left behind. Restoration is byte-exact,
+so re-indentation from wrapping code in callbacks unwinds cleanly — which is exactly what a
+comment-marker or regex approach cannot do reliably.
+
+## Step 1 — Read the manifest
+
+```bash
+cat .claude/.perftrace/manifest.json
+```
+
+If it is missing, do **not** start guessing at edits. Instead report that, and offer the fallback in
+[No manifest](#no-manifest).
+
+**Expect roughly seven entries, not two.** A fully instrumented install covers the harness file, the
+app loader, both client middlewares, the v6 controller, `ExperimentAssignmentService`, and
+`FeatureFlagService`. Fewer is legitimate — the user may have instrumented only one endpoint — so
+the manifest, not the expected footprint, is authoritative for *what to restore*. Use the footprint
+only as the stray check in Step 5: if the manifest lists two entries but the tree has `tracePerf`
+calls in five files, the manifest is incomplete and Step 5 is what will catch it.
+
+## Step 2 — Detect drift before restoring anything
+
+For every `modified` entry, compare the current file against `sha256AfterSetup`:
+
+```bash
+shasum -a 256 <path> | cut -d' ' -f1
+```
+
+- **Matches** — untouched since setup. Safe to restore silently.
+- **Differs** — the file changed after setup. Either you added spans in a later turn (expected), or
+  the user made unrelated edits (must not be lost).
+
+For every file that differs, show the user a diff of what restoring would discard:
+
+```bash
+diff <(cat .claude/.perftrace/backups/<backup>) <path>
+```
+
+If the only differences are perf spans, restore. If there is unrelated work mixed in, **stop and
+ask** — restoring would silently delete it. Offer to reapply their changes on top of the restored
+file instead.
+
+With a full install this check spans ~7 files, and a mismatch on the heavily instrumented ones
+(`ExperimentAssignmentService.ts` carries ~20 spans) is *expected* rather than alarming — setup
+fills in `sha256AfterSetup` per file, but any later turn that added a span leaves the hash stale.
+Read each diff on its own merits; do not batch-approve them because the first one looked routine.
+
+## Step 3 — Restore
+
+- `action: "modified"` → copy the backup back over the path.
+- `action: "created"` → delete the file.
+
+Then remove now-empty directories the setup created:
+
+```bash
+rmdir packages/backend/src/lib/perf 2>/dev/null || true
+```
+
+## Step 4 — Remove the env vars
+
+Strip the `PERF_TRACE_*` block from `packages/backend/.env`, including its comments. Leave
+`.env.example` and `.env.test` alone — setup never touches them.
+
+## Step 5 — Verify nothing is left behind
+
+```bash
+grep -rn "perfTrace\|tracePerfAsync\|tracePerfSync\|PERF_TRACE\|perfTraceMiddleware" \
+  packages/backend/src packages/backend/test packages/backend/.env 2>/dev/null
+```
+
+Expect zero hits. Any hit means a file was instrumented without being added to the manifest —
+remove it by hand and say so explicitly in your summary. This is the single most important check in
+this skill: the manifest can be incomplete, but a leftover `tracePerfAsync` import is a compile
+error waiting to happen once `perfTrace.ts` is deleted, and a leftover span is instrumentation that
+ships. Treat a non-empty result as a failed teardown, not a warning.
+
+To strip a stray by hand, recover the original shape from the reference branch rather than
+un-indenting by eye:
+
+```bash
+git show origin/reference/client-perftraces:<path> | grep -n tracePerf   # what setup added
+git diff origin/dev -- <path>                                            # what is left to undo
+```
+
+Confirm the app bootstrap is back to `createExpressServer`:
+
+```bash
+grep -n "createExpressServer\|useExpressServer" packages/backend/src/loaders/app/index.ts
+```
+
+Then:
+
+```bash
+cd packages/backend && npx tsc --noEmit && npx jest --config=jest.config.js test/unit
+```
+
+Finally, confirm the diff is clean — the branch should show no perf-related changes:
+
+```bash
+git status --short && git diff --stat
+```
+
+## Step 6 — Remove the manifest
+
+```bash
+rm -rf .claude/.perftrace
+```
+
+Report which files were restored, which were deleted, and anything you found that was not in the
+manifest.
+
+## No manifest
+
+If `.claude/.perftrace/manifest.json` is gone, fall back to git rather than hand-editing:
+
+1. `git status --short` and `git diff` to see what the harness touched.
+2. If the instrumentation is uncommitted, `git checkout -- <files>` for modified ones and delete
+   `packages/backend/src/lib/perf/perfTrace.ts`. **Check the diff first** — if unrelated uncommitted
+   work is in the same files, `git checkout` will destroy it. Ask before doing that.
+3. If it was committed, identify the commit and `git revert` it.
+4. Run the Step 5 verification either way.
+
+Say plainly that you worked without a manifest and that removal was inferred from the diff rather
+than restored from a snapshot.

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,15 @@
 .DS_Store
 .dccache
 node_modules
+# .claude holds local Claude Code state (settings, perftrace snapshots). Ignored by default, with
+# the committed subdirectories re-included below. Order matters: the directory has to be unignored
+# before git will descend into it, then its contents re-ignored, then the keepers negated.
 .claude*
+!.claude/
+.claude/*
+!.claude/skills/
+!.claude/plans/
 .vscode
-.claude
 setup_upgrade.sh
 .idea
 *.iml


### PR DESCRIPTION
`/setup-perftrace`
`/teardown-perftrace`

When invoking `/setup-perftrace` for Claude, it will reference the `reference/performance` branch among a list of other steps that will scaffold any branch with `tracePerfSync` and other wrapper functions to log the duration of a functions.

It will do some work to set up the necessary utilities and then it will prompt you to ask which endpoints it should actually build out the traces for.

For example if picking just `/assign`, it will wrap `tracePerfSync` around every function or operation that it either sees is instrumented in the reference branch, but also it will follow some conventions to identify new code if it is not part of the reference branch and could potentially be of interest to track the time of.

After selecting, it will do that work. It has some built in tests it does to verify this, which may take a little more time but i guess it ensures it'll work correctly right away.

Logs will looks something like this:
```
[backend] [perf] ┌───── req=0001 inflight=1 start=352080.970 POST /api/v6/assign
[backend] [perf] │ req=0001 inflight=1 dur=18.347ms start=352105.754 end=352124.101 span=UserCheckMiddleware.getUserDoc
[backend] [perf] │ req=0001 inflight=1 dur=1.940ms start=352124.497 end=352126.437 span=ClientLibMiddleware.getClientCheck
[backend] [perf] │ req=0001 inflight=1 dur=3.990ms start=352134.348 end=352138.339 span=previewUserService.findOneFromCache
[backend] [perf] │ req=0001 inflight=1 dur=85.457ms start=352138.493 end=352223.950 span=getExperimentsForUser
[backend] [perf] │ req=0001 inflight=1 dur=9.825ms start=352224.040 end=352233.865 span=checkUserOrGroupIsGloballyExcluded
[backend] [perf] │ req=0001 inflight=1 dur=0.156ms start=352233.914 end=352234.070 span=filterAndProcessGroupExperiments
[backend] [perf] │ req=0001 inflight=1 dur=8.744ms start=352234.101 end=352242.845 span=getAssignmentsAndExclusionsForUser(experiments=4)
[backend] [perf] │ req=0001 inflight=1 dur=3.002ms start=352242.964 end=352245.966 span=experimentLevelExclusionInclusion
[backend] [perf] │ req=0001 inflight=1 dur=0.591ms start=352246.022 end=352246.613 span=processExperimentPools
[backend] [perf] │ req=0001 inflight=1 dur=0.096ms start=352247.017 end=352247.113 span=assignExperiment(31d7d538-4e01-4c99-a3da-03d39721eb82)
[backend] [perf] │ req=0001 inflight=1 dur=0.422ms start=352246.728 end=352247.149 span=assignExperiment(9e489a13-d082-415a-8e0a-e0b36accb5a0)
[backend] [perf] │ req=0001 inflight=1 dur=0.131ms start=352247.031 end=352247.163 span=assignExperiment(781fd22b-f38a-416c-9408-3f0f0cad410d)
[backend] [perf] │ req=0001 inflight=1 dur=0.539ms start=352246.639 end=352247.179 span=assignExperiments(experiments=3)
[backend] [perf] │ req=0001 inflight=1 dur=1.549ms start=352247.209 end=352248.758 span=getRepeatedEnrollmentCount
[backend] [perf] │ req=0001 inflight=1 dur=1.087ms start=352248.797 end=352249.884 span=buildDecisionPoints
[backend] [perf] │ req=0001 inflight=1 dur=0.186ms start=352249.917 end=352250.103 span=formatAssignments
[backend] [perf] └───── req=0001 inflight=1 dur=174.785ms start=352080.970 end=352255.755 POST /api/v6/assign
```

you should be able to make changes directly on top of this, and then when finished, you should be able to run /teardown-perftrace to remove that scaffolding and then your changes should remain.

beta! 