### PR TITLE
split experiment/dp and monitored dp queries

### DIFF
--- a/packages/backend/src/api/services/ExperimentAssignmentService.ts
+++ b/packages/backend/src/api/services/ExperimentAssignmentService.ts
@@ -70,7 +70,7 @@ import { CacheService } from './CacheService';
 import { UserStratificationFactorRepository } from '../repositories/UserStratificationRepository';
 import { UserStratificationFactor } from '../models/UserStratificationFactor';
 import { RequestedExperimentUser } from '../controllers/validators/ExperimentUserValidator';
-import { In } from 'typeorm';
+import { Brackets, In } from 'typeorm';
 import { env } from '../../env';
 import { MoocletExperimentService } from './MoocletExperimentService';
 import { ExperimentPrecomputedSegmentService } from './ExperimentPrecomputedSegmentService';
@@ -134,33 +134,65 @@ export class ExperimentAssignmentService {
 
   private async getCachedExperiments(site: string, target: string): Promise<[DecisionPoint[], Experiment[]]> {
     const cacheKey = CACHE_PREFIX.MARK_KEY_PREFIX + '-' + site + '-' + target;
-    const dpExperiments = await this.cacheService.wrap(cacheKey, () =>
-      this.decisionPointRepository.find({
+    const cached = await this.cacheService.wrap(cacheKey, async () => {
+      // Keep the decision-point query minimal; hydrate heavy experiment relations separately.
+      const decisionPoints = await this.decisionPointRepository.find({
         where: {
-          site: site,
-          target: target,
+          site,
+          target,
         },
-        relations: {
+        select: {
+          id: true,
+          site: true,
+          target: true,
           experiment: {
-            conditions: {
-              conditionPayloads: true,
-            },
-
-            partitions: true,
-
-            experimentSegmentInclusion: {
-              segment: true,
-            },
-
-            experimentSegmentExclusion: {
-              segment: true,
-            },
+            id: true,
           },
         },
-      })
-    );
+        relations: {
+          experiment: true,
+        },
+      });
 
-    return [dpExperiments, dpExperiments.map((dp) => dp.experiment)];
+      const experimentIds = Array.from(
+        new Set(decisionPoints.map((dp) => dp.experiment?.id).filter((id): id is string => Boolean(id)))
+      );
+
+      if (experimentIds.length === 0) {
+        return { dpExperiments: [] as DecisionPoint[], experiments: [] as Experiment[] };
+      }
+
+      const experiments = await this.experimentRepository.find({
+        where: { id: In(experimentIds) },
+        relationLoadStrategy: 'query',
+        relations: {
+          conditions: {
+            conditionPayloads: true,
+          },
+          partitions: true,
+          experimentSegmentInclusion: {
+            segment: true,
+          },
+          experimentSegmentExclusion: {
+            segment: true,
+          },
+        },
+      });
+
+      const experimentById = new Map(experiments.map((experiment) => [experiment.id, experiment]));
+
+      const dpExperiments = decisionPoints
+        .map((dp) => {
+          const experiment = experimentById.get(dp.experiment?.id);
+          if (!experiment) return null;
+          return { ...dp, experiment } as DecisionPoint;
+        })
+        .filter((dp): dp is DecisionPoint => dp !== null);
+
+      return { dpExperiments, experiments };
+    });
+
+    return [cached.dpExperiments, cached.experiments];
   }
 
   public async markExperimentPoint(
@@ -1444,50 +1476,47 @@ export class ExperimentAssignmentService {
   }
 
   private async getMonitoredDocumentOfExperiment(experimentDoc: Experiment): Promise<MonitoredDecisionPoint[]> {
-    // get groupAssignment and individual assignment details
-    const decisionPoints = experimentDoc.partitions;
-    const individualAssignments = await this.individualEnrollmentRepository.find({
+    const userEnrollments = await this.individualEnrollmentRepository.find({
       where: { experiment: { id: experimentDoc.id } },
-      relations: {
-        user: true,
+      select: {
+        userId: true,
       },
     });
 
-    // get the monitored document for all the decisionPoints in the experiment
-    const experimentDecisionPointIds = decisionPoints.map(async (decisionPoint) => {
-      const target = decisionPoint.target;
-      const site = decisionPoint.site;
-      const decisionPointId = await this.decisionPointRepository.findOne({
-        where: {
-          site: site,
-          target: target,
-        },
-      });
-      return decisionPointId;
+    const userIds = Array.from(new Set(userEnrollments.map((enrollment) => enrollment.userId).filter(Boolean)));
+    if (userIds.length === 0 || experimentDoc.partitions.length === 0) {
+      return [];
+    }
+
+    const decisionPointPairs = Array.from(
+      new Set(experimentDoc.partitions.map((dp) => `${dp.site}__${dp.target ?? ''}`))
+    ).map((pair) => {
+      const [site, ...targetParts] = pair.split('__');
+      return { site, target: targetParts.join('__') };
     });
 
-    const monitoredDocumentIds = [];
-    individualAssignments.forEach((individualAssignment) => {
-      experimentDecisionPointIds.forEach(async (experimentDecisionPointId) => {
-        monitoredDocumentIds.push(
-          await this.monitoredDecisionPointRepository.findOne({
-            where: {
-              site: (await experimentDecisionPointId).site,
-              target: (await experimentDecisionPointId).target,
-              user: { id: individualAssignment.user.id },
-            },
-          })
-        );
-      });
-    });
+    if (decisionPointPairs.length === 0) {
+      return [];
+    }
 
-    // fetch all the monitored document if exist
-    const monitoredDocuments = await this.monitoredDecisionPointRepository.find({
-      where: { id: In(monitoredDocumentIds) },
-      relations: {
-        user: true,
-      },
-    });
+    const monitoredDocuments = await this.monitoredDecisionPointRepository
+      .createQueryBuilder('monitoredDecisionPoint')
+      .leftJoinAndSelect('monitoredDecisionPoint.user', 'user')
+      .where('user.id IN (:...userIds)', { userIds })
+      .andWhere(
+        new Brackets((qb) => {
+          decisionPointPairs.forEach((dp, index) => {
+            qb.orWhere(
+              `monitoredDecisionPoint.site = :site${index} AND COALESCE(monitoredDecisionPoint.target, '') = :target${index}`,
+              {
+                [`site${index}`]: dp.site,
+                [`target${index}`]: dp.target,
+              }
+            );
+          });
+        })
+      )
+      .getMany();
 
     return monitoredDocuments;
   }

--- a/packages/backend/src/api/services/ExperimentAssignmentService.ts
+++ b/packages/backend/src/api/services/ExperimentAssignmentService.ts
@@ -134,7 +134,7 @@ export class ExperimentAssignmentService {
 
   private async getCachedExperiments(site: string, target: string): Promise<[DecisionPoint[], Experiment[]]> {
     const cacheKey = CACHE_PREFIX.MARK_KEY_PREFIX + '-' + site + '-' + target;
-    const cached = await this.cacheService.wrap(cacheKey, async () => {
+    const dpExperiments = await this.cacheService.wrap(cacheKey, async () => {
       // Keep the decision-point query minimal; hydrate heavy experiment relations separately.
       const decisionPoints = await this.decisionPointRepository.find({
         where: {
@@ -159,7 +159,7 @@ export class ExperimentAssignmentService {
       );
 
       if (experimentIds.length === 0) {
-        return { dpExperiments: [] as DecisionPoint[], experiments: [] as Experiment[] };
+        return [] as DecisionPoint[];
       }
 
       const experiments = await this.experimentRepository.find({
@@ -181,18 +181,16 @@ export class ExperimentAssignmentService {
 
       const experimentById = new Map(experiments.map((experiment) => [experiment.id, experiment]));
 
-      const dpExperiments = decisionPoints
+      return decisionPoints
         .map((dp) => {
           const experiment = experimentById.get(dp.experiment?.id);
           if (!experiment) return null;
           return { ...dp, experiment } as DecisionPoint;
         })
         .filter((dp): dp is DecisionPoint => dp !== null);
-
-      return { dpExperiments, experiments };
     });
 
-    return [cached.dpExperiments, cached.experiments];
+    return [dpExperiments, dpExperiments.map((dp) => dp.experiment)];
   }
 
   public async markExperimentPoint(


### PR DESCRIPTION
times for the the two methods `updateEnrollmentExclusionDocumentsAndCheckEndingCriteria` and `getCachedExperiments` improved a bit in perftrace