### PR TITLE
Add list value filtering across experiments, feature flags, and segments

### DIFF
--- a/packages/backend/src/api/controllers/ExperimentController.ts
+++ b/packages/backend/src/api/controllers/ExperimentController.ts
@@ -786,7 +786,7 @@ export class ExperimentController {
    *                properties:
    *                  key:
    *                    type: string
-   *                    enum: [all, name, status, tag, context, id, decisionPoint]
+   *                    enum: [all, name, status, tag, context, id, decisionPoint, listValue]
    *                  string:
    *                    type: string
    *               sortParams:

--- a/packages/backend/src/api/controllers/FeatureFlagController.ts
+++ b/packages/backend/src/api/controllers/FeatureFlagController.ts
@@ -243,7 +243,7 @@ export class FeatureFlagsController {
    *                properties:
    *                  key:
    *                    type: string
-   *                    enum: [all, name, key, status, tag, context, listValue]
+   *                    enum: [all, name, key, status, tag, context, id, listValue]
    *                  string:
    *                    type: string
    *               sortParams:

--- a/packages/backend/src/api/controllers/FeatureFlagController.ts
+++ b/packages/backend/src/api/controllers/FeatureFlagController.ts
@@ -243,7 +243,7 @@ export class FeatureFlagsController {
    *                properties:
    *                  key:
    *                    type: string
-   *                    enum: [all, name, key, status, tag, context]
+   *                    enum: [all, name, key, status, tag, context, listValue]
    *                  string:
    *                    type: string
    *               sortParams:

--- a/packages/backend/src/api/controllers/SegmentController.ts
+++ b/packages/backend/src/api/controllers/SegmentController.ts
@@ -315,7 +315,7 @@ export class SegmentController {
    *                properties:
    *                  key:
    *                    type: string
-   *                    enum: [all, name, tag, context, listValue]
+   *                    enum: [all, name, tag, context, id, listValue]
    *                  string:
    *                    type: string
    *               sortParams:

--- a/packages/backend/src/api/controllers/SegmentController.ts
+++ b/packages/backend/src/api/controllers/SegmentController.ts
@@ -315,7 +315,7 @@ export class SegmentController {
    *                properties:
    *                  key:
    *                    type: string
-   *                    enum: [all, name, tag, context]
+   *                    enum: [all, name, tag, context, listValue]
    *                  string:
    *                    type: string
    *               sortParams:

--- a/packages/backend/src/api/controllers/validators/FeatureFlagsPaginatedParamsValidator.ts
+++ b/packages/backend/src/api/controllers/validators/FeatureFlagsPaginatedParamsValidator.ts
@@ -27,6 +27,7 @@ export enum FLAG_SEARCH_KEY {
   TAG = 'tag',
   CONTEXT = 'context',
   ID = 'id',
+  LIST_VALUE = 'listValue',
 }
 
 class IFeatureFlagSortParamsValidator {

--- a/packages/backend/src/api/controllers/validators/SegmentPaginatedParamsValidator.ts
+++ b/packages/backend/src/api/controllers/validators/SegmentPaginatedParamsValidator.ts
@@ -23,6 +23,7 @@ export enum SEGMENT_SEARCH_KEY {
   TAG = 'tag',
   CONTEXT = 'context',
   ID = 'id',
+  LIST_VALUE = 'listValue',
 }
 
 class ISegmentSortParamsValidator {

--- a/packages/backend/src/api/services/ExperimentService.ts
+++ b/packages/backend/src/api/services/ExperimentService.ts
@@ -88,6 +88,12 @@ import { FactorDTO } from '../DTO/FactorDTO';
 import { LevelDTO } from '../DTO/LevelDTO';
 import { CacheService } from './CacheService';
 import { QueryService } from './QueryService';
+import {
+  LIST_VALUE_SEARCH_PATTERN_PARAMETER,
+  buildListValueSearchPattern,
+  getListValueSearchPredicate,
+  isListValueSearchKey,
+} from './listValueSearchHelpers';
 import { ArchivedStats } from '../models/ArchivedStats';
 import { ArchivedStatsRepository } from '../repositories/ArchivedStatsRepository';
 import { isUUID, validate } from 'class-validator';
@@ -178,10 +184,18 @@ export class ExperimentService {
       .select('experiment.id')
       .leftJoin('experiment.partitions', 'partitions')
       .groupBy('experiment.id');
+    let listValueSearchPattern: string | undefined;
 
     if (searchParams && searchParams.string !== '') {
       const whereClause = this.paginatedSearchString(searchParams);
       paginatedParentSubQuery = paginatedParentSubQuery.andWhere(whereClause);
+      if (isListValueSearchKey(searchParams.key)) {
+        listValueSearchPattern = buildListValueSearchPattern(searchParams.string);
+        paginatedParentSubQuery = paginatedParentSubQuery.setParameter(
+          LIST_VALUE_SEARCH_PATTERN_PARAMETER,
+          listValueSearchPattern
+        );
+      }
     }
 
     // Filter out archived experiments unless specifically searching by status
@@ -210,6 +224,13 @@ export class ExperimentService {
       .leftJoinAndSelect('experiment.partitions', 'partitions')
       .leftJoinAndSelect('experiment.experimentSegmentInclusion', 'experimentSegmentInclusion')
       .where(`experiment.id IN ${paginatedParentSubQuery.getQuery()}`);
+
+    if (listValueSearchPattern) {
+      queryBuilderToReturn = queryBuilderToReturn.setParameter(
+        LIST_VALUE_SEARCH_PATTERN_PARAMETER,
+        listValueSearchPattern
+      );
+    }
 
     if (sortParams) {
       queryBuilderToReturn = queryBuilderToReturn
@@ -1862,6 +1883,7 @@ export class ExperimentService {
       searchArray.push(`partitions.target ${likeString}`);
       searchArray.push(decisionPointDisplaySearch);
     };
+    const listValueSearch = getListValueSearchPredicate('experiment');
 
     switch (type) {
       case EXPERIMENT_SEARCH_KEY.NAME:
@@ -1882,12 +1904,18 @@ export class ExperimentService {
       case EXPERIMENT_SEARCH_KEY.DECISION_POINT:
         addDecisionPointSearch();
         break;
+      case EXPERIMENT_SEARCH_KEY.LIST_VALUE:
+        searchArray.push(listValueSearch);
+        break;
       default:
         searchArray.push(`name ${likeString}`);
         searchArray.push(`state::TEXT = '${this.mapStatusStrings(searchString)}'`);
         searchArray.push(`ARRAY_TO_STRING(context, ',') ${likeString}`);
         searchArray.push(`ARRAY_TO_STRING(tags, ',') ${likeString}`);
         addDecisionPointSearch();
+        if (type === EXPERIMENT_SEARCH_KEY.ALL) {
+          searchArray.push(listValueSearch);
+        }
         if (isUUID(searchString)) {
           searchArray.push(`experiment.id = '${searchString}'`);
         }

--- a/packages/backend/src/api/services/FeatureFlagService.ts
+++ b/packages/backend/src/api/services/FeatureFlagService.ts
@@ -63,6 +63,12 @@ import { SegmentFile, SegmentInputValidator } from '../controllers/validators/Se
 import dayjs from 'dayjs';
 import { getDateRangeNames } from '../repositories/utils/dateQuery';
 import { FeatureFlagExposure } from '../models/FeatureFlagExposure';
+import {
+  LIST_VALUE_SEARCH_PATTERN_PARAMETER,
+  buildListValueSearchPattern,
+  getListValueSearchPredicate,
+  isListValueSearchKey,
+} from './listValueSearchHelpers';
 
 @Service()
 export class FeatureFlagService {
@@ -268,9 +274,15 @@ export class FeatureFlagService {
     logger.info({ message: 'Find paginated Feature flags' });
 
     let queryBuilder = this.featureFlagRepository.createQueryBuilder('feature_flag');
-    if (searchParams) {
+    if (searchParams && searchParams.string !== '') {
       const whereClause = this.paginatedSearchString(searchParams);
       queryBuilder = queryBuilder.where(whereClause);
+      if (isListValueSearchKey(searchParams.key)) {
+        queryBuilder = queryBuilder.setParameter(
+          LIST_VALUE_SEARCH_PATTERN_PARAMETER,
+          buildListValueSearchPattern(searchParams.string)
+        );
+      }
     }
     if (sortParams) {
       queryBuilder = queryBuilder.addOrderBy(`feature_flag.${sortParams.key}`, sortParams.sortAs);
@@ -1040,6 +1052,7 @@ export class FeatureFlagService {
     }
     const likeString = `ILIKE '%${searchString}%'`;
     const searchArray: string[] = [];
+    const listValueSearch = getListValueSearchPredicate('featureFlag');
     switch (type) {
       case FLAG_SEARCH_KEY.NAME:
         searchArray.push(`${type} ${likeString}`);
@@ -1056,11 +1069,17 @@ export class FeatureFlagService {
       case FLAG_SEARCH_KEY.ID:
         searchArray.push(`feature_flag.id = '${searchString}'`);
         break;
+      case FLAG_SEARCH_KEY.LIST_VALUE:
+        searchArray.push(listValueSearch);
+        break;
       default:
         searchArray.push(`name ${likeString}`);
         searchArray.push(`status::TEXT ${likeString}`);
         searchArray.push(`ARRAY_TO_STRING(context, ',') ${likeString}`);
         searchArray.push(`ARRAY_TO_STRING(tags, ',') ${likeString}`);
+        if (type === FLAG_SEARCH_KEY.ALL) {
+          searchArray.push(listValueSearch);
+        }
         if (isUUID(searchString)) {
           searchArray.push(`feature_flag.id = '${searchString}'`);
         }

--- a/packages/backend/src/api/services/SegmentService.ts
+++ b/packages/backend/src/api/services/SegmentService.ts
@@ -12,7 +12,6 @@ import {
   CACHE_PREFIX,
   IMPORT_COMPATIBILITY_TYPE,
   ValidatedImportResponse,
-  SEGMENT_SEARCH_KEY,
   DuplicateSegmentNameError,
   EXPERIMENT_STATE_DISPLAY_NAME_OVERRIDES,
   EXPERIMENT_STATE,
@@ -41,9 +40,19 @@ import { ExperimentPrecomputedSegmentService } from './ExperimentPrecomputedSegm
 import { isUUID, validate } from 'class-validator';
 import { plainToClass } from 'class-transformer';
 import path from 'path';
-import { ISegmentSearchParams, ISegmentSortParams } from '../controllers/validators/SegmentPaginatedParamsValidator';
+import {
+  ISegmentSearchParams,
+  ISegmentSortParams,
+  SEGMENT_SEARCH_KEY,
+} from '../controllers/validators/SegmentPaginatedParamsValidator';
 import { ExperimentSegmentExclusion } from 'src/api/models/ExperimentSegmentExclusion';
 import { ExperimentSegmentInclusion } from 'src/api/models/ExperimentSegmentInclusion';
+import {
+  LIST_VALUE_SEARCH_PATTERN_PARAMETER,
+  buildListValueSearchPattern,
+  getListValueSearchPredicate,
+  isListValueSearchKey,
+} from './listValueSearchHelpers';
 
 interface IsSegmentValidWithError {
   missingProperty: string;
@@ -214,10 +223,18 @@ export class SegmentService {
       .subQuery()
       .from(Segment, 'segment')
       .select('segment.id');
+    let listValueSearchPattern: string | undefined;
 
-    if (searchParams) {
+    if (searchParams && searchParams.string !== '') {
       const whereClause = this.paginatedSearchString(searchParams);
       paginatedParentSubQuery = paginatedParentSubQuery.where(whereClause);
+      if (isListValueSearchKey(searchParams.key)) {
+        listValueSearchPattern = buildListValueSearchPattern(searchParams.string);
+        paginatedParentSubQuery = paginatedParentSubQuery.setParameter(
+          LIST_VALUE_SEARCH_PATTERN_PARAMETER,
+          listValueSearchPattern
+        );
+      }
     }
 
     if (sortParams) {
@@ -241,6 +258,10 @@ export class SegmentService {
       .setParameter('type', SEGMENT_TYPE.PUBLIC)
       .where(`segment.id IN ${paginatedParentSubQuery.getQuery()}`);
 
+    if (listValueSearchPattern) {
+      segmentsDataQuery = segmentsDataQuery.setParameter(LIST_VALUE_SEARCH_PATTERN_PARAMETER, listValueSearchPattern);
+    }
+
     if (sortParams) {
       segmentsDataQuery = segmentsDataQuery
         .addOrderBy(`segment.${sortParams.key}`, sortParams.sortAs)
@@ -261,6 +282,7 @@ export class SegmentService {
     }
     const likeString = `ILIKE '%${searchString}%'`;
     const searchArray: string[] = [];
+    const listValueSearch = getListValueSearchPredicate('segment');
     switch (type) {
       case SEGMENT_SEARCH_KEY.NAME || SEGMENT_SEARCH_KEY.CONTEXT:
         searchArray.push(`${type} ${likeString}`);
@@ -271,10 +293,16 @@ export class SegmentService {
       case SEGMENT_SEARCH_KEY.ID:
         searchArray.push(`segment.id = '${searchString}'`);
         break;
+      case SEGMENT_SEARCH_KEY.LIST_VALUE:
+        searchArray.push(listValueSearch);
+        break;
       default:
         searchArray.push(`${SEGMENT_SEARCH_KEY.NAME} ${likeString}`);
         searchArray.push(`${SEGMENT_SEARCH_KEY.CONTEXT} ${likeString}`);
         searchArray.push(`ARRAY_TO_STRING(tags, ',') ${likeString}`);
+        if (type === SEGMENT_SEARCH_KEY.ALL) {
+          searchArray.push(listValueSearch);
+        }
         if (isUUID(searchString)) {
           searchArray.push(`segment.id = '${searchString}'`);
         }

--- a/packages/backend/src/api/services/listValueSearchHelpers.ts
+++ b/packages/backend/src/api/services/listValueSearchHelpers.ts
@@ -1,0 +1,78 @@
+import { FILTER_MODE } from 'upgrade_types';
+
+export const LIST_VALUE_SEARCH_PATTERN_PARAMETER = 'listValueSearchPattern';
+
+export type ListValueSearchTarget = 'experiment' | 'featureFlag' | 'segment';
+
+const matchingSegmentIdsQuery = `
+  WITH RECURSIVE "directListValueSegments" AS (
+    SELECT "segmentId" AS "id"
+    FROM "individual_for_segment"
+    WHERE "userId" ILIKE :${LIST_VALUE_SEARCH_PATTERN_PARAMETER} ESCAPE '\\'
+    UNION
+    SELECT "segmentId" AS "id"
+    FROM "group_for_segment"
+    WHERE "groupId" ILIKE :${LIST_VALUE_SEARCH_PATTERN_PARAMETER} ESCAPE '\\'
+  ),
+  "matchingListValueSegments" AS (
+    SELECT "id"
+    FROM "directListValueSegments"
+    UNION
+    SELECT "segmentRelation"."parentSegmentId" AS "id"
+    FROM "segment_for_segment" "segmentRelation"
+    INNER JOIN "matchingListValueSegments" "matchedSegment"
+      ON "segmentRelation"."childSegmentId" = "matchedSegment"."id"
+  )
+  SELECT "id"
+  FROM "matchingListValueSegments"
+`;
+
+const ownerSearchConfig = {
+  experiment: {
+    ownerAlias: 'experiment',
+    ownerIdColumn: 'experimentId',
+    inclusionTable: 'experiment_segment_inclusion',
+    exclusionTable: 'experiment_segment_exclusion',
+  },
+  featureFlag: {
+    ownerAlias: 'feature_flag',
+    ownerIdColumn: 'featureFlagId',
+    inclusionTable: 'feature_flag_segment_inclusion',
+    exclusionTable: 'feature_flag_segment_exclusion',
+  },
+} as const;
+
+export function buildListValueSearchPattern(searchString: string): string {
+  const escapedSearchString = searchString.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
+  return `%${escapedSearchString}%`;
+}
+
+export function isListValueSearchKey(searchKey: string): boolean {
+  return searchKey === 'all' || searchKey === 'listValue';
+}
+
+export function getListValueSearchPredicate(target: ListValueSearchTarget): string {
+  if (target === 'segment') {
+    return `segment.id IN (${matchingSegmentIdsQuery})`;
+  }
+
+  const config = ownerSearchConfig[target];
+  return `EXISTS (
+    SELECT 1
+    FROM (
+      SELECT "segmentId", "${config.ownerIdColumn}" AS "ownerId",
+        TRUE AS "isInclusion"
+      FROM "${config.inclusionTable}"
+      UNION ALL
+      SELECT "segmentId", "${config.ownerIdColumn}" AS "ownerId",
+        FALSE AS "isInclusion"
+      FROM "${config.exclusionTable}"
+    ) "attachedList"
+    WHERE "attachedList"."ownerId" = ${config.ownerAlias}.id
+      AND (
+        "attachedList"."isInclusion" = FALSE
+        OR ${config.ownerAlias}."filterMode" <> '${FILTER_MODE.INCLUDE_ALL}'
+      )
+      AND "attachedList"."segmentId" IN (${matchingSegmentIdsQuery})
+  )`;
+}

--- a/packages/backend/src/api/services/listValueSearchHelpers.ts
+++ b/packages/backend/src/api/services/listValueSearchHelpers.ts
@@ -4,8 +4,7 @@ export const LIST_VALUE_SEARCH_PATTERN_PARAMETER = 'listValueSearchPattern';
 
 export type ListValueSearchTarget = 'experiment' | 'featureFlag' | 'segment';
 
-const matchingSegmentIdsQuery = `
-  WITH RECURSIVE "directListValueSegments" AS (
+const matchingSegmentIdsCte = `WITH RECURSIVE "directListValueSegments" AS (
     SELECT "segmentId" AS "id"
     FROM "individual_for_segment"
     WHERE "userId" ILIKE :${LIST_VALUE_SEARCH_PATTERN_PARAMETER} ESCAPE '\\'
@@ -22,20 +21,19 @@ const matchingSegmentIdsQuery = `
     FROM "segment_for_segment" "segmentRelation"
     INNER JOIN "matchingListValueSegments" "matchedSegment"
       ON "segmentRelation"."childSegmentId" = "matchedSegment"."id"
-  )
-  SELECT "id"
-  FROM "matchingListValueSegments"
-`;
+  )`;
 
 const ownerSearchConfig = {
   experiment: {
     ownerAlias: 'experiment',
+    ownerTable: 'experiment',
     ownerIdColumn: 'experimentId',
     inclusionTable: 'experiment_segment_inclusion',
     exclusionTable: 'experiment_segment_exclusion',
   },
   featureFlag: {
     ownerAlias: 'feature_flag',
+    ownerTable: 'feature_flag',
     ownerIdColumn: 'featureFlagId',
     inclusionTable: 'feature_flag_segment_inclusion',
     exclusionTable: 'feature_flag_segment_exclusion',
@@ -53,26 +51,33 @@ export function isListValueSearchKey(searchKey: string): boolean {
 
 export function getListValueSearchPredicate(target: ListValueSearchTarget): string {
   if (target === 'segment') {
-    return `segment.id IN (${matchingSegmentIdsQuery})`;
+    return `segment.id IN (
+    ${matchingSegmentIdsCte}
+    SELECT "id"
+    FROM "matchingListValueSegments"
+  )`;
   }
 
   const config = ownerSearchConfig[target];
-  return `EXISTS (
-    SELECT 1
-    FROM (
-      SELECT "segmentId", "${config.ownerIdColumn}" AS "ownerId",
-        TRUE AS "isInclusion"
-      FROM "${config.inclusionTable}"
-      UNION ALL
-      SELECT "segmentId", "${config.ownerIdColumn}" AS "ownerId",
-        FALSE AS "isInclusion"
-      FROM "${config.exclusionTable}"
-    ) "attachedList"
-    WHERE "attachedList"."ownerId" = ${config.ownerAlias}.id
-      AND (
-        "attachedList"."isInclusion" = FALSE
-        OR ${config.ownerAlias}."filterMode" <> '${FILTER_MODE.INCLUDE_ALL}'
+  // Include All makes inclusion lists inapplicable. Feature flag list enabled state is intentionally
+  // ignored because this search discovers attached configuration, not assignment eligibility.
+  return `${config.ownerAlias}.id IN (
+    ${matchingSegmentIdsCte}
+    SELECT "listValueInclusion"."${config.ownerIdColumn}"
+    FROM "${config.inclusionTable}" "listValueInclusion"
+    INNER JOIN "${config.ownerTable}" "listValueOwner"
+      ON "listValueOwner".id = "listValueInclusion"."${config.ownerIdColumn}"
+    WHERE "listValueOwner"."filterMode" <> '${FILTER_MODE.INCLUDE_ALL}'
+      AND "listValueInclusion"."segmentId" IN (
+        SELECT "id"
+        FROM "matchingListValueSegments"
       )
-      AND "attachedList"."segmentId" IN (${matchingSegmentIdsQuery})
+    UNION
+    SELECT "listValueExclusion"."${config.ownerIdColumn}"
+    FROM "${config.exclusionTable}" "listValueExclusion"
+    WHERE "listValueExclusion"."segmentId" IN (
+      SELECT "id"
+      FROM "matchingListValueSegments"
+    )
   )`;
 }

--- a/packages/backend/test/integration/ListValueFiltering/index.ts
+++ b/packages/backend/test/integration/ListValueFiltering/index.ts
@@ -80,7 +80,7 @@ export async function ListValueFiltering(): Promise<void> {
   });
   const nestedExperimentList = dataSource.getRepository(Segment).create({
     id: crypto.randomUUID(),
-    name: 'Nested public segment',
+    name: 'Nested experiment list',
     description: '',
     context,
     type: SEGMENT_TYPE.PRIVATE,
@@ -89,7 +89,7 @@ export async function ListValueFiltering(): Promise<void> {
   });
   const includeAllNestedExperimentList = dataSource.getRepository(Segment).create({
     id: crypto.randomUUID(),
-    name: 'Nested public segment',
+    name: 'Include-all nested experiment list',
     description: '',
     context,
     type: SEGMENT_TYPE.PRIVATE,
@@ -98,7 +98,7 @@ export async function ListValueFiltering(): Promise<void> {
   });
   const activeNestedFeatureFlagList = dataSource.getRepository(Segment).create({
     id: crypto.randomUUID(),
-    name: 'Nested public segment',
+    name: 'Active nested feature flag list',
     description: '',
     context,
     type: SEGMENT_TYPE.PRIVATE,
@@ -107,7 +107,7 @@ export async function ListValueFiltering(): Promise<void> {
   });
   const includeAllNestedFeatureFlagList = dataSource.getRepository(Segment).create({
     id: crypto.randomUUID(),
-    name: 'Nested public segment',
+    name: 'Include-all nested feature flag list',
     description: '',
     context,
     type: SEGMENT_TYPE.PRIVATE,
@@ -116,7 +116,7 @@ export async function ListValueFiltering(): Promise<void> {
   });
   const disabledNestedFeatureFlagList = dataSource.getRepository(Segment).create({
     id: crypto.randomUUID(),
-    name: 'Nested public segment',
+    name: 'Disabled nested feature flag list',
     description: '',
     context,
     type: SEGMENT_TYPE.PRIVATE,

--- a/packages/backend/test/integration/ListValueFiltering/index.ts
+++ b/packages/backend/test/integration/ListValueFiltering/index.ts
@@ -1,0 +1,360 @@
+import Container from 'typedi';
+import {
+  ASSIGNMENT_UNIT,
+  CONSISTENCY_RULE,
+  EXPERIMENT_SEARCH_KEY,
+  EXPERIMENT_STATE,
+  EXPERIMENT_TYPE,
+  FEATURE_FLAG_STATUS,
+  FILTER_MODE,
+  POST_EXPERIMENT_RULE,
+  SEGMENT_TYPE,
+} from 'upgrade_types';
+import { Experiment } from '../../../src/api/models/Experiment';
+import { ExperimentSegmentExclusion } from '../../../src/api/models/ExperimentSegmentExclusion';
+import { ExperimentSegmentInclusion } from '../../../src/api/models/ExperimentSegmentInclusion';
+import { FeatureFlag } from '../../../src/api/models/FeatureFlag';
+import { FeatureFlagSegmentExclusion } from '../../../src/api/models/FeatureFlagSegmentExclusion';
+import { FeatureFlagSegmentInclusion } from '../../../src/api/models/FeatureFlagSegmentInclusion';
+import { GroupForSegment } from '../../../src/api/models/GroupForSegment';
+import { IndividualForSegment } from '../../../src/api/models/IndividualForSegment';
+import { Segment } from '../../../src/api/models/Segment';
+import { FLAG_SEARCH_KEY } from '../../../src/api/controllers/validators/FeatureFlagsPaginatedParamsValidator';
+import { SEGMENT_SEARCH_KEY } from '../../../src/api/controllers/validators/SegmentPaginatedParamsValidator';
+import { ExperimentService } from '../../../src/api/services/ExperimentService';
+import { FeatureFlagService } from '../../../src/api/services/FeatureFlagService';
+import { SegmentService } from '../../../src/api/services/SegmentService';
+import { UpgradeLogger } from '../../../src/lib/logger/UpgradeLogger';
+import { Container as typeOrmContainer } from '../../../src/typeorm-typedi-extensions';
+
+export async function ListValueFiltering(): Promise<void> {
+  const dataSource = typeOrmContainer.getDataSource();
+  if (!dataSource) {
+    throw new Error('Default data source is not available');
+  }
+  const context = 'home';
+
+  const directExperimentList = dataSource.getRepository(Segment).create({
+    id: crypto.randomUUID(),
+    name: 'Direct experiment list',
+    description: '',
+    context,
+    type: SEGMENT_TYPE.PRIVATE,
+    listType: 'Individual',
+    tags: [],
+  });
+  const directFeatureFlagList = dataSource.getRepository(Segment).create({
+    id: crypto.randomUUID(),
+    name: 'Direct feature flag list',
+    description: '',
+    context,
+    type: SEGMENT_TYPE.PRIVATE,
+    listType: 'Individual',
+    tags: [],
+  });
+  const directSegmentList = dataSource.getRepository(Segment).create({
+    id: crypto.randomUUID(),
+    name: 'Direct segment list',
+    description: '',
+    context,
+    type: SEGMENT_TYPE.PRIVATE,
+    listType: 'Individual',
+    tags: [],
+  });
+  const directPublicSegment = dataSource.getRepository(Segment).create({
+    id: crypto.randomUUID(),
+    name: 'Direct public segment',
+    description: '',
+    context,
+    type: SEGMENT_TYPE.PUBLIC,
+    tags: [],
+  });
+  const nestedList = dataSource.getRepository(Segment).create({
+    id: crypto.randomUUID(),
+    name: 'Nested list',
+    description: '',
+    context,
+    type: SEGMENT_TYPE.PRIVATE,
+    listType: 'home-group1',
+    tags: [],
+  });
+  const nestedExperimentList = dataSource.getRepository(Segment).create({
+    id: crypto.randomUUID(),
+    name: 'Nested public segment',
+    description: '',
+    context,
+    type: SEGMENT_TYPE.PRIVATE,
+    listType: 'Segment',
+    tags: [],
+  });
+  const includeAllNestedExperimentList = dataSource.getRepository(Segment).create({
+    id: crypto.randomUUID(),
+    name: 'Nested public segment',
+    description: '',
+    context,
+    type: SEGMENT_TYPE.PRIVATE,
+    listType: 'Segment',
+    tags: [],
+  });
+  const activeNestedFeatureFlagList = dataSource.getRepository(Segment).create({
+    id: crypto.randomUUID(),
+    name: 'Nested public segment',
+    description: '',
+    context,
+    type: SEGMENT_TYPE.PRIVATE,
+    listType: 'Segment',
+    tags: [],
+  });
+  const includeAllNestedFeatureFlagList = dataSource.getRepository(Segment).create({
+    id: crypto.randomUUID(),
+    name: 'Nested public segment',
+    description: '',
+    context,
+    type: SEGMENT_TYPE.PRIVATE,
+    listType: 'Segment',
+    tags: [],
+  });
+  const disabledNestedFeatureFlagList = dataSource.getRepository(Segment).create({
+    id: crypto.randomUUID(),
+    name: 'Nested public segment',
+    description: '',
+    context,
+    type: SEGMENT_TYPE.PRIVATE,
+    listType: 'Segment',
+    tags: [],
+  });
+  const nestedPublicSegment = dataSource.getRepository(Segment).create({
+    id: crypto.randomUUID(),
+    name: 'Nested public segment',
+    description: '',
+    context,
+    type: SEGMENT_TYPE.PUBLIC,
+    tags: [],
+  });
+  const nonmatchingExperimentList = dataSource.getRepository(Segment).create({
+    id: crypto.randomUUID(),
+    name: 'Nonmatching experiment list',
+    description: '',
+    context,
+    type: SEGMENT_TYPE.PRIVATE,
+    listType: 'Individual',
+    tags: [],
+  });
+  const nonmatchingFeatureFlagList = dataSource.getRepository(Segment).create({
+    id: crypto.randomUUID(),
+    name: 'Nonmatching feature flag list',
+    description: '',
+    context,
+    type: SEGMENT_TYPE.PRIVATE,
+    listType: 'Individual',
+    tags: [],
+  });
+
+  await dataSource
+    .getRepository(Segment)
+    .save([
+      directExperimentList,
+      directFeatureFlagList,
+      directSegmentList,
+      directPublicSegment,
+      nestedList,
+      nestedExperimentList,
+      includeAllNestedExperimentList,
+      activeNestedFeatureFlagList,
+      includeAllNestedFeatureFlagList,
+      disabledNestedFeatureFlagList,
+      nestedPublicSegment,
+      nonmatchingExperimentList,
+      nonmatchingFeatureFlagList,
+    ]);
+  await dataSource.getRepository(IndividualForSegment).save([
+    { segmentId: directExperimentList.id, userId: 'CAPublicRe7EB2QN' },
+    { segmentId: directFeatureFlagList.id, userId: 'CAPublicRe7EB2QN' },
+    { segmentId: directSegmentList.id, userId: 'CAPublicRe7EB2QN' },
+    { segmentId: nonmatchingExperimentList.id, userId: 'different-school-id' },
+    { segmentId: nonmatchingFeatureFlagList.id, userId: 'different-school-id' },
+  ]);
+  await dataSource.getRepository(GroupForSegment).save({
+    segmentId: nestedList.id,
+    groupId: 'District-Alpha-9000',
+    type: 'home-group1',
+  });
+  await dataSource.query(
+    `INSERT INTO "segment_for_segment" ("childSegmentId", "parentSegmentId") VALUES
+      ($1, $2), ($3, $4), ($5, $6), ($7, $8), ($9, $10), ($11, $12), ($13, $14)`,
+    [
+      directSegmentList.id,
+      directPublicSegment.id,
+      nestedList.id,
+      nestedPublicSegment.id,
+      nestedPublicSegment.id,
+      nestedExperimentList.id,
+      nestedPublicSegment.id,
+      includeAllNestedExperimentList.id,
+      nestedPublicSegment.id,
+      activeNestedFeatureFlagList.id,
+      nestedPublicSegment.id,
+      includeAllNestedFeatureFlagList.id,
+      nestedPublicSegment.id,
+      disabledNestedFeatureFlagList.id,
+    ]
+  );
+
+  const experimentRepository = dataSource.getRepository(Experiment);
+  const createExperiment = (name: string, filterMode = FILTER_MODE.EXCLUDE_ALL): Experiment =>
+    experimentRepository.create({
+      id: crypto.randomUUID(),
+      name,
+      description: '',
+      context: [context],
+      state: EXPERIMENT_STATE.INACTIVE,
+      consistencyRule: CONSISTENCY_RULE.INDIVIDUAL,
+      assignmentUnit: ASSIGNMENT_UNIT.INDIVIDUAL,
+      postExperimentRule: POST_EXPERIMENT_RULE.CONTINUE,
+      tags: [],
+      filterMode,
+      type: EXPERIMENT_TYPE.SIMPLE,
+    });
+  const directExperiment = createExperiment('Direct list experiment');
+  const nestedExperiment = createExperiment('Nested list experiment', FILTER_MODE.INCLUDE_ALL);
+  const includeAllNestedExperiment = createExperiment(
+    'Include-all nested inclusion experiment',
+    FILTER_MODE.INCLUDE_ALL
+  );
+  const nonmatchingExperiment = createExperiment('Nonmatching experiment');
+  await experimentRepository.save([
+    directExperiment,
+    nestedExperiment,
+    includeAllNestedExperiment,
+    nonmatchingExperiment,
+  ]);
+  await dataSource.getRepository(ExperimentSegmentInclusion).save([
+    { experimentId: directExperiment.id, segmentId: directExperimentList.id },
+    { experimentId: includeAllNestedExperiment.id, segmentId: includeAllNestedExperimentList.id },
+    { experimentId: nonmatchingExperiment.id, segmentId: nonmatchingExperimentList.id },
+  ]);
+  await dataSource.getRepository(ExperimentSegmentExclusion).save({
+    experimentId: nestedExperiment.id,
+    segmentId: nestedExperimentList.id,
+  });
+
+  const featureFlagRepository = dataSource.getRepository(FeatureFlag);
+  const createFeatureFlag = (
+    name: string,
+    key: string,
+    filterMode = FILTER_MODE.INCLUDE_ALL,
+    status = FEATURE_FLAG_STATUS.ENABLED
+  ): FeatureFlag =>
+    featureFlagRepository.create({
+      id: crypto.randomUUID(),
+      name,
+      key,
+      description: '',
+      context: [context],
+      tags: [],
+      status,
+      filterMode,
+    });
+  const directFeatureFlag = createFeatureFlag('Direct list flag', 'DIRECT_LIST_FLAG');
+  const disabledFeatureFlagWithActiveNestedList = createFeatureFlag(
+    'Disabled flag with active nested list',
+    'DISABLED_FLAG_ACTIVE_NESTED_LIST',
+    FILTER_MODE.EXCLUDE_ALL,
+    FEATURE_FLAG_STATUS.DISABLED
+  );
+  const includeAllNestedFeatureFlag = createFeatureFlag('Include-all nested list flag', 'INCLUDE_ALL_NESTED_LIST_FLAG');
+  const enabledFeatureFlagWithDisabledNestedList = createFeatureFlag(
+    'Enabled flag with disabled nested list',
+    'ENABLED_FLAG_DISABLED_NESTED_LIST',
+    FILTER_MODE.EXCLUDE_ALL
+  );
+  const nonmatchingFeatureFlag = createFeatureFlag('Nonmatching flag', 'NONMATCHING_FLAG', FILTER_MODE.EXCLUDE_ALL);
+  await featureFlagRepository.save([
+    directFeatureFlag,
+    disabledFeatureFlagWithActiveNestedList,
+    includeAllNestedFeatureFlag,
+    enabledFeatureFlagWithDisabledNestedList,
+    nonmatchingFeatureFlag,
+  ]);
+  await dataSource.getRepository(FeatureFlagSegmentExclusion).save({
+    featureFlagId: directFeatureFlag.id,
+    segmentId: directFeatureFlagList.id,
+    enabled: false,
+    listType: 'Individual',
+  });
+  await dataSource.getRepository(FeatureFlagSegmentInclusion).save([
+    {
+      featureFlagId: disabledFeatureFlagWithActiveNestedList.id,
+      segmentId: activeNestedFeatureFlagList.id,
+      enabled: true,
+      listType: 'Segment',
+    },
+    {
+      featureFlagId: includeAllNestedFeatureFlag.id,
+      segmentId: includeAllNestedFeatureFlagList.id,
+      enabled: true,
+      listType: 'Segment',
+    },
+    {
+      featureFlagId: enabledFeatureFlagWithDisabledNestedList.id,
+      segmentId: disabledNestedFeatureFlagList.id,
+      enabled: false,
+      listType: 'Segment',
+    },
+    {
+      featureFlagId: nonmatchingFeatureFlag.id,
+      segmentId: nonmatchingFeatureFlagList.id,
+      enabled: true,
+      listType: 'Individual',
+    },
+  ]);
+
+  const logger = new UpgradeLogger();
+  const experimentService = Container.get<ExperimentService>(ExperimentService);
+  const featureFlagService = Container.get<FeatureFlagService>(FeatureFlagService);
+  const segmentService = Container.get<SegmentService>(SegmentService);
+
+  const [directExperiments, directExperimentCount] = await experimentService.findPaginated(0, 20, logger, {
+    key: EXPERIMENT_SEARCH_KEY.LIST_VALUE,
+    string: 'publicRE7e',
+  });
+  expect(directExperimentCount).toBe(1);
+  expect(directExperiments.map(({ id }) => id)).toEqual([directExperiment.id]);
+
+  const [nestedExperiments, nestedExperimentCount] = await experimentService.findPaginated(0, 20, logger, {
+    key: EXPERIMENT_SEARCH_KEY.ALL,
+    string: 'ALPHA-9',
+  });
+  expect(nestedExperimentCount).toBe(1);
+  expect(nestedExperiments.map(({ id }) => id)).toEqual([nestedExperiment.id]);
+
+  const [directFeatureFlags, directFeatureFlagCount] = await featureFlagService.findPaginated(0, 20, logger, {
+    key: FLAG_SEARCH_KEY.LIST_VALUE,
+    string: 'publicRE7e',
+  });
+  expect(directFeatureFlagCount).toBe(1);
+  expect(directFeatureFlags.map(({ id }) => id)).toEqual([directFeatureFlag.id]);
+
+  const [nestedFeatureFlags, nestedFeatureFlagCount] = await featureFlagService.findPaginated(0, 20, logger, {
+    key: FLAG_SEARCH_KEY.ALL,
+    string: 'ALPHA-9',
+  });
+  expect(nestedFeatureFlagCount).toBe(2);
+  expect(nestedFeatureFlags.map(({ id }) => id).sort()).toEqual(
+    [disabledFeatureFlagWithActiveNestedList.id, enabledFeatureFlagWithDisabledNestedList.id].sort()
+  );
+
+  const [directSegments, directSegmentCount] = await segmentService.findPaginated(0, 20, logger, {
+    key: SEGMENT_SEARCH_KEY.LIST_VALUE,
+    string: 'publicRE7e',
+  });
+  expect(directSegmentCount).toBe(1);
+  expect(directSegments.segmentsData.map(({ id }) => id)).toEqual([directPublicSegment.id]);
+
+  const [nestedSegments, nestedSegmentCount] = await segmentService.findPaginated(0, 20, logger, {
+    key: SEGMENT_SEARCH_KEY.ALL,
+    string: 'ALPHA-9',
+  });
+  expect(nestedSegmentCount).toBe(1);
+  expect(nestedSegments.segmentsData.map(({ id }) => id)).toEqual([nestedPublicSegment.id]);
+}

--- a/packages/backend/test/integration/index.test.ts
+++ b/packages/backend/test/integration/index.test.ts
@@ -122,6 +122,7 @@ import {
 } from './Experiment/exclusionCode';
 import { ExperimentValidation } from './Experiment/validation';
 import { FeatureFlagInclusionExclusion } from './FeatureFlags';
+import { ListValueFiltering } from './ListValueFiltering';
 
 describe('Integration Tests', () => {
   jest.setTimeout(100000000);
@@ -563,6 +564,10 @@ describe('Integration Tests', () => {
 
   test('Inclusion and Exclusion of user in FeatureFlags', () => {
     return FeatureFlagInclusionExclusion();
+  });
+
+  test('List value filtering across root pages', () => {
+    return ListValueFiltering();
   });
 
   // test('Experiment Preview Scenario 1 - Individual Assignment With Individual Consistency for Preview', () => {

--- a/packages/backend/test/unit/services/ExperimentService.test.ts
+++ b/packages/backend/test/unit/services/ExperimentService.test.ts
@@ -1167,6 +1167,32 @@ describe('ExperimentService Testing', () => {
       );
     });
 
+    it('should search experiments by applicable attached list values', () => {
+      const result = getSearchClause(EXPERIMENT_SEARCH_KEY.LIST_VALUE, 'school-id');
+
+      expect(result).toContain('FROM "experiment_segment_inclusion"');
+      expect(result).toContain('FROM "experiment_segment_exclusion"');
+      expect(result).toContain('"userId" ILIKE :listValueSearchPattern');
+      expect(result).toContain('"groupId" ILIKE :listValueSearchPattern');
+      expect(result).not.toContain('"attachedList"."enabled"');
+      expect(result).toContain('"attachedList"."isInclusion" = FALSE');
+      expect(result).toContain(`experiment."filterMode" <> 'includeAll'`);
+    });
+
+    it('should include list values in all-search results', () => {
+      const result = getSearchClause(EXPERIMENT_SEARCH_KEY.ALL, 'school-id');
+
+      expect(result).toContain('FROM "experiment_segment_inclusion"');
+      expect(result).toContain('FROM "experiment_segment_exclusion"');
+    });
+
+    it('should not include list values in unrelated dedicated searches', () => {
+      const result = getSearchClause(EXPERIMENT_SEARCH_KEY.NAME, 'school-id');
+
+      expect(result).not.toContain('individual_for_segment');
+      expect(result).not.toContain('group_for_segment');
+    });
+
     it('should escape LIKE wildcards and the escape character in search input', () => {
       const result = getSearchClause(EXPERIMENT_SEARCH_KEY.NAME, '100%_path\\name');
 

--- a/packages/backend/test/unit/services/ExperimentService.test.ts
+++ b/packages/backend/test/unit/services/ExperimentService.test.ts
@@ -1174,9 +1174,10 @@ describe('ExperimentService Testing', () => {
       expect(result).toContain('FROM "experiment_segment_exclusion"');
       expect(result).toContain('"userId" ILIKE :listValueSearchPattern');
       expect(result).toContain('"groupId" ILIKE :listValueSearchPattern');
-      expect(result).not.toContain('"attachedList"."enabled"');
-      expect(result).toContain('"attachedList"."isInclusion" = FALSE');
-      expect(result).toContain(`experiment."filterMode" <> 'includeAll'`);
+      expect(result).toContain('experiment.id IN (');
+      expect(result).not.toContain('EXISTS (');
+      expect(result).not.toContain('"enabled"');
+      expect(result).toContain(`"listValueOwner"."filterMode" <> 'includeAll'`);
     });
 
     it('should include list values in all-search results', () => {

--- a/packages/backend/test/unit/services/FeatureFlagService.test.ts
+++ b/packages/backend/test/unit/services/FeatureFlagService.test.ts
@@ -451,6 +451,46 @@ describe('Feature Flag Service Testing', () => {
     expect(results).toEqual([mockFlagArr, 3]);
   });
 
+  describe('paginated list-value search', () => {
+    const getSearchClause = (key: FLAG_SEARCH_KEY, searchString: string): string =>
+      service['paginatedSearchString']({ key, string: searchString });
+
+    it('should search feature flags through attached list values regardless of list enabled state', () => {
+      const result = getSearchClause(FLAG_SEARCH_KEY.LIST_VALUE, 'school-id');
+
+      expect(result).toContain('FROM "feature_flag_segment_inclusion"');
+      expect(result).toContain('FROM "feature_flag_segment_exclusion"');
+      expect(result).toContain('"userId" ILIKE :listValueSearchPattern');
+      expect(result).toContain('"groupId" ILIKE :listValueSearchPattern');
+      expect(result).not.toContain('"attachedList"."enabled"');
+      expect(result).toContain('"attachedList"."isInclusion" = FALSE');
+      expect(result).toContain(`feature_flag."filterMode" <> 'includeAll'`);
+    });
+
+    it('should include list values in all-search results', () => {
+      const result = getSearchClause(FLAG_SEARCH_KEY.ALL, 'school-id');
+
+      expect(result).toContain('FROM "feature_flag_segment_inclusion"');
+      expect(result).toContain('FROM "feature_flag_segment_exclusion"');
+    });
+
+    it('should not include list values in unrelated dedicated searches', () => {
+      const result = getSearchClause(FLAG_SEARCH_KEY.KEY, 'school-id');
+
+      expect(result).not.toContain('individual_for_segment');
+      expect(result).not.toContain('group_for_segment');
+    });
+
+    it('should skip search query generation for an empty search string', async () => {
+      const searchSpy = jest.spyOn(service as any, 'paginatedSearchString');
+
+      await service.findPaginated(0, 10, logger, { key: FLAG_SEARCH_KEY.LIST_VALUE, string: '' });
+
+      expect(searchSpy).not.toHaveBeenCalled();
+      searchSpy.mockRestore();
+    });
+  });
+
   it('should update the flag', async () => {
     const results = await service.update(mockFlag2, mockUser1, logger);
     expect(isUUID(results.id)).toBeTruthy();

--- a/packages/backend/test/unit/services/FeatureFlagService.test.ts
+++ b/packages/backend/test/unit/services/FeatureFlagService.test.ts
@@ -462,9 +462,10 @@ describe('Feature Flag Service Testing', () => {
       expect(result).toContain('FROM "feature_flag_segment_exclusion"');
       expect(result).toContain('"userId" ILIKE :listValueSearchPattern');
       expect(result).toContain('"groupId" ILIKE :listValueSearchPattern');
-      expect(result).not.toContain('"attachedList"."enabled"');
-      expect(result).toContain('"attachedList"."isInclusion" = FALSE');
-      expect(result).toContain(`feature_flag."filterMode" <> 'includeAll'`);
+      expect(result).toContain('feature_flag.id IN (');
+      expect(result).not.toContain('EXISTS (');
+      expect(result).not.toContain('"enabled"');
+      expect(result).toContain(`"listValueOwner"."filterMode" <> 'includeAll'`);
     });
 
     it('should include list values in all-search results', () => {

--- a/packages/backend/test/unit/services/SegmentService.test.ts
+++ b/packages/backend/test/unit/services/SegmentService.test.ts
@@ -976,6 +976,44 @@ describe('Segment Service Testing', () => {
     expect(results).toEqual(res);
   });
 
+  describe('paginated list-value search', () => {
+    const getSearchClause = (key: SEGMENT_SEARCH_KEY, searchString: string): string =>
+      service['paginatedSearchString']({ key, string: searchString });
+
+    it('should search segments by direct and nested list values', () => {
+      const result = getSearchClause(SEGMENT_SEARCH_KEY.LIST_VALUE, 'school-id');
+
+      expect(result).toContain('segment.id IN');
+      expect(result).toContain('"userId" ILIKE :listValueSearchPattern');
+      expect(result).toContain('"groupId" ILIKE :listValueSearchPattern');
+      expect(result).toContain('SELECT "segmentRelation"."parentSegmentId" AS "id"');
+    });
+
+    it('should include list values in all-search results', () => {
+      const result = getSearchClause(SEGMENT_SEARCH_KEY.ALL, 'school-id');
+
+      expect(result).toContain('segment.id IN');
+      expect(result).toContain('individual_for_segment');
+      expect(result).toContain('group_for_segment');
+    });
+
+    it('should not include list values in unrelated dedicated searches', () => {
+      const result = getSearchClause(SEGMENT_SEARCH_KEY.CONTEXT, 'school-id');
+
+      expect(result).not.toContain('individual_for_segment');
+      expect(result).not.toContain('group_for_segment');
+    });
+
+    it('should skip search query generation for an empty search string', async () => {
+      const searchSpy = jest.spyOn(service as any, 'paginatedSearchString');
+
+      await service.findPaginated(0, 10, logger, { key: SEGMENT_SEARCH_KEY.LIST_VALUE, string: '' });
+
+      expect(searchSpy).not.toHaveBeenCalled();
+      searchSpy.mockRestore();
+    });
+  });
+
   describe('Private segment cloning behavior', () => {
     it('should clone private subsegments when they are lists of a public segment', async () => {
       // Create a public segment with private subsegments (lists)

--- a/packages/backend/test/unit/services/listValueSearchHelpers.test.ts
+++ b/packages/backend/test/unit/services/listValueSearchHelpers.test.ts
@@ -30,25 +30,27 @@ describe('list value search helpers', () => {
   it('matches experiments through inclusion and exclusion lists', () => {
     const predicate = getListValueSearchPredicate('experiment');
 
+    expect(predicate).toContain('experiment.id IN (');
     expect(predicate).toContain('FROM "experiment_segment_inclusion"');
     expect(predicate).toContain('FROM "experiment_segment_exclusion"');
-    expect(predicate).toContain('"experimentId" AS "ownerId"');
-    expect(predicate).toContain('"attachedList"."ownerId" = experiment.id');
+    expect(predicate).toContain('INNER JOIN "experiment" "listValueOwner"');
+    expect(predicate).toContain('ON "listValueOwner".id = "listValueInclusion"."experimentId"');
+    expect(predicate).not.toContain('EXISTS (');
     expect(predicate).not.toContain('"enabled"');
-    expect(predicate).toContain('"attachedList"."isInclusion" = FALSE');
-    expect(predicate).toContain(`experiment."filterMode" <> 'includeAll'`);
+    expect(predicate).toContain(`"listValueOwner"."filterMode" <> 'includeAll'`);
   });
 
   it('matches feature flags through attached lists regardless of list enabled state', () => {
     const predicate = getListValueSearchPredicate('featureFlag');
 
+    expect(predicate).toContain('feature_flag.id IN (');
     expect(predicate).toContain('FROM "feature_flag_segment_inclusion"');
     expect(predicate).toContain('FROM "feature_flag_segment_exclusion"');
-    expect(predicate).toContain('"featureFlagId" AS "ownerId"');
-    expect(predicate).toContain('"attachedList"."ownerId" = feature_flag.id');
+    expect(predicate).toContain('INNER JOIN "feature_flag" "listValueOwner"');
+    expect(predicate).toContain('ON "listValueOwner".id = "listValueInclusion"."featureFlagId"');
+    expect(predicate).not.toContain('EXISTS (');
     expect(predicate).not.toContain('"enabled"');
-    expect(predicate).toContain('"attachedList"."isInclusion" = FALSE');
-    expect(predicate).toContain(`feature_flag."filterMode" <> 'includeAll'`);
+    expect(predicate).toContain(`"listValueOwner"."filterMode" <> 'includeAll'`);
   });
 
   it('only identifies list-value and all-search keys as list-value searches', () => {

--- a/packages/backend/test/unit/services/listValueSearchHelpers.test.ts
+++ b/packages/backend/test/unit/services/listValueSearchHelpers.test.ts
@@ -1,0 +1,59 @@
+import {
+  LIST_VALUE_SEARCH_PATTERN_PARAMETER,
+  buildListValueSearchPattern,
+  getListValueSearchPredicate,
+  isListValueSearchKey,
+} from '../../../src/api/services/listValueSearchHelpers';
+
+describe('list value search helpers', () => {
+  it('builds a literal partial-match pattern', () => {
+    expect(buildListValueSearchPattern('School%_Id\\Value')).toBe('%School\\%\\_Id\\\\Value%');
+  });
+
+  it('matches individual and group IDs case-insensitively', () => {
+    const predicate = getListValueSearchPredicate('segment');
+
+    expect(predicate).toContain(`"userId" ILIKE :${LIST_VALUE_SEARCH_PATTERN_PARAMETER} ESCAPE '\\'`);
+    expect(predicate).toContain(`"groupId" ILIKE :${LIST_VALUE_SEARCH_PATTERN_PARAMETER} ESCAPE '\\'`);
+  });
+
+  it('recursively walks from matching segments to ancestors with cycle-safe UNION semantics', () => {
+    const predicate = getListValueSearchPredicate('segment');
+
+    expect(predicate).toContain('WITH RECURSIVE "directListValueSegments"');
+    expect(predicate).toContain('INNER JOIN "matchingListValueSegments" "matchedSegment"');
+    expect(predicate).toContain('ON "segmentRelation"."childSegmentId" = "matchedSegment"."id"');
+    expect(predicate).toContain('SELECT "segmentRelation"."parentSegmentId" AS "id"');
+    expect(predicate).not.toContain('UNION ALL\n    SELECT "segmentRelation"."parentSegmentId"');
+  });
+
+  it('matches experiments through inclusion and exclusion lists', () => {
+    const predicate = getListValueSearchPredicate('experiment');
+
+    expect(predicate).toContain('FROM "experiment_segment_inclusion"');
+    expect(predicate).toContain('FROM "experiment_segment_exclusion"');
+    expect(predicate).toContain('"experimentId" AS "ownerId"');
+    expect(predicate).toContain('"attachedList"."ownerId" = experiment.id');
+    expect(predicate).not.toContain('"enabled"');
+    expect(predicate).toContain('"attachedList"."isInclusion" = FALSE');
+    expect(predicate).toContain(`experiment."filterMode" <> 'includeAll'`);
+  });
+
+  it('matches feature flags through attached lists regardless of list enabled state', () => {
+    const predicate = getListValueSearchPredicate('featureFlag');
+
+    expect(predicate).toContain('FROM "feature_flag_segment_inclusion"');
+    expect(predicate).toContain('FROM "feature_flag_segment_exclusion"');
+    expect(predicate).toContain('"featureFlagId" AS "ownerId"');
+    expect(predicate).toContain('"attachedList"."ownerId" = feature_flag.id');
+    expect(predicate).not.toContain('"enabled"');
+    expect(predicate).toContain('"attachedList"."isInclusion" = FALSE');
+    expect(predicate).toContain(`feature_flag."filterMode" <> 'includeAll'`);
+  });
+
+  it('only identifies list-value and all-search keys as list-value searches', () => {
+    expect(isListValueSearchKey('listValue')).toBe(true);
+    expect(isListValueSearchKey('all')).toBe(true);
+    expect(isListValueSearchKey('name')).toBe(false);
+  });
+});

--- a/packages/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-root-page/experiment-root-page-content/experiment-root-section-card/experiment-root-section-card.component.ts
+++ b/packages/frontend/projects/upgrade/src/app/features/dashboard/experiments/pages/experiment-root-page/experiment-root-page-content/experiment-root-section-card/experiment-root-section-card.component.ts
@@ -58,6 +58,7 @@ export class ExperimentRootSectionCardComponent {
     { value: EXPERIMENT_SEARCH_KEY.CONTEXT, type: 'text' },
     { value: EXPERIMENT_SEARCH_KEY.TAG, type: 'text' },
     { value: EXPERIMENT_SEARCH_KEY.DECISION_POINT, label: 'Decision Point', type: 'text' },
+    { value: EXPERIMENT_SEARCH_KEY.LIST_VALUE, label: 'List Value', type: 'text' },
   ];
   isSectionCardExpanded = true;
 

--- a/packages/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card.component.ts
+++ b/packages/frontend/projects/upgrade/src/app/features/dashboard/feature-flags/pages/feature-flag-root-page/feature-flag-root-page-content/feature-flag-root-section-card/feature-flag-root-section-card.component.ts
@@ -57,6 +57,7 @@ export class FeatureFlagRootSectionCardComponent {
     { value: FLAG_SEARCH_KEY.STATUS },
     { value: FLAG_SEARCH_KEY.CONTEXT },
     { value: FLAG_SEARCH_KEY.TAG },
+    { value: FLAG_SEARCH_KEY.LIST_VALUE, label: 'List Value' },
   ];
   isSectionCardExpanded = true;
 

--- a/packages/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-root-section-card/segment-root-section-card.component.ts
+++ b/packages/frontend/projects/upgrade/src/app/features/dashboard/segments/pages/segment-root-page/segment-root-page-content/segment-root-section-card/segment-root-section-card.component.ts
@@ -51,6 +51,7 @@ export class SegmentRootSectionCardComponent {
     { value: SEGMENT_SEARCH_KEY.ID },
     { value: SEGMENT_SEARCH_KEY.CONTEXT },
     { value: SEGMENT_SEARCH_KEY.TAG },
+    { value: SEGMENT_SEARCH_KEY.LIST_VALUE, label: 'List Value' },
   ];
   isSectionCardExpanded = true;
 

--- a/packages/types/src/Experiment/enums.ts
+++ b/packages/types/src/Experiment/enums.ts
@@ -189,6 +189,7 @@ export enum EXPERIMENT_SEARCH_KEY {
   CONTEXT = 'context',
   ID = 'id',
   DECISION_POINT = 'decisionPoint',
+  LIST_VALUE = 'listValue',
 }
 
 export enum EXPERIMENT_SORT_KEY {
@@ -276,6 +277,7 @@ export enum SEGMENT_SEARCH_KEY {
   STATUS = 'status',
   CONTEXT = 'context',
   ID = 'id',
+  LIST_VALUE = 'listValue',
 }
 
 export enum SEGMENT_SORT_KEY {
@@ -291,6 +293,7 @@ export enum FLAG_SEARCH_KEY {
   TAG = 'tag',
   CONTEXT = 'context',
   ID = 'id',
+  LIST_VALUE = 'listValue',
 }
 
 export enum METRIC_SEARCH_KEY {


### PR DESCRIPTION
Resolves #3284

## Changes

- Add a `List Value` filter to the Experiments, Feature Flags, and Segments pages.
- Include list values in each page's `All` search.
- Support case-insensitive partial matching for individual and group IDs in direct and nested lists.
- Respect `Include All` behavior while searching applicable inclusion and exclusion lists.
- Add unit and integration coverage for list-value filtering.
