### PR TITLE
Prevent Cartesian row growth in experiment list queries

### DIFF
--- a/packages/backend/src/api/repositories/ExperimentRepository.ts
+++ b/packages/backend/src/api/repositories/ExperimentRepository.ts
@@ -24,13 +24,15 @@ export class ExperimentRepository extends Repository<Experiment> {
       .addOrderBy('queries.order', 'ASC', 'NULLS LAST')
       .addOrderBy('queries.createdAt', 'ASC');
 
-    const experimentSegment = this.buildSegmentQuery();
+    const experimentInclusionSegmentQuery = this.buildInclusionSegmentQuery();
+    const experimentExclusionSegmentQuery = this.buildExclusionSegmentQuery();
 
     const [
       experimentConditionLevelPayloadData,
       experimentFactorPartitionLevelPayloadData,
       experimentMetricData,
-      experimentSegmentData,
+      experimentInclusionSegmentData,
+      experimentExclusionSegmentData,
     ] = await Promise.all([
       experimentConditionLevelPayloadQuery.getMany().catch((errorMsg: any) => {
         const errorMsgString = repositoryError(
@@ -59,16 +61,27 @@ export class ExperimentRepository extends Repository<Experiment> {
         );
         throw errorMsgString;
       }),
-      experimentSegment.getMany().catch((errorMsg: any) => {
+      experimentInclusionSegmentQuery.getMany().catch((errorMsg: any) => {
         const errorMsgString = repositoryError(
           'ExperimentRepository',
-          'findAllExperiments-experimentSegmentData',
+          'findAllExperiments-experimentInclusionSegmentData',
+          {},
+          errorMsg
+        );
+        throw errorMsgString;
+      }),
+      experimentExclusionSegmentQuery.getMany().catch((errorMsg: any) => {
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'findAllExperiments-experimentExclusionSegmentData',
           {},
           errorMsg
         );
         throw errorMsgString;
       }),
     ]);
+
+    const experimentSegmentData = this.mergeSegmentData(experimentInclusionSegmentData, experimentExclusionSegmentData);
 
     const experimentData = experimentConditionLevelPayloadData.map((data) => {
       const data2 = experimentFactorPartitionLevelPayloadData.find((i) => i.id === data.id);
@@ -118,42 +131,63 @@ export class ExperimentRepository extends Repository<Experiment> {
       })
     );
 
-    const experimentSegmentQuery = this.buildSegmentQuery().where(
+    const experimentInclusionSegmentQuery = this.buildInclusionSegmentQuery().where(
       new Brackets((qb) => {
         qb.where(whereExperimentsClause, whereClauseParams);
       })
     );
 
-    const [experimentConditionLevelPayloadData, experimentFactorDecisionPointLevelPayloadData, experimentSegmentData] =
-      await Promise.all([
-        experimentConditionLevelPayloadQuery.getMany().catch((errorMsg: any) => {
-          const errorMsgString = repositoryError(
-            'ExperimentRepository',
-            'getValidExperiments-experimentConditionLevelPayloadQuery',
-            {},
-            errorMsg
-          );
-          throw errorMsgString;
-        }),
-        experimentFactorDecisionPointLevelPayloadQuery.getMany().catch((errorMsg: any) => {
-          const errorMsgString = repositoryError(
-            'ExperimentRepository',
-            'getValidExperiments-experimentFactorDecisionPointLevelPayloadQuery',
-            {},
-            errorMsg
-          );
-          throw errorMsgString;
-        }),
-        experimentSegmentQuery.getMany().catch((errorMsg: any) => {
-          const errorMsgString = repositoryError(
-            'ExperimentRepository',
-            'getValidExperiments-experimentSegmentQuery',
-            {},
-            errorMsg
-          );
-          throw errorMsgString;
-        }),
-      ]);
+    const experimentExclusionSegmentQuery = this.buildExclusionSegmentQuery().where(
+      new Brackets((qb) => {
+        qb.where(whereExperimentsClause, whereClauseParams);
+      })
+    );
+
+    const [
+      experimentConditionLevelPayloadData,
+      experimentFactorDecisionPointLevelPayloadData,
+      experimentInclusionSegmentData,
+      experimentExclusionSegmentData,
+    ] = await Promise.all([
+      experimentConditionLevelPayloadQuery.getMany().catch((errorMsg: any) => {
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'getValidExperiments-experimentConditionLevelPayloadQuery',
+          {},
+          errorMsg
+        );
+        throw errorMsgString;
+      }),
+      experimentFactorDecisionPointLevelPayloadQuery.getMany().catch((errorMsg: any) => {
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'getValidExperiments-experimentFactorDecisionPointLevelPayloadQuery',
+          {},
+          errorMsg
+        );
+        throw errorMsgString;
+      }),
+      experimentInclusionSegmentQuery.getMany().catch((errorMsg: any) => {
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'getValidExperiments-experimentInclusionSegmentQuery',
+          {},
+          errorMsg
+        );
+        throw errorMsgString;
+      }),
+      experimentExclusionSegmentQuery.getMany().catch((errorMsg: any) => {
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'getValidExperiments-experimentExclusionSegmentQuery',
+          {},
+          errorMsg
+        );
+        throw errorMsgString;
+      }),
+    ]);
+
+    const experimentSegmentData = this.mergeSegmentData(experimentInclusionSegmentData, experimentExclusionSegmentData);
 
     const experimentData = experimentConditionLevelPayloadData.map((data) => {
       const data2 = experimentFactorDecisionPointLevelPayloadData.find((i) => i.id === data.id);
@@ -204,7 +238,7 @@ export class ExperimentRepository extends Repository<Experiment> {
       })
     );
 
-    const segmentQuery = this.buildSegmentQuery()
+    const inclusionSegmentQuery = this.buildInclusionSegmentQuery()
       .leftJoin('experiment.partitions', 'partitions')
       .where(
         new Brackets((qb) => {
@@ -212,35 +246,55 @@ export class ExperimentRepository extends Repository<Experiment> {
         })
       );
 
-    const [conditionLevelPayloadData, factorDecisionPointPayloadData, segmentData] = await Promise.all([
-      conditionLevelPayloadQuery.getMany().catch((errorMsg: any) => {
-        const errorMsgString = repositoryError(
-          'ExperimentRepository',
-          'getValidExperimentsForContextAndDecisionPoint-conditionLevelPayloadData',
-          {},
-          errorMsg
-        );
-        throw errorMsgString;
-      }),
-      factorDecisionPointPayloadQuery.getMany().catch((errorMsg: any) => {
-        const errorMsgString = repositoryError(
-          'ExperimentRepository',
-          'getValidExperimentsForContextAndDecisionPoint-factorDecisionPointPayloadData',
-          {},
-          errorMsg
-        );
-        throw errorMsgString;
-      }),
-      segmentQuery.getMany().catch((errorMsg: any) => {
-        const errorMsgString = repositoryError(
-          'ExperimentRepository',
-          'getValidExperimentsForContextAndDecisionPoint-segmentData',
-          {},
-          errorMsg
-        );
-        throw errorMsgString;
-      }),
-    ]);
+    const exclusionSegmentQuery = this.buildExclusionSegmentQuery()
+      .leftJoin('experiment.partitions', 'partitions')
+      .where(
+        new Brackets((qb) => {
+          qb.where(decisionPointWhereClause, whereClauseParams);
+        })
+      );
+
+    const [conditionLevelPayloadData, factorDecisionPointPayloadData, inclusionSegmentData, exclusionSegmentData] =
+      await Promise.all([
+        conditionLevelPayloadQuery.getMany().catch((errorMsg: any) => {
+          const errorMsgString = repositoryError(
+            'ExperimentRepository',
+            'getValidExperimentsForContextAndDecisionPoint-conditionLevelPayloadData',
+            {},
+            errorMsg
+          );
+          throw errorMsgString;
+        }),
+        factorDecisionPointPayloadQuery.getMany().catch((errorMsg: any) => {
+          const errorMsgString = repositoryError(
+            'ExperimentRepository',
+            'getValidExperimentsForContextAndDecisionPoint-factorDecisionPointPayloadData',
+            {},
+            errorMsg
+          );
+          throw errorMsgString;
+        }),
+        inclusionSegmentQuery.getMany().catch((errorMsg: any) => {
+          const errorMsgString = repositoryError(
+            'ExperimentRepository',
+            'getValidExperimentsForContextAndDecisionPoint-inclusionSegmentData',
+            {},
+            errorMsg
+          );
+          throw errorMsgString;
+        }),
+        exclusionSegmentQuery.getMany().catch((errorMsg: any) => {
+          const errorMsgString = repositoryError(
+            'ExperimentRepository',
+            'getValidExperimentsForContextAndDecisionPoint-exclusionSegmentData',
+            {},
+            errorMsg
+          );
+          throw errorMsgString;
+        }),
+      ]);
+
+    const segmentData = this.mergeSegmentData(inclusionSegmentData, exclusionSegmentData);
 
     const experimentData = factorDecisionPointPayloadData.map((data) => {
       const condData = conditionLevelPayloadData.find((i) => i.id === data.id);
@@ -275,42 +329,63 @@ export class ExperimentRepository extends Repository<Experiment> {
       })
     );
 
-    const experimentSegmentQuery = this.buildSegmentQuery().where(
+    const experimentInclusionSegmentQuery = this.buildInclusionSegmentQuery().where(
       new Brackets((qb) => {
         qb.where(whereExperimentsClause, whereClauseParams);
       })
     );
 
-    const [experimentConditionLevelPayloadData, experimentFactorDecisionPointLevelPayloadData, experimentSegmentData] =
-      await Promise.all([
-        experimentConditionLevelPayloadQuery.getMany().catch((errorMsg: any) => {
-          const errorMsgString = repositoryError(
-            'ExperimentRepository',
-            'getValidExperimentsWithPreview-experimentConditionLevelPayloadQuery',
-            {},
-            errorMsg
-          );
-          throw errorMsgString;
-        }),
-        experimentFactorDecisionPointLevelPayloadQuery.getMany().catch((errorMsg: any) => {
-          const errorMsgString = repositoryError(
-            'ExperimentRepository',
-            'getValidExperimentsWithPreview-experimentFactorDecisionPointLevelPayloadQuery',
-            {},
-            errorMsg
-          );
-          throw errorMsgString;
-        }),
-        experimentSegmentQuery.getMany().catch((errorMsg: any) => {
-          const errorMsgString = repositoryError(
-            'ExperimentRepository',
-            'getValidExperimentsWithPreview-experimentSegmentQuery',
-            {},
-            errorMsg
-          );
-          throw errorMsgString;
-        }),
-      ]);
+    const experimentExclusionSegmentQuery = this.buildExclusionSegmentQuery().where(
+      new Brackets((qb) => {
+        qb.where(whereExperimentsClause, whereClauseParams);
+      })
+    );
+
+    const [
+      experimentConditionLevelPayloadData,
+      experimentFactorDecisionPointLevelPayloadData,
+      experimentInclusionSegmentData,
+      experimentExclusionSegmentData,
+    ] = await Promise.all([
+      experimentConditionLevelPayloadQuery.getMany().catch((errorMsg: any) => {
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'getValidExperimentsWithPreview-experimentConditionLevelPayloadQuery',
+          {},
+          errorMsg
+        );
+        throw errorMsgString;
+      }),
+      experimentFactorDecisionPointLevelPayloadQuery.getMany().catch((errorMsg: any) => {
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'getValidExperimentsWithPreview-experimentFactorDecisionPointLevelPayloadQuery',
+          {},
+          errorMsg
+        );
+        throw errorMsgString;
+      }),
+      experimentInclusionSegmentQuery.getMany().catch((errorMsg: any) => {
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'getValidExperimentsWithPreview-experimentInclusionSegmentQuery',
+          {},
+          errorMsg
+        );
+        throw errorMsgString;
+      }),
+      experimentExclusionSegmentQuery.getMany().catch((errorMsg: any) => {
+        const errorMsgString = repositoryError(
+          'ExperimentRepository',
+          'getValidExperimentsWithPreview-experimentExclusionSegmentQuery',
+          {},
+          errorMsg
+        );
+        throw errorMsgString;
+      }),
+    ]);
+
+    const experimentSegmentData = this.mergeSegmentData(experimentInclusionSegmentData, experimentExclusionSegmentData);
 
     const experimentData = experimentConditionLevelPayloadData.map((data) => {
       const data2 = experimentFactorDecisionPointLevelPayloadData.find((i) => i.id === data.id);
@@ -468,19 +543,46 @@ export class ExperimentRepository extends Repository<Experiment> {
       .leftJoinAndSelect('factors.levels', 'levels');
   }
 
-  private buildSegmentQuery() {
+  private buildInclusionSegmentQuery() {
     return this.createQueryBuilder('experiment')
       .select('experiment.id')
       .leftJoinAndSelect('experiment.experimentSegmentInclusion', 'experimentSegmentInclusion')
       .leftJoinAndSelect('experimentSegmentInclusion.segment', 'segmentInclusion')
       .leftJoinAndSelect('segmentInclusion.individualForSegment', 'individualForSegment')
       .leftJoinAndSelect('segmentInclusion.groupForSegment', 'groupForSegment')
-      .leftJoinAndSelect('segmentInclusion.subSegments', 'subSegment')
+      .leftJoinAndSelect('segmentInclusion.subSegments', 'subSegment');
+  }
+
+  private buildExclusionSegmentQuery() {
+    return this.createQueryBuilder('experiment')
+      .select('experiment.id')
       .leftJoinAndSelect('experiment.experimentSegmentExclusion', 'experimentSegmentExclusion')
       .leftJoinAndSelect('experimentSegmentExclusion.segment', 'segmentExclusion')
       .leftJoinAndSelect('segmentExclusion.individualForSegment', 'individualForSegmentExclusion')
       .leftJoinAndSelect('segmentExclusion.groupForSegment', 'groupForSegmentExclusion')
       .leftJoinAndSelect('segmentExclusion.subSegments', 'subSegmentExclusion');
+  }
+
+  private mergeSegmentData(inclusionData: Experiment[], exclusionData: Experiment[]): Experiment[] {
+    const inclusionById = new Map(inclusionData.map((experiment) => [experiment.id, experiment]));
+    const exclusionById = new Map(exclusionData.map((experiment) => [experiment.id, experiment]));
+    const experimentIds = new Set([...inclusionById.keys(), ...exclusionById.keys()]);
+
+    return [...experimentIds].map((experimentId) => {
+      const inclusion = inclusionById.get(experimentId);
+      const exclusion = exclusionById.get(experimentId);
+
+      return {
+        ...inclusion,
+        ...exclusion,
+        ...(inclusion?.experimentSegmentInclusion !== undefined
+          ? { experimentSegmentInclusion: inclusion.experimentSegmentInclusion }
+          : {}),
+        ...(exclusion?.experimentSegmentExclusion !== undefined
+          ? { experimentSegmentExclusion: exclusion.experimentSegmentExclusion }
+          : {}),
+      } as Experiment;
+    });
   }
 
   public async findOneExperiment(id: string): Promise<Experiment | undefined> {
@@ -502,50 +604,66 @@ export class ExperimentRepository extends Repository<Experiment> {
       .addOrderBy('queries.createdAt', 'ASC')
       .where({ id });
 
-    const segmentQuery = this.buildSegmentQuery().where({ id });
+    const inclusionSegmentQuery = this.buildInclusionSegmentQuery().where({ id });
+    const exclusionSegmentQuery = this.buildExclusionSegmentQuery().where({ id });
 
-    const [conditionLevelPayloadData, factorDecisionPointPayloadData, metricData, segmentData] = await Promise.all([
-      conditionLevelPayloadQuery.getOne().catch((errorMsg: any) => {
-        const errorMsgString = repositoryError(
-          'ExperimentRepository',
-          'findOneExperiment-conditionLevelPayloadData',
-          { id },
-          errorMsg
-        );
-        throw errorMsgString;
-      }),
-      factorDecisionPointPayloadQuery.getOne().catch((errorMsg: any) => {
-        const errorMsgString = repositoryError(
-          'ExperimentRepository',
-          'findOneExperiment-factorDecisionPointPayloadData',
-          { id },
-          errorMsg
-        );
-        throw errorMsgString;
-      }),
-      metricQuery.getOne().catch((errorMsg: any) => {
-        const errorMsgString = repositoryError(
-          'ExperimentRepository',
-          'findOneExperiment-metricData',
-          { id },
-          errorMsg
-        );
-        throw errorMsgString;
-      }),
-      segmentQuery.getOne().catch((errorMsg: any) => {
-        const errorMsgString = repositoryError(
-          'ExperimentRepository',
-          'findOneExperiment-segmentData',
-          { id },
-          errorMsg
-        );
-        throw errorMsgString;
-      }),
-    ]);
+    const [conditionLevelPayloadData, factorDecisionPointPayloadData, metricData, inclusionData, exclusionData] =
+      await Promise.all([
+        conditionLevelPayloadQuery.getOne().catch((errorMsg: any) => {
+          const errorMsgString = repositoryError(
+            'ExperimentRepository',
+            'findOneExperiment-conditionLevelPayloadData',
+            { id },
+            errorMsg
+          );
+          throw errorMsgString;
+        }),
+        factorDecisionPointPayloadQuery.getOne().catch((errorMsg: any) => {
+          const errorMsgString = repositoryError(
+            'ExperimentRepository',
+            'findOneExperiment-factorDecisionPointPayloadData',
+            { id },
+            errorMsg
+          );
+          throw errorMsgString;
+        }),
+        metricQuery.getOne().catch((errorMsg: any) => {
+          const errorMsgString = repositoryError(
+            'ExperimentRepository',
+            'findOneExperiment-metricData',
+            { id },
+            errorMsg
+          );
+          throw errorMsgString;
+        }),
+        inclusionSegmentQuery.getOne().catch((errorMsg: any) => {
+          const errorMsgString = repositoryError(
+            'ExperimentRepository',
+            'findOneExperiment-inclusionSegmentData',
+            { id },
+            errorMsg
+          );
+          throw errorMsgString;
+        }),
+        exclusionSegmentQuery.getOne().catch((errorMsg: any) => {
+          const errorMsgString = repositoryError(
+            'ExperimentRepository',
+            'findOneExperiment-exclusionSegmentData',
+            { id },
+            errorMsg
+          );
+          throw errorMsgString;
+        }),
+      ]);
 
     if (!conditionLevelPayloadData) {
       return undefined;
     }
+
+    const [segmentData] = this.mergeSegmentData(
+      inclusionData ? [inclusionData] : [],
+      exclusionData ? [exclusionData] : []
+    );
 
     return { ...conditionLevelPayloadData, ...factorDecisionPointPayloadData, ...metricData, ...segmentData };
   }

--- a/packages/backend/src/api/repositories/ExperimentRepository.ts
+++ b/packages/backend/src/api/repositories/ExperimentRepository.ts
@@ -660,12 +660,13 @@ export class ExperimentRepository extends Repository<Experiment> {
       return undefined;
     }
 
-    const [segmentData] = this.mergeSegmentData(
-      inclusionData ? [inclusionData] : [],
-      exclusionData ? [exclusionData] : []
-    );
-
-    return { ...conditionLevelPayloadData, ...factorDecisionPointPayloadData, ...metricData, ...segmentData };
+    return {
+      ...conditionLevelPayloadData,
+      ...factorDecisionPointPayloadData,
+      ...metricData,
+      experimentSegmentInclusion: inclusionData?.experimentSegmentInclusion ?? [],
+      experimentSegmentExclusion: exclusionData?.experimentSegmentExclusion ?? [],
+    };
   }
 
   public async fetchExperimentDetailsForCSVDataExport(experimentId: string): Promise<ExperimentDetailsForCSVData[]> {

--- a/packages/backend/src/api/repositories/ExperimentRepository.ts
+++ b/packages/backend/src/api/repositories/ExperimentRepository.ts
@@ -10,6 +10,10 @@ import { ConditionPayload } from '../models/ConditionPayload';
 import { DecisionPoint } from '../models/DecisionPoint';
 import { ExperimentCondition } from '../models/ExperimentCondition';
 
+type SegmentInclusionFragment = Pick<Experiment, 'id' | 'experimentSegmentInclusion'>;
+type SegmentExclusionFragment = Pick<Experiment, 'id' | 'experimentSegmentExclusion'>;
+type SegmentFragment = SegmentInclusionFragment & SegmentExclusionFragment;
+
 @EntityRepository(Experiment)
 export class ExperimentRepository extends Repository<Experiment> {
   public async findAllExperiments(): Promise<Experiment[]> {
@@ -563,26 +567,19 @@ export class ExperimentRepository extends Repository<Experiment> {
       .leftJoinAndSelect('segmentExclusion.subSegments', 'subSegmentExclusion');
   }
 
-  private mergeSegmentData(inclusionData: Experiment[], exclusionData: Experiment[]): Experiment[] {
+  private mergeSegmentData(
+    inclusionData: SegmentInclusionFragment[],
+    exclusionData: SegmentExclusionFragment[]
+  ): SegmentFragment[] {
     const inclusionById = new Map(inclusionData.map((experiment) => [experiment.id, experiment]));
     const exclusionById = new Map(exclusionData.map((experiment) => [experiment.id, experiment]));
     const experimentIds = new Set([...inclusionById.keys(), ...exclusionById.keys()]);
 
-    return [...experimentIds].map((experimentId) => {
-      const inclusion = inclusionById.get(experimentId);
-      const exclusion = exclusionById.get(experimentId);
-
-      return {
-        ...inclusion,
-        ...exclusion,
-        ...(inclusion?.experimentSegmentInclusion !== undefined
-          ? { experimentSegmentInclusion: inclusion.experimentSegmentInclusion }
-          : {}),
-        ...(exclusion?.experimentSegmentExclusion !== undefined
-          ? { experimentSegmentExclusion: exclusion.experimentSegmentExclusion }
-          : {}),
-      } as Experiment;
-    });
+    return [...experimentIds].map((id) => ({
+      id,
+      experimentSegmentInclusion: inclusionById.get(id)?.experimentSegmentInclusion ?? [],
+      experimentSegmentExclusion: exclusionById.get(id)?.experimentSegmentExclusion ?? [],
+    }));
   }
 
   public async findOneExperiment(id: string): Promise<Experiment | undefined> {

--- a/packages/backend/test/unit/repositories/ExperimentRepository.test.ts
+++ b/packages/backend/test/unit/repositories/ExperimentRepository.test.ts
@@ -407,7 +407,11 @@ describe('ExperimentRepository Testing', () => {
     expect(mock.where).toHaveBeenCalledTimes(5);
     expect(mock.getOne).toHaveBeenCalledTimes(5);
 
-    expect(res).toEqual(experiment);
+    expect(res).toEqual({
+      ...experiment,
+      experimentSegmentInclusion: [],
+      experimentSegmentExclusion: [],
+    });
   });
 
   it('should merge separately loaded segment data when finding one experiment', async () => {

--- a/packages/backend/test/unit/repositories/ExperimentRepository.test.ts
+++ b/packages/backend/test/unit/repositories/ExperimentRepository.test.ts
@@ -15,6 +15,8 @@ const err = new Error('test error');
 
 const experiment = new Experiment();
 experiment.id = 'id1';
+experiment.experimentSegmentInclusion = [];
+experiment.experimentSegmentExclusion = [];
 
 const result = {
   identifiers: [{ id: experiment.id }],
@@ -194,6 +196,34 @@ describe('ExperimentRepository Testing', () => {
       experimentSegmentInclusion: ['inclusion'],
       experimentSegmentExclusion: ['exclusion'],
     });
+  });
+
+  it('should default segment data missing from either query to an empty array', async () => {
+    const baseData = [{ id: 'exp-a' }, { id: 'exp-b' }] as any;
+    const inclusionData = [{ id: 'exp-a', experimentSegmentInclusion: ['inclusion'] }] as any;
+    const exclusionData = [{ id: 'exp-b', experimentSegmentExclusion: ['exclusion'] }] as any;
+
+    mock.getMany
+      .mockResolvedValueOnce(baseData)
+      .mockResolvedValueOnce(baseData)
+      .mockResolvedValueOnce(baseData)
+      .mockResolvedValueOnce(inclusionData)
+      .mockResolvedValueOnce(exclusionData);
+
+    const res = await repo.findAllExperiments();
+
+    expect(res).toEqual([
+      {
+        id: 'exp-a',
+        experimentSegmentInclusion: ['inclusion'],
+        experimentSegmentExclusion: [],
+      },
+      {
+        id: 'exp-b',
+        experimentSegmentInclusion: [],
+        experimentSegmentExclusion: ['exclusion'],
+      },
+    ]);
   });
 
   it('should throw an error when find all experiments fails', async () => {

--- a/packages/backend/test/unit/repositories/ExperimentRepository.test.ts
+++ b/packages/backend/test/unit/repositories/ExperimentRepository.test.ts
@@ -155,11 +155,11 @@ describe('ExperimentRepository Testing', () => {
 
     const res = await repo.findAllExperiments();
 
-    expect(repo.createQueryBuilder).toHaveBeenCalledTimes(4);
+    expect(repo.createQueryBuilder).toHaveBeenCalledTimes(5);
 
     expect(mock.leftJoinAndSelect).toHaveBeenCalledTimes(23);
-    expect(mock.select).toHaveBeenCalledTimes(1);
-    expect(mock.getMany).toHaveBeenCalledTimes(4);
+    expect(mock.select).toHaveBeenCalledTimes(2);
+    expect(mock.getMany).toHaveBeenCalledTimes(5);
 
     // queries are ordered by `order` ASC (NULLS LAST) then `createdAt` ASC as a stable fallback
     expect(mock.addOrderBy).toHaveBeenCalledTimes(2);
@@ -169,6 +169,33 @@ describe('ExperimentRepository Testing', () => {
     expect(res).toEqual(result);
   });
 
+  it('should merge separately loaded inclusion and exclusion segment data', async () => {
+    const conditionData = { id: 'exp-a', name: 'Experiment A', conditions: ['condition'] } as any;
+    const factorData = { id: 'exp-a', partitions: ['partition'] } as any;
+    const metricData = { id: 'exp-a', queries: ['query'] } as any;
+    const inclusionData = { id: 'exp-a', experimentSegmentInclusion: ['inclusion'] } as any;
+    const exclusionData = { id: 'exp-a', experimentSegmentExclusion: ['exclusion'] } as any;
+
+    mock.getMany
+      .mockResolvedValueOnce([conditionData])
+      .mockResolvedValueOnce([factorData])
+      .mockResolvedValueOnce([metricData])
+      .mockResolvedValueOnce([inclusionData])
+      .mockResolvedValueOnce([exclusionData]);
+
+    const [res] = await repo.findAllExperiments();
+
+    expect(res).toMatchObject({
+      id: 'exp-a',
+      name: 'Experiment A',
+      conditions: ['condition'],
+      partitions: ['partition'],
+      queries: ['query'],
+      experimentSegmentInclusion: ['inclusion'],
+      experimentSegmentExclusion: ['exclusion'],
+    });
+  });
+
   it('should throw an error when find all experiments fails', async () => {
     mock.getMany.mockRejectedValue(err);
 
@@ -176,11 +203,11 @@ describe('ExperimentRepository Testing', () => {
       await repo.findAllExperiments();
     }).rejects.toThrow(err);
 
-    expect(repo.createQueryBuilder).toHaveBeenCalledTimes(4);
+    expect(repo.createQueryBuilder).toHaveBeenCalledTimes(5);
 
     expect(mock.leftJoinAndSelect).toHaveBeenCalledTimes(23);
-    expect(mock.select).toHaveBeenCalledTimes(1);
-    expect(mock.getMany).toHaveBeenCalledTimes(4);
+    expect(mock.select).toHaveBeenCalledTimes(2);
+    expect(mock.getMany).toHaveBeenCalledTimes(5);
   });
 
   it('should find all experiments by name', async () => {
@@ -213,12 +240,12 @@ describe('ExperimentRepository Testing', () => {
 
     const res = await repo.getValidExperiments('context');
 
-    expect(repo.createQueryBuilder).toHaveBeenCalledTimes(3);
+    expect(repo.createQueryBuilder).toHaveBeenCalledTimes(4);
 
     expect(mock.leftJoinAndSelect).toHaveBeenCalledTimes(20);
-    expect(mock.where).toHaveBeenCalledTimes(3);
-    expect(mock.select).toHaveBeenCalledTimes(1);
-    expect(mock.getMany).toHaveBeenCalledTimes(3);
+    expect(mock.where).toHaveBeenCalledTimes(4);
+    expect(mock.select).toHaveBeenCalledTimes(2);
+    expect(mock.getMany).toHaveBeenCalledTimes(4);
 
     expect(res).toEqual(result);
   });
@@ -230,12 +257,12 @@ describe('ExperimentRepository Testing', () => {
       await repo.getValidExperiments('context');
     }).rejects.toThrow(err);
 
-    expect(repo.createQueryBuilder).toHaveBeenCalledTimes(3);
+    expect(repo.createQueryBuilder).toHaveBeenCalledTimes(4);
 
     expect(mock.leftJoinAndSelect).toHaveBeenCalledTimes(20);
-    expect(mock.where).toHaveBeenCalledTimes(3);
-    expect(mock.select).toHaveBeenCalledTimes(1);
-    expect(mock.getMany).toHaveBeenCalledTimes(3);
+    expect(mock.where).toHaveBeenCalledTimes(4);
+    expect(mock.select).toHaveBeenCalledTimes(2);
+    expect(mock.getMany).toHaveBeenCalledTimes(4);
   });
 
   it('should get valid experiments with preview', async () => {
@@ -244,12 +271,12 @@ describe('ExperimentRepository Testing', () => {
 
     const res = await repo.getValidExperimentsWithPreview('context');
 
-    expect(repo.createQueryBuilder).toHaveBeenCalledTimes(3);
+    expect(repo.createQueryBuilder).toHaveBeenCalledTimes(4);
 
     expect(mock.leftJoinAndSelect).toHaveBeenCalledTimes(20);
-    expect(mock.where).toHaveBeenCalledTimes(3);
-    expect(mock.select).toHaveBeenCalledTimes(1);
-    expect(mock.getMany).toHaveBeenCalledTimes(3);
+    expect(mock.where).toHaveBeenCalledTimes(4);
+    expect(mock.select).toHaveBeenCalledTimes(2);
+    expect(mock.getMany).toHaveBeenCalledTimes(4);
 
     expect(res).toEqual(result);
   });
@@ -261,12 +288,12 @@ describe('ExperimentRepository Testing', () => {
       await repo.getValidExperimentsWithPreview('context');
     }).rejects.toThrow(err);
 
-    expect(repo.createQueryBuilder).toHaveBeenCalledTimes(3);
+    expect(repo.createQueryBuilder).toHaveBeenCalledTimes(4);
 
     expect(mock.leftJoinAndSelect).toHaveBeenCalledTimes(20);
-    expect(mock.where).toHaveBeenCalledTimes(3);
-    expect(mock.select).toHaveBeenCalledTimes(1);
-    expect(mock.getMany).toHaveBeenCalledTimes(3);
+    expect(mock.where).toHaveBeenCalledTimes(4);
+    expect(mock.select).toHaveBeenCalledTimes(2);
+    expect(mock.getMany).toHaveBeenCalledTimes(4);
   });
 
   it('should update experiment state', async () => {
@@ -369,18 +396,45 @@ describe('ExperimentRepository Testing', () => {
   it('should find one experiment ordered by queries.order then createdAt', async () => {
     const res = await repo.findOneExperiment(experiment.id);
 
-    // 4 parallel queries: conditionLevelPayload, factorDecisionPointPayload, metric, segment
-    expect(repo.createQueryBuilder).toHaveBeenCalledTimes(4);
+    // 5 parallel queries: conditionLevelPayload, factorDecisionPointPayload, metric, inclusion, exclusion
+    expect(repo.createQueryBuilder).toHaveBeenCalledTimes(5);
 
     // conditions(1) + partitions+factors+levels(3) + queries.order+createdAt(2) = 6 addOrderBy calls
     expect(mock.addOrderBy).toHaveBeenCalledTimes(6);
     expect(mock.addOrderBy).toHaveBeenCalledWith('queries.order', 'ASC', 'NULLS LAST');
     expect(mock.addOrderBy).toHaveBeenCalledWith('queries.createdAt', 'ASC');
 
-    expect(mock.where).toHaveBeenCalledTimes(4);
-    expect(mock.getOne).toHaveBeenCalledTimes(4);
+    expect(mock.where).toHaveBeenCalledTimes(5);
+    expect(mock.getOne).toHaveBeenCalledTimes(5);
 
     expect(res).toEqual(experiment);
+  });
+
+  it('should merge separately loaded segment data when finding one experiment', async () => {
+    const conditionData = { id: 'exp-a', name: 'Experiment A', conditions: ['condition'] } as any;
+    const factorData = { id: 'exp-a', partitions: ['partition'] } as any;
+    const metricData = { id: 'exp-a', queries: ['query'] } as any;
+    const inclusionData = { id: 'exp-a', experimentSegmentInclusion: ['inclusion'] } as any;
+    const exclusionData = { id: 'exp-a', experimentSegmentExclusion: ['exclusion'] } as any;
+
+    mock.getOne
+      .mockResolvedValueOnce(conditionData)
+      .mockResolvedValueOnce(factorData)
+      .mockResolvedValueOnce(metricData)
+      .mockResolvedValueOnce(inclusionData)
+      .mockResolvedValueOnce(exclusionData);
+
+    const res = await repo.findOneExperiment('exp-a');
+
+    expect(res).toMatchObject({
+      id: 'exp-a',
+      name: 'Experiment A',
+      conditions: ['condition'],
+      partitions: ['partition'],
+      queries: ['query'],
+      experimentSegmentInclusion: ['inclusion'],
+      experimentSegmentExclusion: ['exclusion'],
+    });
   });
 
   it('should clear the database', async () => {
@@ -412,29 +466,33 @@ describe('ExperimentRepository Testing', () => {
   });
 
   describe('getValidExperimentsForContextAndDecisionPoint', () => {
-    it('should build three queries and add a leftJoin on partitions (decision points) for the condition and segment queries', async () => {
+    it('should build four queries and add a leftJoin on partitions for the condition and segment queries', async () => {
       const result = [experiment];
       mock.getMany.mockResolvedValue(result);
 
       const res = await repo.getValidExperimentsForContextAndDecisionPoint('context', 'site1', 'target1');
 
-      expect(repo.createQueryBuilder).toHaveBeenCalledTimes(3);
-      // 4 (conditionLevel) + 6 (factorDecisionPoint) + 10 (segment) = 20
+      expect(repo.createQueryBuilder).toHaveBeenCalledTimes(4);
+      // 4 (conditionLevel) + 6 (factorDecisionPoint) + 5 (inclusion) + 5 (exclusion) = 20
       expect(mock.leftJoinAndSelect).toHaveBeenCalledTimes(20);
-      // conditionLevelPayloadQuery and segmentQuery each add a non-selecting leftJoin for partition filtering
-      expect(mock.leftJoin).toHaveBeenCalledTimes(2);
+      // conditionLevelPayloadQuery and both segment queries add a non-selecting leftJoin for partition filtering
+      expect(mock.leftJoin).toHaveBeenCalledTimes(3);
       expect(mock.leftJoin).toHaveBeenCalledWith('experiment.partitions', 'partitions');
-      // buildSegmentQuery calls .select('experiment.id')
-      expect(mock.select).toHaveBeenCalledTimes(1);
-      expect(mock.where).toHaveBeenCalledTimes(3);
-      expect(mock.getMany).toHaveBeenCalledTimes(3);
+      // Both segment queries call .select('experiment.id')
+      expect(mock.select).toHaveBeenCalledTimes(2);
+      expect(mock.where).toHaveBeenCalledTimes(4);
+      expect(mock.getMany).toHaveBeenCalledTimes(4);
 
       expect(res).toEqual(result);
     });
 
     it('should return empty array when no experiments match the site/target', async () => {
       // conditionLevel and segment find experiments, but factorDecisionPoint finds none at this site/target
-      mock.getMany.mockResolvedValueOnce([experiment]).mockResolvedValueOnce([]).mockResolvedValueOnce([experiment]);
+      mock.getMany
+        .mockResolvedValueOnce([experiment])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([experiment])
+        .mockResolvedValueOnce([experiment]);
 
       const res = await repo.getValidExperimentsForContextAndDecisionPoint('context', 'site1', 'target1');
 
@@ -451,6 +509,7 @@ describe('ExperimentRepository Testing', () => {
       mock.getMany
         .mockResolvedValueOnce([expA, expB])
         .mockResolvedValueOnce([expA])
+        .mockResolvedValueOnce([expA, expB])
         .mockResolvedValueOnce([expA, expB]);
 
       const res = await repo.getValidExperimentsForContextAndDecisionPoint('context', 'site1', 'target1');
@@ -462,12 +521,14 @@ describe('ExperimentRepository Testing', () => {
     it('should merge condition, partition, and segment data onto each result experiment', async () => {
       const condData = { id: 'exp-a', conditions: ['cond1'] } as any;
       const factorData = { id: 'exp-a', partitions: ['part1'] } as any;
-      const segData = { id: 'exp-a', experimentSegmentInclusion: ['seg1'] } as any;
+      const inclusionData = { id: 'exp-a', experimentSegmentInclusion: ['seg1'] } as any;
+      const exclusionData = { id: 'exp-a', experimentSegmentExclusion: ['seg2'] } as any;
 
       mock.getMany
         .mockResolvedValueOnce([condData])
         .mockResolvedValueOnce([factorData])
-        .mockResolvedValueOnce([segData]);
+        .mockResolvedValueOnce([inclusionData])
+        .mockResolvedValueOnce([exclusionData]);
 
       const [result] = await repo.getValidExperimentsForContextAndDecisionPoint('context', 'site1', 'target1');
 
@@ -476,6 +537,7 @@ describe('ExperimentRepository Testing', () => {
         conditions: ['cond1'],
         partitions: ['part1'],
         experimentSegmentInclusion: ['seg1'],
+        experimentSegmentExclusion: ['seg2'],
       });
     });
 
@@ -483,7 +545,11 @@ describe('ExperimentRepository Testing', () => {
       const condData = { id: 'exp-a', conditions: ['cond1'] } as any;
       const factorData = { id: 'exp-a', partitions: ['part1'] } as any;
 
-      mock.getMany.mockResolvedValueOnce([condData]).mockResolvedValueOnce([factorData]).mockResolvedValueOnce([]);
+      mock.getMany
+        .mockResolvedValueOnce([condData])
+        .mockResolvedValueOnce([factorData])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
 
       const [result] = await repo.getValidExperimentsForContextAndDecisionPoint('context', 'site1', 'target1');
 
@@ -492,13 +558,23 @@ describe('ExperimentRepository Testing', () => {
 
     it('should return factorDecisionPoint data even when conditionLevel query returns no match', async () => {
       const factorData = { id: 'exp-a', partitions: ['part1'] } as any;
-      const segData = { id: 'exp-a', experimentSegmentInclusion: ['seg1'] } as any;
+      const inclusionData = { id: 'exp-a', experimentSegmentInclusion: ['seg1'] } as any;
+      const exclusionData = { id: 'exp-a', experimentSegmentExclusion: ['seg2'] } as any;
 
-      mock.getMany.mockResolvedValueOnce([]).mockResolvedValueOnce([factorData]).mockResolvedValueOnce([segData]);
+      mock.getMany
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([factorData])
+        .mockResolvedValueOnce([inclusionData])
+        .mockResolvedValueOnce([exclusionData]);
 
       const [result] = await repo.getValidExperimentsForContextAndDecisionPoint('context', 'site1', 'target1');
 
-      expect(result).toMatchObject({ id: 'exp-a', partitions: ['part1'], experimentSegmentInclusion: ['seg1'] });
+      expect(result).toMatchObject({
+        id: 'exp-a',
+        partitions: ['part1'],
+        experimentSegmentInclusion: ['seg1'],
+        experimentSegmentExclusion: ['seg2'],
+      });
     });
 
     it('should throw an error when a sub-query fails', async () => {
@@ -506,7 +582,7 @@ describe('ExperimentRepository Testing', () => {
 
       await expect(repo.getValidExperimentsForContextAndDecisionPoint('context', 'site1', 'target1')).rejects.toThrow();
 
-      expect(repo.createQueryBuilder).toHaveBeenCalledTimes(3);
+      expect(repo.createQueryBuilder).toHaveBeenCalledTimes(4);
     });
   });
 


### PR DESCRIPTION
Resolves #3295

## Summary

- Loads experiment inclusion and exclusion segment relations in separate database queries
- Merges the independently loaded relations by experiment ID while preserving the existing response structure
- Applies the split to experiment details, list, assignment, and preview query paths
- Adds regression coverage for independently loaded inclusion and exclusion data

## Problem

The existing experiment segment query joins inclusion and exclusion list members together. When both lists contain many values, the intermediate result grows multiplicatively as `N × M`.

For example, approximately 2,300 inclusion values and 2,300 exclusion values can produce more than 5 million intermediate rows. Materializing those rows through TypeORM can exhaust the Node.js heap and terminate the backend process.

## Implementation

The combined segment query has been replaced with separate inclusion and exclusion queries. Their results are merged by experiment ID before being combined with the remaining experiment data.

This preserves the existing API response and list membership behavior while avoiding Cartesian growth. No API contract or database schema changes are required.

## Testing

- Backend typecheck
- ESLint
- Experiment repository unit tests
- Complete backend unit test suite: 1,004 passing