### PR TITLE
update the feature-flag controller to correctly use 404

### DIFF
--- a/packages/backend/src/api/controllers/FeatureFlagController.ts
+++ b/packages/backend/src/api/controllers/FeatureFlagController.ts
@@ -204,17 +204,22 @@ export class FeatureFlagsController {
    *                $ref: '#/definitions/FeatureFlag'
    *          '401':
    *            description: AuthorizationRequiredError
-   *          '204':
-   *            description: No content
+   *          '404':
+   *            description: Feature flag not found
    *          '400':
    *            description: id should be of type UUID
    */
   @Get('/:id')
-  public findOne(
+  public async findOne(
     @Params({ validate: true }) { id }: IdValidator,
     @Req() request: AppRequest
-  ): Promise<FeatureFlag | undefined> {
-    return this.featureFlagService.findOneForDetails(id, request.logger);
+  ): Promise<FeatureFlag> {
+    const featureFlag = await this.featureFlagService.findOneForDetails(id, request.logger);
+
+    if (!featureFlag) {
+      throw new NotFoundException('Feature flag not found.');
+    }
+    return featureFlag;
   }
 
   /**
@@ -418,15 +423,22 @@ export class FeatureFlagsController {
    *       responses:
    *          '200':
    *            description: Delete Feature flag By Id
+   *          '404':
+   *            description: Feature flag not found
    */
 
   @Delete('/:id')
-  public delete(
+  public async delete(
     @Params({ validate: true }) { id }: IdValidator,
     @CurrentUser() currentUser: UserDTO,
     @Req() request: AppRequest
-  ): Promise<FeatureFlag | undefined> {
-    return this.featureFlagService.delete(id, currentUser, request.logger);
+  ): Promise<FeatureFlag> {
+    const featureFlag = await this.featureFlagService.delete(id, currentUser, request.logger);
+
+    if (!featureFlag) {
+      throw new NotFoundException('Feature flag not found.');
+    }
+    return featureFlag;
   }
 
   /**
@@ -457,9 +469,11 @@ export class FeatureFlagsController {
    *       responses:
    *          '200':
    *            description: Feature flags is updated
+   *          '404':
+   *            description: Feature flag not found
    */
   @Put('/:id')
-  public update(
+  public async update(
     @Params({ validate: true }) { id }: IdValidator,
     @Body({ validate: true })
     flag: FeatureFlagValidation,
@@ -469,6 +483,11 @@ export class FeatureFlagsController {
     const contextValidationError = this.featureFlagService.validateFeatureFlagContext(flag);
     if (contextValidationError) {
       throw new BadRequestError(contextValidationError);
+    }
+
+    const existingFeatureFlag = await this.featureFlagService.findOneForDetails(id, request.logger);
+    if (!existingFeatureFlag) {
+      throw new NotFoundException('Feature flag not found.');
     }
 
     return this.featureFlagService.update({ ...flag, id }, currentUser, request.logger);

--- a/packages/backend/test/unit/controllers/FeatureFlagController.test.ts
+++ b/packages/backend/test/unit/controllers/FeatureFlagController.test.ts
@@ -10,6 +10,8 @@ import { useContainer as classValidatorUseContainer } from 'class-validator';
 
 import { ExperimentUserService } from '../../../src/api/services/ExperimentUserService';
 import ExperimentUserServiceMock from './mocks/ExperimentUserServiceMock';
+import { ErrorService } from '../../../src/api/services/ErrorService';
+import ErrorServiceMock from './mocks/ErrorServiceMock';
 
 describe('Feature Flag Controller Testing', () => {
   beforeAll(() => {
@@ -19,6 +21,7 @@ describe('Feature Flag Controller Testing', () => {
 
     Container.set(FeatureFlagService, new FeatureFlagServiceMock());
     Container.set(ExperimentUserService, new ExperimentUserServiceMock());
+    Container.set(ErrorService, new ErrorServiceMock());
   });
 
   afterAll(() => {
@@ -242,4 +245,160 @@ describe('Feature Flag Controller Testing', () => {
   //     .expect('Content-Type', /json/)
   //     .expect(200);
   // });
+
+  describe('Negative scenarios', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    test('Get request for /api/flags/id returns 404 when flag does not exist', () => {
+      const mockService = Container.get(FeatureFlagService);
+      jest.spyOn(mockService, 'findOneForDetails').mockResolvedValueOnce(undefined);
+
+      return request(app)
+        .get('/api/flags/' + crypto.randomUUID())
+        .set('Accept', 'application/json')
+        .expect(404);
+    });
+
+    test('Get request for /api/flags/id returns 400 for a non-UUID id', () => {
+      return request(app).get('/api/flags/not-a-uuid').set('Accept', 'application/json').expect(400);
+    });
+
+    test('Delete request for /api/flags/id returns 404 when flag does not exist', () => {
+      const mockService = Container.get(FeatureFlagService);
+      jest.spyOn(mockService, 'delete').mockResolvedValueOnce(undefined);
+
+      return request(app)
+        .delete('/api/flags/' + crypto.randomUUID())
+        .set('Accept', 'application/json')
+        .expect(404);
+    });
+
+    test('Delete request for /api/flags/id returns 400 for a non-UUID id', () => {
+      return request(app).delete('/api/flags/not-a-uuid').set('Accept', 'application/json').expect(400);
+    });
+
+    test('Put request for /api/flags/id returns 404 when flag does not exist', () => {
+      const mockService = Container.get(FeatureFlagService);
+      jest.spyOn(mockService, 'findOneForDetails').mockResolvedValueOnce(undefined);
+
+      return request(app)
+        .put('/api/flags/' + crypto.randomUUID())
+        .send({
+          id: crypto.randomUUID(),
+          name: 'string',
+          key: 'string',
+          description: 'string',
+          status: 'enabled',
+          context: ['foo'],
+          tags: ['bar'],
+          filterMode: 'includeAll',
+        })
+        .set('Accept', 'application/json')
+        .expect(404);
+    });
+
+    test('Put request for /api/flags/id returns 400 for a non-UUID id', () => {
+      return request(app)
+        .put('/api/flags/not-a-uuid')
+        .send({
+          id: crypto.randomUUID(),
+          name: 'string',
+          key: 'string',
+          description: 'string',
+          status: 'enabled',
+          context: ['foo'],
+          tags: ['bar'],
+          filterMode: 'includeAll',
+        })
+        .set('Accept', 'application/json')
+        .expect(400);
+    });
+
+    test('Put request for /api/flags/id returns 400 when the context is invalid', () => {
+      const mockService = Container.get(FeatureFlagService);
+      jest.spyOn(mockService, 'validateFeatureFlagContext').mockReturnValueOnce('Invalid context');
+
+      return request(app)
+        .put('/api/flags/' + crypto.randomUUID())
+        .send({
+          id: crypto.randomUUID(),
+          name: 'string',
+          key: 'string',
+          description: 'string',
+          status: 'enabled',
+          context: ['foo'],
+          tags: ['bar'],
+          filterMode: 'includeAll',
+        })
+        .set('Accept', 'application/json')
+        .expect(400);
+    });
+
+    test('Post request for /api/flags returns 400 when the context is invalid', () => {
+      const mockService = Container.get(FeatureFlagService);
+      jest.spyOn(mockService, 'validateFeatureFlagContext').mockReturnValueOnce('Invalid context');
+
+      return request(app)
+        .post('/api/flags')
+        .send({
+          id: crypto.randomUUID(),
+          name: 'string',
+          key: 'string',
+          description: 'string',
+          status: 'enabled',
+          context: ['foo'],
+          tags: ['bar'],
+          filterMode: 'includeAll',
+        })
+        .set('Accept', 'application/json')
+        .expect(400);
+    });
+
+    test('Post request for /api/flags returns 400 when required fields are missing', () => {
+      return request(app)
+        .post('/api/flags')
+        .send({
+          id: crypto.randomUUID(),
+          description: 'string',
+        })
+        .set('Accept', 'application/json')
+        .expect(400);
+    });
+
+    test('Patch request for /api/flags/status returns 400 when status is invalid', () => {
+      return request(app)
+        .patch('/api/flags/status')
+        .send({
+          flagId: crypto.randomUUID(),
+          status: 'not-a-real-status',
+        })
+        .set('Accept', 'application/json')
+        .expect(400);
+    });
+
+    test('Patch request for /api/flags/filterMode returns 400 when filterMode is invalid', () => {
+      return request(app)
+        .patch('/api/flags/filterMode')
+        .send({
+          flagId: crypto.randomUUID(),
+          filterMode: 'not-a-real-filter-mode',
+        })
+        .set('Accept', 'application/json')
+        .expect(400);
+    });
+
+    test('Patch request for /api/flags/inclusionList/id/status returns 400 for a non-UUID id', () => {
+      return request(app)
+        .patch('/api/flags/inclusionList/not-a-uuid/status')
+        .send({ enabled: false })
+        .set('Accept', 'application/json')
+        .expect(400);
+    });
+
+    test('Delete request for /api/flags/inclusionList/id returns 400 for a non-UUID id', () => {
+      return request(app).delete('/api/flags/inclusionList/not-a-uuid').set('Accept', 'application/json').expect(400);
+    });
+  });
 });


### PR DESCRIPTION
- handle no entity found as a 404 in feature flag controller for GET, UPDATE, and DELETE

This brings the controller in line with how experiments and segments work.
Note that this would be less likely to happen in `update` and `delete` because the user isn't in control of id being used, but the same issue was there so might as well fix also.