### PR TITLE
add client-context and client-version to client libs, logging 

### DIFF
--- a/clientlibs/java/pom.xml
+++ b/clientlibs/java/pom.xml
@@ -11,7 +11,21 @@
 
 	<version>6.7.0</version>
 	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+			</resource>
+		</resources>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>3.3.1</version>
+				<configuration>
+					<propertiesEncoding>UTF-8</propertiesEncoding>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>

--- a/clientlibs/java/src/main/java/org/upgradeplatform/client/ExperimentClient.java
+++ b/clientlibs/java/src/main/java/org/upgradeplatform/client/ExperimentClient.java
@@ -94,7 +94,7 @@ public class ExperimentClient implements AutoCloseable {
 			throw new IllegalArgumentException("Context cannot be null or empty");
 		}
 		this.context = context;
-		this.apiService = new APIService(baseUrl, authToken, sessionId, userId, properties);
+		this.apiService = new APIService(baseUrl, authToken, sessionId, userId, context, properties);
 	}
 
 	// To close jax-rs client connection open when calling ExperimentClient

--- a/clientlibs/java/src/main/java/org/upgradeplatform/client/QuickTest.java
+++ b/clientlibs/java/src/main/java/org/upgradeplatform/client/QuickTest.java
@@ -21,7 +21,7 @@ public class QuickTest {
     private static final String userId = "quicktest_user_" + System.currentTimeMillis();
     private static final String group = "test_class_group";
     private static final String alias = "alias" + userId;
-    private static final String hostUrl = ECS_STAGING_URL;
+    private static final String hostUrl = LOCAL_URL;
     private static final String context = "upgrade-internal";
     private static final String site = "SelectSection";
     private static final String target = "my_fave_workspace";

--- a/clientlibs/java/src/main/java/org/upgradeplatform/utils/APIService.java
+++ b/clientlibs/java/src/main/java/org/upgradeplatform/utils/APIService.java
@@ -3,7 +3,10 @@ package org.upgradeplatform.utils;
 
 import static org.upgradeplatform.utils.Utils.*;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Map;
+import java.util.Properties;
 
 import jakarta.ws.rs.client.AsyncInvoker;
 import jakarta.ws.rs.client.Client;
@@ -18,13 +21,29 @@ import org.glassfish.jersey.client.ClientConfig;
 
 public class APIService implements AutoCloseable{
 
+	private static final String CLIENT_VERSION = loadClientVersion();
+
 	private final String baseUrl;
 	private final String authToken;
 	private final String sessionId;
 	private final String userId;
+	private final String context;
 	private final Client client;
-	
-	public APIService(String baseUrl, String authToken, String sessionId, String userId, Map<String, Object> properties) {
+
+	private static String loadClientVersion() {
+		try (InputStream stream = APIService.class.getResourceAsStream("/client-version.properties")) {
+			if (stream == null) {
+				return "unknown";
+			}
+			Properties properties = new Properties();
+			properties.load(stream);
+			return properties.getProperty("version", "unknown");
+		} catch (IOException e) {
+			return "unknown";
+		}
+	}
+
+	public APIService(String baseUrl, String authToken, String sessionId, String userId, String context, Map<String, Object> properties) {
         if (isStringNull(baseUrl)) {
             throw new IllegalArgumentException(INVALID_BASE_URL);
         }
@@ -37,6 +56,7 @@ public class APIService implements AutoCloseable{
 
 		this.userId=userId;
 		this.sessionId=sessionId;
+		this.context=context;
 		client = createClient(properties);
 	}
 
@@ -64,6 +84,8 @@ public class APIService implements AutoCloseable{
 				.header("Authorization", "Bearer "+this.authToken)
 				.header("Session-Id", this.sessionId)
 				.header("User-Id", this.userId)
+				.header("Client-Context", this.context)
+				.header("Client-Version", CLIENT_VERSION)
 				.property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true)
 				.async();
 	}

--- a/clientlibs/java/src/main/resources/client-version.properties
+++ b/clientlibs/java/src/main/resources/client-version.properties
@@ -1,0 +1,1 @@
+version=${project.version}

--- a/clientlibs/js/jest.config.ts
+++ b/clientlibs/js/jest.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from '@jest/types';
+import packageJson = require('./package.json');
 // Sync object
 const config: Config.InitialOptions = {
   verbose: true,
@@ -14,6 +15,7 @@ const config: Config.InitialOptions = {
     USE_CUSTOM_HTTP_CLIENT: true,
     IS_BROWSER: true,
     API_VERSION: 6,
+    CLIENT_VERSION: packageJson.version,
   },
   moduleNameMapper: {
     upgrade_types: '<rootDir>/../../packages/types/src',

--- a/clientlibs/js/src/ApiService/ApiService.spec.ts
+++ b/clientlibs/js/src/ApiService/ApiService.spec.ts
@@ -9,6 +9,9 @@ import ApiService from './ApiService';
 import { UpGradeClientInterfaces } from './../types/Interfaces';
 import { UpGradeClientRequests } from './../types/requests';
 
+// this global is injected by webpack at build time (see ApiService.ts) and mocked in jest.config.ts for tests
+declare const CLIENT_VERSION: string;
+
 const MockDataService = {
   findExperimentAssignmentBySiteAndTarget: jest.fn(),
   rotateAssignmentList: jest.fn(),
@@ -51,6 +54,8 @@ describe('ApiService', () => {
         'Session-Id': 'testClientSessionId',
         URL: expectedUrl,
         'User-Id': defaultConfig.userId,
+        'Client-Context': defaultConfig.context,
+        'Client-Version': CLIENT_VERSION,
         Authorization: 'Bearer testToken',
       },
       withCredentials: false,
@@ -116,6 +121,8 @@ describe('ApiService', () => {
         'Session-Id': 'testClientSessionId',
         URL: expectedUrl,
         'User-Id': defaultConfig.userId,
+        'Client-Context': defaultConfig.context,
+        'Client-Version': CLIENT_VERSION,
         Authorization: 'Bearer testToken',
       },
       withCredentials: false,
@@ -144,6 +151,8 @@ describe('ApiService', () => {
         'Session-Id': 'testClientSessionId',
         URL: expectedUrl,
         'User-Id': defaultConfig.userId,
+        'Client-Context': defaultConfig.context,
+        'Client-Version': CLIENT_VERSION,
         Authorization: 'Bearer testToken',
       },
       withCredentials: false,
@@ -171,6 +180,8 @@ describe('ApiService', () => {
         'Session-Id': 'testClientSessionId',
         URL: expectedUrl,
         'User-Id': defaultConfig.userId,
+        'Client-Context': defaultConfig.context,
+        'Client-Version': CLIENT_VERSION,
         Authorization: 'Bearer testToken',
       },
       withCredentials: false,
@@ -196,6 +207,8 @@ describe('ApiService', () => {
         'Session-Id': 'testClientSessionId',
         URL: expectedUrl,
         'User-Id': defaultConfig.userId,
+        'Client-Context': defaultConfig.context,
+        'Client-Version': CLIENT_VERSION,
         Authorization: 'Bearer testToken',
       },
       withCredentials: false,
@@ -220,6 +233,8 @@ describe('ApiService', () => {
         'Session-Id': 'testClientSessionId',
         URL: expectedUrl,
         'User-Id': defaultConfig.userId,
+        'Client-Context': defaultConfig.context,
+        'Client-Version': CLIENT_VERSION,
         Authorization: 'Bearer testToken',
       },
       withCredentials: false,
@@ -262,6 +277,8 @@ describe('ApiService', () => {
         'Session-Id': 'testClientSessionId',
         URL: expectedUrl,
         'User-Id': defaultConfig.userId,
+        'Client-Context': defaultConfig.context,
+        'Client-Version': CLIENT_VERSION,
         Authorization: 'Bearer testToken',
       },
       withCredentials: false,
@@ -552,6 +569,8 @@ describe('ApiService', () => {
         'Session-Id': 'testClientSessionId',
         URL: expectedUrl,
         'User-Id': defaultConfig.userId,
+        'Client-Context': defaultConfig.context,
+        'Client-Version': CLIENT_VERSION,
         Authorization: 'Bearer testToken',
       },
       withCredentials: false,

--- a/clientlibs/js/src/ApiService/ApiService.ts
+++ b/clientlibs/js/src/ApiService/ApiService.ts
@@ -5,6 +5,8 @@ import { IApiServiceRequestParams, IEndpoints } from './ApiService.types';
 
 // this variable is used by webpack to replace the value of USE_CUSTOM_HTTP_CLIENT with true or false to create two different builds
 declare const USE_CUSTOM_HTTP_CLIENT: boolean;
+// this variable is injected by webpack at build time from package.json's version
+declare const CLIENT_VERSION: string;
 
 export default class ApiService {
   private context: string;
@@ -96,6 +98,8 @@ export default class ApiService {
         'Session-Id': this.clientSessionId,
         URL: url,
         'User-Id': this.userId,
+        'Client-Context': this.context,
+        'Client-Version': CLIENT_VERSION,
       },
     };
 

--- a/clientlibs/js/webpack.config.ts
+++ b/clientlibs/js/webpack.config.ts
@@ -3,6 +3,7 @@ import webpack = require('webpack');
 import packageJson = require('./package.json');
 
 const version = packageJson.version.split('.')[0];
+const clientVersion = JSON.stringify(packageJson.version);
 
 const generalConfiguration = {
   mode: 'production',
@@ -25,6 +26,7 @@ const generalConfiguration = {
   plugins: [
     new webpack.DefinePlugin({
       API_VERSION: version,
+      CLIENT_VERSION: clientVersion,
     }),
   ],
 };
@@ -44,6 +46,7 @@ const createConfig = (target: string, outputPath: string, useCustomHttpClient: b
   plugins: [
     new webpack.DefinePlugin({
       API_VERSION: version,
+      CLIENT_VERSION: clientVersion,
       USE_CUSTOM_HTTP_CLIENT: JSON.stringify(useCustomHttpClient),
     }),
   ],

--- a/clientlibs/python/src/upgrade_client_lib/api_service.py
+++ b/clientlibs/python/src/upgrade_client_lib/api_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
 import httpx
@@ -19,6 +20,11 @@ from upgrade_client_lib.types.responses import (
 )
 
 _API_VERSION = "v6"
+
+try:
+    _CLIENT_VERSION = version("upgrade-client-lib")
+except PackageNotFoundError:
+    _CLIENT_VERSION = "unknown"
 
 
 class ApiService:
@@ -56,6 +62,8 @@ class ApiService:
             "Content-Type": "application/json",
             "Session-Id": self._client_session_id,
             "User-Id": self._user_id,
+            "Client-Context": self._context,
+            "Client-Version": _CLIENT_VERSION,
         }
         if self._token:
             headers["Authorization"] = f"Bearer {self._token}"

--- a/clientlibs/python/tests/test_api_service.py
+++ b/clientlibs/python/tests/test_api_service.py
@@ -4,7 +4,7 @@ import pytest
 import respx
 from httpx import Request, Response
 
-from upgrade_client_lib.api_service import ApiService
+from upgrade_client_lib.api_service import _CLIENT_VERSION, ApiService
 from upgrade_client_lib.exceptions import UpgradeApiError
 from upgrade_client_lib.types.enums import BinaryRewardValue, ExperimentType, MarkedDecisionPointStatus
 from upgrade_client_lib.types.requests import LogInput, LogMetrics
@@ -33,6 +33,8 @@ def assert_common_headers(request: Request) -> None:
     assert request.headers["content-type"] == "application/json"
     assert request.headers["user-id"] == USER_ID
     assert request.headers["session-id"] == SESSION_ID
+    assert request.headers["client-context"] == CONTEXT
+    assert request.headers["client-version"] == _CLIENT_VERSION
     assert request.headers["authorization"] == f"Bearer {TOKEN}"
 
 

--- a/packages/backend/src/api/controllers/ExperimentClientController.v6.ts
+++ b/packages/backend/src/api/controllers/ExperimentClientController.v6.ts
@@ -90,9 +90,9 @@ interface IMonitoredDecisionPoint {
  */
 
 @JsonController('/v6/')
-@UseBefore(ClientContextMiddleware)
 @UseBefore(ClientLibMiddleware)
 @UseBefore(UserCheckMiddleware)
+@UseBefore(ClientContextMiddleware)
 export class ExperimentClientController {
   constructor(
     public experimentService: ExperimentService,

--- a/packages/backend/src/api/controllers/ExperimentClientController.v6.ts
+++ b/packages/backend/src/api/controllers/ExperimentClientController.v6.ts
@@ -20,6 +20,7 @@ import { UpdateWorkingGroupValidatorv6 } from './validators/UpdateWorkingGroupVa
 import { IExperimentAssignment, IGroupMembership, IUserAliases, IWorkingGroup } from 'upgrade_types';
 import { FeatureFlagService } from '../services/FeatureFlagService';
 import { ClientLibMiddleware } from '../middlewares/ClientLibMiddleware';
+import { ClientContextMiddleware } from '../middlewares/ClientContextMiddleware';
 import { LogValidatorv6 } from './validators/LogValidator';
 import { MetricService } from '../services/MetricService';
 import { ExperimentUserAliasesValidatorv6 } from './validators/ExperimentUserAliasesValidator';
@@ -89,6 +90,7 @@ interface IMonitoredDecisionPoint {
  */
 
 @JsonController('/v6/')
+@UseBefore(ClientContextMiddleware)
 @UseBefore(ClientLibMiddleware)
 @UseBefore(UserCheckMiddleware)
 export class ExperimentClientController {

--- a/packages/backend/src/api/middlewares/ClientContextMiddleware.ts
+++ b/packages/backend/src/api/middlewares/ClientContextMiddleware.ts
@@ -1,0 +1,24 @@
+import * as express from 'express';
+import { ExpressMiddlewareInterface } from 'routing-controllers';
+import { Service } from 'typedi';
+import { AppRequest } from '../../types';
+import { addCustomAttribute } from '../../lib/newrelic';
+
+// Scoped (via @UseBefore) to the client-SDK controller only, so admin/UI traffic never
+// carries this facet. Older clientlibs on v6 routes don't send these headers yet, so we
+// still report 'unknown' there rather than dropping the field.
+@Service()
+export class ClientContextMiddleware implements ExpressMiddlewareInterface {
+  public use(req: AppRequest, res: express.Response, next: express.NextFunction): void {
+    const clientContext = req.get('Client-Context') || 'unknown';
+    const clientVersion = req.get('Client-Version') || 'unknown';
+
+    req.logger.child({ client_context: clientContext, client_version: clientVersion });
+
+    // makes `clientContext`/`clientVersion` available as FACETs on New Relic transactions
+    addCustomAttribute('clientContext', clientContext);
+    addCustomAttribute('clientVersion', clientVersion);
+
+    next();
+  }
+}

--- a/packages/backend/src/api/middlewares/ClientContextMiddleware.ts
+++ b/packages/backend/src/api/middlewares/ClientContextMiddleware.ts
@@ -2,7 +2,7 @@ import * as express from 'express';
 import { ExpressMiddlewareInterface } from 'routing-controllers';
 import { Service } from 'typedi';
 import { AppRequest } from '../../types';
-import { addCustomAttribute } from '../../lib/newrelic';
+import { addCustomAttribute, sanitizeCustomAttributeValue } from '../../lib/newrelic';
 
 // Scoped (via @UseBefore) to the client-SDK controller only, so admin/UI traffic never
 // carries this facet. Older clientlibs on v6 routes don't send these headers yet, so we
@@ -10,8 +10,8 @@ import { addCustomAttribute } from '../../lib/newrelic';
 @Service()
 export class ClientContextMiddleware implements ExpressMiddlewareInterface {
   public use(req: AppRequest, res: express.Response, next: express.NextFunction): void {
-    const clientContext = req.get('Client-Context') || 'unknown';
-    const clientVersion = req.get('Client-Version') || 'unknown';
+    const clientContext = sanitizeCustomAttributeValue(req.get('Client-Context'));
+    const clientVersion = sanitizeCustomAttributeValue(req.get('Client-Version'));
 
     req.logger.child({ client_context: clientContext, client_version: clientVersion });
 

--- a/packages/backend/src/api/middlewares/LogMiddleware.ts
+++ b/packages/backend/src/api/middlewares/LogMiddleware.ts
@@ -3,7 +3,6 @@ import express from 'express';
 import morgan from 'morgan';
 import { ExpressMiddlewareInterface, Middleware } from 'routing-controllers';
 import { UpgradeLogger } from '../../lib/logger/UpgradeLogger';
-import { addCustomAttribute } from '../../lib/newrelic';
 
 @Middleware({ type: 'before' })
 export class LogMiddleware implements ExpressMiddlewareInterface {
@@ -28,25 +27,14 @@ export class LogMiddleware implements ExpressMiddlewareInterface {
     const id = oldValue === undefined ? crypto.randomUUID() : oldValue;
     res.set(headerName, id);
 
-    // the context the clientlib was configured for, sent on every client request.
-    // Older clientlibs don't send it, so report those as 'unknown' rather than dropping the field.
-    const clientContext = req.get('Client-Context') || 'unknown';
-    const clientVersion = req.get('Client-Version') || 'unknown';
-
     // child logger creation
     const logger = new UpgradeLogger();
     logger.child({
       request_id: id,
       endpoint: req.url,
       request_method_type: req.method,
-      client_context: clientContext,
-      client_version: clientVersion,
     });
     req.logger = logger;
-
-    // makes `clientContext`/`clientVersion` available as FACETs on New Relic transactions
-    addCustomAttribute('clientContext', clientContext);
-    addCustomAttribute('clientVersion', clientVersion);
 
     return morgan(this.jsonFormat, {
       stream: {

--- a/packages/backend/src/api/middlewares/LogMiddleware.ts
+++ b/packages/backend/src/api/middlewares/LogMiddleware.ts
@@ -3,6 +3,7 @@ import express from 'express';
 import morgan from 'morgan';
 import { ExpressMiddlewareInterface, Middleware } from 'routing-controllers';
 import { UpgradeLogger } from '../../lib/logger/UpgradeLogger';
+import { addCustomAttribute } from '../../lib/newrelic';
 
 @Middleware({ type: 'before' })
 export class LogMiddleware implements ExpressMiddlewareInterface {
@@ -27,14 +28,25 @@ export class LogMiddleware implements ExpressMiddlewareInterface {
     const id = oldValue === undefined ? crypto.randomUUID() : oldValue;
     res.set(headerName, id);
 
+    // the context the clientlib was configured for, sent on every client request.
+    // Older clientlibs don't send it, so report those as 'unknown' rather than dropping the field.
+    const clientContext = req.get('Client-Context') || 'unknown';
+    const clientVersion = req.get('Client-Version') || 'unknown';
+
     // child logger creation
     const logger = new UpgradeLogger();
     logger.child({
       request_id: id,
       endpoint: req.url,
       request_method_type: req.method,
+      client_context: clientContext,
+      client_version: clientVersion,
     });
     req.logger = logger;
+
+    // makes `clientContext`/`clientVersion` available as FACETs on New Relic transactions
+    addCustomAttribute('clientContext', clientContext);
+    addCustomAttribute('clientVersion', clientVersion);
 
     return morgan(this.jsonFormat, {
       stream: {

--- a/packages/backend/src/lib/newrelic.ts
+++ b/packages/backend/src/lib/newrelic.ts
@@ -1,0 +1,42 @@
+import { env } from '../env';
+
+/**
+ * Thin wrapper over the New Relic agent's custom-attribute API.
+ *
+ * The agent itself is started in `src/app.ts` when USE_NEW_RELIC is set. We resolve it here
+ * once at module load — not per request — so the hot path costs a null check and a property
+ * access. `require('newrelic')` and `require('newrelic/index')` resolve to the same file, so
+ * this shares the require cache with app.ts rather than initializing a second agent.
+ *
+ * When USE_NEW_RELIC is false the agent is never loaded and every call below is a no-op.
+ */
+interface NewRelicAgent {
+  addCustomAttribute(key: string, value: string | number | boolean): void;
+}
+
+let agent: NewRelicAgent | null = null;
+
+if (env.useNewRelic) {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    agent = require('newrelic') as NewRelicAgent;
+  } catch {
+    agent = null;
+  }
+}
+
+/**
+ * Attach a custom attribute to the current New Relic transaction, making it available as a
+ * FACET in NRQL. Synchronous and in-process — no I/O, nothing added to request latency.
+ * Never throws: telemetry must not be able to fail a request.
+ */
+export function addCustomAttribute(key: string, value: string | number | boolean): void {
+  if (!agent) {
+    return;
+  }
+  try {
+    agent.addCustomAttribute(key, value);
+  } catch {
+    // no-op — e.g. called outside an active transaction
+  }
+}

--- a/packages/backend/src/lib/newrelic.ts
+++ b/packages/backend/src/lib/newrelic.ts
@@ -40,3 +40,22 @@ export function addCustomAttribute(key: string, value: string | number | boolean
     // no-op — e.g. called outside an active transaction
   }
 }
+
+// New Relic silently truncates custom attribute values at 255 chars, so cap here too —
+// otherwise the same request shows a truncated value in NR but the untruncated one in logs.
+const MAX_CUSTOM_ATTRIBUTE_LENGTH = 255;
+
+// Strip control/non-printable characters: values reported here often come straight off
+// request headers on public endpoints, and neither NR nor our log fields sanitize them.
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARS = /[\x00-\x1f\x7f]/g;
+
+/**
+ * Normalize a raw string (e.g. a request header) before it's used as both a log field and an
+ * NR custom attribute value: strips control characters, trims, caps length to match NR's own
+ * truncation limit, and falls back to `fallback` when nothing meaningful is left.
+ */
+export function sanitizeCustomAttributeValue(value: string | undefined, fallback = 'unknown'): string {
+  const cleaned = (value ?? '').replace(CONTROL_CHARS, '').trim();
+  return cleaned ? cleaned.slice(0, MAX_CUSTOM_ATTRIBUTE_LENGTH) : fallback;
+}


### PR DESCRIPTION
Closes #3297
Closes #1331

this'll give us `Client-Context` and `Client-Version` in request headers automatically in the client libraries.

they will show up in backend logs like other header info, and that will give us the ability to facet log queries based on app-context and/or version

older clients or custom setups will show as `"unknown"`, although a custom setup can opt to send it if they want.